### PR TITLE
fix(http): retry connection-level errors independently of max_retries

### DIFF
--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -82,6 +82,114 @@ class TestPostMaxRetriesOverride:
         assert client._client.request.call_count == 2
 
 
+class TestConnectionErrorRetry:
+    """Connection-level errors are retried regardless of max_retries."""
+
+    def test_connection_error_retried_with_max_retries_1(self, client):
+        """OSError (Bad file descriptor) retries even with max_retries=1."""
+        ok_response = MagicMock()
+        ok_response.is_success = True
+        ok_response.status_code = 200
+        ok_response.content = b'{"id": "op-1"}'
+        ok_response.json.return_value = {"id": "op-1"}
+
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.side_effect = [
+            OSError(9, "Bad file descriptor"),
+            ok_response,
+        ]
+
+        result = client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
+
+        assert result == {"id": "op-1"}
+        assert client._client.request.call_count == 2
+
+    def test_connection_reset_retried_with_max_retries_1(self, client):
+        """ConnectionResetError retries even with max_retries=1."""
+        ok_response = MagicMock()
+        ok_response.is_success = True
+        ok_response.status_code = 200
+        ok_response.content = b'{"ok": true}'
+        ok_response.json.return_value = {"ok": True}
+
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.side_effect = [
+            ConnectionResetError("Connection reset by peer"),
+            ok_response,
+        ]
+
+        result = client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
+
+        assert result == {"ok": True}
+        assert client._client.request.call_count == 2
+
+    def test_connect_error_retried_with_max_retries_1(self, client):
+        """httpx.ConnectError retries even with max_retries=1."""
+        ok_response = MagicMock()
+        ok_response.is_success = True
+        ok_response.status_code = 200
+        ok_response.content = b'{"ok": true}'
+        ok_response.json.return_value = {"ok": True}
+
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.side_effect = [
+            httpx.ConnectError("Connection refused"),
+            ok_response,
+        ]
+
+        result = client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
+
+        assert result == {"ok": True}
+        assert client._client.request.call_count == 2
+
+    def test_connection_error_exhausts_after_default_retries(self, client):
+        """Persistent connection errors raise after DEFAULT_CONNECTION_RETRIES."""
+        from weaver._http import DEFAULT_CONNECTION_RETRIES
+
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.side_effect = OSError(9, "Bad file descriptor")
+
+        with pytest.raises(OSError, match="Bad file descriptor"):
+            client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
+
+        assert client._client.request.call_count == DEFAULT_CONNECTION_RETRIES
+
+    def test_non_connection_error_not_retried_with_max_retries_1(self, client):
+        """Non-connection errors (e.g., ReadTimeout) still respect max_retries=1."""
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.side_effect = httpx.ReadTimeout("read timed out")
+
+        with pytest.raises(httpx.ReadTimeout):
+            client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
+
+        assert client._client.request.call_count == 1
+
+    def test_remote_protocol_error_retried(self, client):
+        """httpx.RemoteProtocolError retries even with max_retries=1."""
+        ok_response = MagicMock()
+        ok_response.is_success = True
+        ok_response.status_code = 200
+        ok_response.content = b'{"ok": true}'
+        ok_response.json.return_value = {"ok": True}
+
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.side_effect = [
+            httpx.RemoteProtocolError("Server disconnected"),
+            ok_response,
+        ]
+
+        result = client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
+
+        assert result == {"ok": True}
+        assert client._client.request.call_count == 2
+
+
 class TestGetRetryUnchanged:
     """GET requests still use the default client-level retries."""
 

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -35,10 +35,15 @@ USER_AGENT: str = f"weaver-sdk/{__version__}"  # type: ignore[has-type]
 # default timeout is 1 minute
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=60, connect=5.0)
 DEFAULT_MAX_RETRIES = 10
+DEFAULT_CONNECTION_RETRIES = 3
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=1000, max_keepalive_connections=20)
 
 INITIAL_RETRY_DELAY = 0.5
 MAX_RETRY_DELAY = 10.0
