### PR TITLE
[feat] get tokenizer path from server

### DIFF
--- a/weaver/sampling_client.py
+++ b/weaver/sampling_client.py
@@ -35,12 +35,14 @@ class SamplingClient:
         base_model: str | None = None,
         model_path: str | None = None,
         model_id: str | None = None,
+        tokenizer_path: str | None = None,
     ) -> None:
         self._service = service
         self.sampling_session_id = sampling_session_id
         self.base_model = base_model
         self.model_path = model_path
         self.model_id = model_id
+        self.tokenizer_path = tokenizer_path
         self._tokenizer: PreTrainedTokenizer | None = None
 
     def sample(
@@ -82,11 +84,16 @@ class SamplingClient:
     def _ensure_tokenizer(self) -> PreTrainedTokenizer:
         if self._tokenizer is not None:
             return self._tokenizer
-        base_model = self._ensure_base_model()
         from transformers import AutoTokenizer
 
+        # Use custom tokenizer_path if provided, otherwise use base_model
+        if self.tokenizer_path:
+            model_name_or_path = self.tokenizer_path
+        else:
+            model_name_or_path = self._ensure_base_model()
+
         self._tokenizer = AutoTokenizer.from_pretrained(
-            base_model,
+            model_name_or_path,
             trust_remote_code=True,
         )
         return self._tokenizer

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -256,11 +256,24 @@ class ServiceClient:
 
         from .training_client import TrainingClient  # avoid circular import
 
+        # Extract tokenizer_path from response if provided by server
+        tokenizer_path = lookup_case_insensitive(response, "tokenizer_path")
+
+        # If not in response, try to get it from supported models config
+        if not tokenizer_path:
+            model_config = self.get_supported_model_config(base_model)
+            if model_config:
+                config = model_config.get("config", {})
+                resource = config.get("resource", {})
+                tokenizer_config = resource.get("tokenizer", {})
+                tokenizer_path = tokenizer_config.get("path")
+
         return TrainingClient(
             service=self,
             model_id=model_id,
             base_model=lookup_case_insensitive(response, "base_model") or base_model,
             session_id=self.session_id,
+            tokenizer_path=tokenizer_path,
         )
 
     def _next_model_seq(self) -> int:
@@ -292,6 +305,7 @@ class ServiceClient:
         sampling_session_seq_id: Optional[int] = None,
         sampling_session_id: Optional[str] = None,
         model_id: Optional[str] = None,
+        tokenizer_path: Optional[str] = None,
     ) -> "SamplingClient":
         from .sampling_client import SamplingClient  # local import to avoid cycles
 
@@ -312,12 +326,25 @@ class ServiceClient:
                 json=body,
             )
             sampling_session_id = extract_id(session)
+            # Extract tokenizer_path from response if provided by server
+            if tokenizer_path is None:
+                tokenizer_path = lookup_case_insensitive(session, "tokenizer_path")
+
+            # If still not found and base_model is provided, try to get it from supported models config
+            if tokenizer_path is None and base_model:
+                model_config = self.get_supported_model_config(base_model)
+                if model_config:
+                    config = model_config.get("config", {})
+                    resource = config.get("resource", {})
+                    tokenizer_config = resource.get("tokenizer", {})
+                    tokenizer_path = tokenizer_config.get("path")
         return SamplingClient(
             service=self,
             sampling_session_id=sampling_session_id,
             base_model=base_model,
             model_path=model_path,
             model_id=model_id,
+            tokenizer_path=tokenizer_path,
         )
 
     def get_sampling_client(
@@ -327,6 +354,7 @@ class ServiceClient:
         base_model: Optional[str] = None,
         model_id: Optional[str] = None,
         sampling_session_id: Optional[str] = None,
+        tokenizer_path: Optional[str] = None,
     ) -> "SamplingClient":
         """Create a sampling client from an exported model path.
 
@@ -338,6 +366,7 @@ class ServiceClient:
             base_model: Base model name (e.g., "llama-3-8b")
             model_id: Optional model ID to associate with this sampling session
             sampling_session_id: Optional existing sampling session ID to reuse
+            tokenizer_path: Optional custom tokenizer path
 
         Returns:
             Configured SamplingClient ready for inference
@@ -347,6 +376,7 @@ class ServiceClient:
             base_model=base_model,
             model_id=model_id,
             sampling_session_id=sampling_session_id,
+            tokenizer_path=tokenizer_path,
         )
 
     def enqueue_operation(self, path: str, payload: Dict[str, Any]) -> OperationHandle:
@@ -372,6 +402,30 @@ class ServiceClient:
                 if name:
                     names.append(str(name))
         return names
+
+    def get_supported_model_config(self, base_model: str) -> Optional[Dict[str, Any]]:
+        """Get configuration for a specific supported model.
+
+        Args:
+            base_model: Base model name to look up
+
+        Returns:
+            Model configuration dict if found, None otherwise
+        """
+        payload = self.http.get("/api/v1/supported-models")
+        if not isinstance(payload, dict):
+            return None
+        items = payload.get("items")
+        if not isinstance(items, list):
+            return None
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            name = lookup_case_insensitive(item, "name")
+            if name and str(name) == base_model:
+                return item
+        return None
 
     def list_training_runs(
         self,

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -35,12 +35,19 @@ logger = logging.getLogger(__name__)
 
 class TrainingClient:
     def __init__(
-        self, *, service: ServiceClient, model_id: str, base_model: str, session_id: str
+        self,
+        *,
+        service: ServiceClient,
+        model_id: str,
+        base_model: str,
+        session_id: str,
+        tokenizer_path: str | None = None,
     ) -> None:
         self._service = service
         self.model_id = model_id
         self.base_model = base_model
         self.session_id = session_id
+        self.tokenizer_path = tokenizer_path
 
     def _next_seq(self) -> int:
         return self._service.next_operation_seq(self.model_id)
@@ -222,12 +229,14 @@ class TrainingClient:
                 base_model=self.base_model,
                 model_id=self.model_id,
                 sampling_session_id=sampling_session_id,
+                tokenizer_path=self.tokenizer_path,
             )
         if model_path:
             return self._service.get_sampling_client(
                 model_path=str(model_path),
                 base_model=self.base_model,
                 model_id=self.model_id,
+                tokenizer_path=self.tokenizer_path,
             )
         raise RuntimeError("Export response missing sampling session id or model path")
 
@@ -235,7 +244,9 @@ class TrainingClient:
     def tokenizer(self):  # type: ignore[misc]
         from transformers import AutoTokenizer
 
-        return AutoTokenizer.from_pretrained(self.base_model, trust_remote_code=True)
+        # Use custom tokenizer_path if provided, otherwise use base_model
+        model_name_or_path = self.tokenizer_path if self.tokenizer_path else self.base_model
+        return AutoTokenizer.from_pretrained(model_name_or_path, trust_remote_code=True)
 
     def get_tokenizer(self):  # Backwards compatible accessor
         return self.tokenizer


### PR DESCRIPTION
As we allow our users to upload their custom models, however, we need to let client pick the right tokenizer.

So we give our users a chance to put `tokenizer_path` inside the model config:

```
curl -X POST https://weaver-console.nex-agi.cn/api/v1/supported-models \
  -H "Content-Type: application/json" \
  -H "X-WEAVER-API-KEY: sk-YOUR_SK" \
  -d '{
    "name": "YOUR-MODEL-NAME",
    "config": {
      ...
      "resource": {
        "tokenizer": {
          "path": "Qwen/Qwen3-32B"
        },
        ...
      }
    }
  }'
```