### PR TITLE
feat: expose debug_info from create_model() on TrainingClient

### DIFF
--- a/tests/test_seq_ids.py
+++ b/tests/test_seq_ids.py
@@ -29,6 +29,36 @@ def test_training_client_seq_ids_are_monotonic():
     assert [training._next_seq() for _ in range(3)] == [1, 2, 3]
 
 
+def test_training_client_debug_info_default_none():
+    training = TrainingClient(
+        service=ServiceClient(),
+        model_id="model-123",
+        base_model="Qwen/Qwen2.5-0.5B-Instruct",
+        session_id="session-1",
+    )
+    assert training.debug_info is None
+
+
+def test_training_client_debug_info_stored():
+    info = {
+        "debug_mode": "manual",
+        "model_id": "abc-123",
+        "job_name": "user-trainer-full_ft-abc-123",
+        "namespace": "qiji",
+        "kubectl_exec": "kubectl exec -it user-trainer-full_ft-abc-123-master-0 -n qiji -- /bin/bash",
+        "config_file": "/tmp/trainer.env",
+    }
+    training = TrainingClient(
+        service=ServiceClient(),
+        model_id="model-123",
+        base_model="Qwen/Qwen2.5-0.5B-Instruct",
+        session_id="session-1",
+        debug_info=info,
+    )
+    assert training.debug_info == info
+    assert training.debug_info["kubectl_exec"].startswith("kubectl exec")
+
+
 def test_service_client_seq_counters_are_monotonic():
     service = ServiceClient()
 

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -14,6 +14,8 @@
 
 """Tests for the ServiceClient."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from weaver.service_client import ServiceClient
@@ -113,3 +115,50 @@ def test_service_client_close_is_idempotent():
     client.close()
     client.close()  # Should not raise
     assert client._closed is True
+
+
+def test_create_model_passes_debug_info():
+    """Test create_model extracts debug_info from response and passes to TrainingClient."""
+    debug_info = {
+        "debug_mode": "manual",
+        "model_id": "abc-123",
+        "job_name": "user-trainer-full_ft-abc-123",
+        "namespace": "qiji",
+        "kubectl_exec": "kubectl exec -it user-trainer-full_ft-abc-123-master-0 -n qiji -- /bin/bash",
+        "config_file": "/tmp/trainer.env",
+    }
+    mock_response = {
+        "id": "abc-123",
+        "base_model": "Qwen/Qwen3-8B",
+        "debug_info": debug_info,
+    }
+
+    client = ServiceClient(api_key="sk-test-key")
+    client._session_id = "session-1"
+    client._http = MagicMock()
+    client._http.post.return_value = mock_response
+    client._http.get.return_value = {"items": []}  # for get_supported_model_config
+
+    training = client.create_model(base_model="Qwen/Qwen3-8B", training_mode="full_ft")
+
+    assert training.debug_info == debug_info
+    assert training.debug_info["kubectl_exec"].startswith("kubectl exec")
+    assert training.model_id == "abc-123"
+
+
+def test_create_model_debug_info_none_when_absent():
+    """Test create_model sets debug_info=None when server response has no debug_info."""
+    mock_response = {
+        "id": "abc-123",
+        "base_model": "Qwen/Qwen3-8B",
+    }
+
+    client = ServiceClient(api_key="sk-test-key")
+    client._session_id = "session-1"
+    client._http = MagicMock()
+    client._http.post.return_value = mock_response
+    client._http.get.return_value = {"items": []}
+
+    training = client.create_model(base_model="Qwen/Qwen3-8B", training_mode="full_ft")
+
+    assert training.debug_info is None

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -268,12 +268,16 @@ class ServiceClient:
                 tokenizer_config = resource.get("tokenizer", {})
                 tokenizer_path = tokenizer_config.get("path")
 
+        # Extract debug_info for manual debug mode
+        debug_info = lookup_case_insensitive(response, "debug_info")
+
         return TrainingClient(
             service=self,
             model_id=model_id,
             base_model=lookup_case_insensitive(response, "base_model") or base_model,
             session_id=self.session_id,
             tokenizer_path=tokenizer_path,
+            debug_info=debug_info,
         )
 
     def _next_model_seq(self) -> int:

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -43,12 +43,14 @@ class TrainingClient:
         base_model: str,
         session_id: str,
         tokenizer_path: str | None = None,
+        debug_info: Dict[str, Any] | None = None,
     ) -> None:
         self._service = service
         self.model_id = model_id
         self.base_model = base_model
         self.session_id = session_id
         self.tokenizer_path = tokenizer_path
+        self.debug_info = debug_info
 
     def _next_seq(self) -> int:
         return self._service.next_operation_seq(self.model_id)


### PR DESCRIPTION
## Summary

- Extract `debug_info` from the server's `create_model` API response and pass it through to `TrainingClient` as a public attribute
- When using `debug_mode: "manual"`, users can now access pod name and kubectl exec command via `training_client.debug_info`
- Defaults to `None` when the server response contains no `debug_info` (non-debug models)

Fixes #33

## Changes

- **`weaver/service_client.py`** — extract `debug_info` via `lookup_case_insensitive()` and pass to `TrainingClient` constructor
- **`weaver/training_client.py`** — add `debug_info` parameter to `__init__`, store as public attribute
- **`tests/test_seq_ids.py`** — tests for `TrainingClient.debug_info` default and explicit values
- **`tests/test_service_client.py`** — mock-based tests for `create_model()` debug_info extraction

## Test plan

- [x] `make ci` passes (61 tests, lint, type check)
- [x] Manual verification with a manual debug mode model on staging

<img width="3836" height="182" alt="Comet 2026-03-09 19 25 43" src="https://github.com/user-attachments/assets/e0f799f6-3e52-4f7b-9afa-717fbdbfb443" />