+
+# Transport-layer errors that indicate the request never reached the server.
+# Safe to retry regardless of idempotency because no server-side state was created.
+CONNECTION_ERRORS = (OSError, httpx.ConnectError, httpx.RemoteProtocolError)
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +180,11 @@ class APIClient:
     ) -> Any:
         """Execute HTTP request with retry logic and trace context injection.
 
+        Connection-level errors (stale sockets, refused connections) are retried
+        up to ``DEFAULT_CONNECTION_RETRIES`` times regardless of *max_retries*
+        because the request never reached the server and is therefore safe to
+        retry even for non-idempotent methods.
+
         Args:
             span: OpenTelemetry span for tracing.
             method: HTTP method (GET, POST, etc.).
@@ -185,9 +195,11 @@ class APIClient:
                 When provided, overrides the client-level ``self._max_retries``.
         """
         effective_max_retries = max_retries if max_retries is not None else self._max_retries
-        last_exception = None
+        last_exception: Exception | None = None
+        request_attempt = 0
+        connection_error_count = 0
 
-        for attempt in range(effective_max_retries):
+        while request_attempt < effective_max_retries:
             try:
                 # Inject trace context into HTTP headers
                 headers = dict(self._client.headers or {})
@@ -218,9 +230,50 @@ class APIClient:
                 span.set_status(Status(StatusCode.ERROR, "API error"))
                 raise
 
-            except Exception as e:
+            except CONNECTION_ERRORS as e:
+                # Connection-level error — the request never reached the server,
+                # so it is safe to retry regardless of max_retries.
+                connection_error_count += 1
                 last_exception = e
-                is_last_attempt = attempt == effective_max_retries - 1
+                span.record_exception(e)
+
+                logger.debug(
+                    "Connection error (attempt %d/%d): %s %s - %s: %s",
+                    connection_error_count,
+                    DEFAULT_CONNECTION_RETRIES,
+                    method,
+                    path,
+                    type(e).__name__,
+                    str(e),
+                )
+
+                if connection_error_count >= DEFAULT_CONNECTION_RETRIES:
+                    span.set_status(
+                        Status(
+                            StatusCode.ERROR,
+                            f"Connection failed after {connection_error_count} attempts",
+                        )
+                    )
+                    logger.error(
+                        "Connection error after %d attempts: %s %s - %s",
+                        connection_error_count,
+                        method,
+                        path,
+                        str(e),
+                    )
+                    raise
+
+                delay = min(
+                    INITIAL_RETRY_DELAY * (2 ** (connection_error_count - 1)),
+                    MAX_RETRY_DELAY,
+                )
+                logger.debug("Retrying in %.1fs...", delay)
+                time.sleep(delay)
+
+            except Exception as e:
+                request_attempt += 1
+                last_exception = e
+                is_last_attempt = request_attempt >= effective_max_retries
 
                 # Record error in span
                 span.record_exception(e)
@@ -232,7 +285,7 @@ class APIClient:
                 # Log the error
                 logger.debug(
                     "HTTP request failed (attempt %d/%d): %s %s - %s: %s",
-                    attempt + 1,
+                    request_attempt,
                     effective_max_retries,
                     method,
                     path,
@@ -251,7 +304,7 @@ class APIClient:
                     raise
 
                 # Wait before retrying with exponential backoff
-                delay = min(INITIAL_RETRY_DELAY * (2**attempt), MAX_RETRY_DELAY)
+                delay = min(INITIAL_RETRY_DELAY * (2 ** (request_attempt - 1)), MAX_RETRY_DELAY)
                 logger.debug("Retrying in %.1fs...", delay)
                 time.sleep(delay)
 


### PR DESCRIPTION
## Summary

Fixes #50

- Transport-layer errors (`OSError`, `ConnectionResetError`, `httpx.ConnectError`, `httpx.RemoteProtocolError`) now retry up to 3 times regardless of `max_retries`, since the request never reached the server
- Non-connection errors (e.g., `ReadTimeout`) still respect the per-request `max_retries` setting
- `enqueue_operation` with `max_retries=1` now survives stale keep-alive connections without caller-side retry loops

## Changes

- **`weaver/_http.py`**: Added `CONNECTION_ERRORS` tuple and `DEFAULT_CONNECTION_RETRIES=3` constant. Refactored `_request_with_retries` to track connection errors on a separate counter from request-level retries.
- **`tests/test_http_retry.py`**: Added 6 tests covering `OSError`, `ConnectionResetError`, `httpx.ConnectError`, `httpx.RemoteProtocolError` retry behavior, exhaustion after 3 connection attempts, and ensuring non-connection errors still respect `max_retries=1`.

## Test plan

- [x] All 10 tests in `test_http_retry.py` pass (3 existing + 6 new + 1 existing GET test)
- [x] `pylint` 10/10, `mypy` clean, `black`/`isort` formatted
- [x] Manual verification with concurrent sampling workers