### PR TITLE
feat(checkpoint): add train_unembed/train_mlp/train_attn fields

### DIFF
--- a/tests/test_training_checkpoint.py
+++ b/tests/test_training_checkpoint.py
@@ -241,6 +241,35 @@ class TestListCheckpoints:
         tc._service.http.get.return_value = None
         assert tc.list_checkpoints() == []
 
+    def test_list_checkpoints_with_training_flags(self):
+        tc = _make_training_client()
+        tc._service.http.get.return_value = {
+            "items": [
+                {
+                    "id": "ckpt-1",
+                    "path": "weaver://ckpt-1",
+                    "type": "weight",
+                    "train_unembed": True,
+                    "train_mlp": False,
+                    "train_attn": True,
+                },
+                {
+                    "id": "ckpt-2",
+                    "path": "weaver://ckpt-2",
+                    "type": "weight",
+                },
+            ]
+        }
+
+        checkpoints = tc.list_checkpoints()
+
+        assert checkpoints[0].train_unembed is True
+        assert checkpoints[0].train_mlp is False
+        assert checkpoints[0].train_attn is True
+        assert checkpoints[1].train_unembed is None
+        assert checkpoints[1].train_mlp is None
+        assert checkpoints[1].train_attn is None
+
 
 # ---------------------------------------------------------------------------
 # Checkpoint type
@@ -268,6 +297,34 @@ class TestCheckpointType:
         assert ckpt.name is None
         assert ckpt.checkpoint_type == "weight"
         assert ckpt.status is None
+        assert ckpt.train_unembed is None
+        assert ckpt.train_mlp is None
+        assert ckpt.train_attn is None
+
+    def test_from_payload_with_training_flags(self):
+        payload = {
+            "id": "ckpt-z",
+            "path": "weaver://ckpt-z",
+            "type": "weight",
+            "train_unembed": True,
+            "train_mlp": False,
+            "train_attn": True,
+        }
+        ckpt = Checkpoint.from_payload(payload)
+        assert ckpt.train_unembed is True
+        assert ckpt.train_mlp is False
+        assert ckpt.train_attn is True
+
+    def test_from_payload_with_partial_training_flags(self):
+        payload = {
+            "id": "ckpt-w",
+            "path": "weaver://ckpt-w",
+            "train_attn": True,
+        }
+        ckpt = Checkpoint.from_payload(payload)
+        assert ckpt.train_unembed is None
+        assert ckpt.train_mlp is None
+        assert ckpt.train_attn is True
 
     def test_checkpoint_is_frozen(self):
         ckpt = Checkpoint(id="1", path="p")

--- a/weaver/types/checkpoint.py
+++ b/weaver/types/checkpoint.py
@@ -32,6 +32,10 @@ class Checkpoint:
         name: Human-readable label provided at save time.
         checkpoint_type: ``"weight"`` or ``"weight_and_optimizer"``.
         status: Current status of the checkpoint (e.g. ``"completed"``).
+        train_unembed: Whether the unembedding layer was trained (``None`` if
+            the server did not report this field).
+        train_mlp: Whether MLP layers were trained.
+        train_attn: Whether attention layers were trained.
     """
 
     id: str
@@ -39,6 +43,9 @@ class Checkpoint:
     name: str | None = None
     checkpoint_type: str = "weight"
     status: str | None = None
+    train_unembed: bool | None = None
+    train_mlp: bool | None = None
+    train_attn: bool | None = None
 
     @classmethod
     def from_payload(cls, payload: dict[str, Any]) -> Checkpoint:
@@ -62,8 +69,15 @@ class Checkpoint:
                 or "weight"
             ),
             status=_str_or_none(lookup_case_insensitive(payload, "status")),
+            train_unembed=_bool_or_none(lookup_case_insensitive(payload, "train_unembed")),
+            train_mlp=_bool_or_none(lookup_case_insensitive(payload, "train_mlp")),
+            train_attn=_bool_or_none(lookup_case_insensitive(payload, "train_attn")),
         )
 
 
 def _str_or_none(value: Any) -> str | None:
     return str(value) if value is not None else None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    return bool(value) if value is not None else None


### PR DESCRIPTION
## Summary

- Add optional `train_unembed`, `train_mlp`, `train_attn` boolean fields to `Checkpoint` dataclass for selective parameter training (SPT) introspection
- Update `from_payload()` to populate these fields from server response (case-insensitive lookup)
- Add unit tests covering full, partial, and absent training flags via both `Checkpoint.from_payload()` and `list_checkpoints()`

Fixes #46

## Test plan

- [x] `test_from_payload_with_training_flags` — all three flags present
- [x] `test_from_payload_with_partial_training_flags` — only `train_attn` set, others `None`
- [x] `test_from_payload_minimal` — no flags present, all default to `None`
- [x] `test_list_checkpoints_with_training_flags` — end-to-end through `TrainingClient.list_checkpoints()`
- [x] All 18 checkpoint tests pass