### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.4.2"
+version = "1.5.0"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Bump SDK version from 1.4.2 to 1.5.0 for the v1.5.0 release.

**Changes:**
- `pyproject.toml`: version 1.4.2 → 1.5.0