### PR TITLE
feat(checkpoint): add ttl_seconds support for checkpoint expiration

### DIFF
--- a/tests/test_training_checkpoint.py
+++ b/tests/test_training_checkpoint.py
@@ -330,3 +330,154 @@ class TestCheckpointType:
         ckpt = Checkpoint(id="1", path="p")
         with pytest.raises(AttributeError):
             ckpt.id = "2"  # type: ignore[misc]
+
+    def test_from_payload_with_ttl_fields(self):
+        payload = {
+            "id": "ckpt-t",
+            "path": "weaver://ckpt-t",
+            "ttl_seconds": 86400,
+            "created_at": "2026-04-14T00:00:00Z",
+            "expires_at": "2026-04-15T00:00:00Z",
+        }
+        ckpt = Checkpoint.from_payload(payload)
+        assert ckpt.ttl_seconds == 86400
+        assert ckpt.created_at == "2026-04-14T00:00:00Z"
+        assert ckpt.expires_at == "2026-04-15T00:00:00Z"
+
+    def test_from_payload_without_ttl_fields(self):
+        payload = {"id": "ckpt-n", "path": "weaver://ckpt-n"}
+        ckpt = Checkpoint.from_payload(payload)
+        assert ckpt.ttl_seconds is None
+        assert ckpt.created_at is None
+        assert ckpt.expires_at is None
+
+
+# ---------------------------------------------------------------------------
+# save_state TTL
+# ---------------------------------------------------------------------------
+
+
+class TestSaveStateTTL:
+    def test_default_no_ttl_in_body(self):
+        tc = _make_training_client()
+        handle = _make_handle({"id": "ckpt-1", "path": "weaver://ckpt-1"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_state(name="test")
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert "ttl_seconds" not in body
+
+    def test_explicit_none_sends_null(self):
+        tc = _make_training_client()
+        handle = _make_handle({"id": "ckpt-1", "path": "weaver://ckpt-1"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_state(name="test", ttl_seconds=None)
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert "ttl_seconds" in body
+        assert body["ttl_seconds"] is None
+
+    def test_with_ttl_seconds(self):
+        tc = _make_training_client()
+        handle = _make_handle({"id": "ckpt-1", "path": "weaver://ckpt-1"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_state(name="test", ttl_seconds=3600)
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert body["ttl_seconds"] == 3600
+
+
+# ---------------------------------------------------------------------------
+# save_weights_for_sampler TTL
+# ---------------------------------------------------------------------------
+
+
+class TestSaveWeightsForSamplerTTL:
+    def test_default_no_ttl_in_body(self):
+        tc = _make_training_client()
+        handle = _make_handle({"model_path": "weaver://path"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_weights_for_sampler(name="test")
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert "ttl_seconds" not in body
+
+    def test_explicit_none_sends_null(self):
+        tc = _make_training_client()
+        handle = _make_handle({"model_path": "weaver://path"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_weights_for_sampler(name="test", ttl_seconds=None)
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert "ttl_seconds" in body
+        assert body["ttl_seconds"] is None
+
+    def test_with_ttl_seconds(self):
+        tc = _make_training_client()
+        handle = _make_handle({"model_path": "weaver://path"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_weights_for_sampler(name="test", ttl_seconds=7200)
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert body["ttl_seconds"] == 7200
+
+
+# ---------------------------------------------------------------------------
+# save_weights_and_get_sampling_client TTL
+# ---------------------------------------------------------------------------
+
+
+class TestSaveWeightsAndGetSamplingClientTTL:
+    def test_default_sends_86400(self):
+        tc = _make_training_client()
+        handle = _make_handle({"model_path": "weaver://path", "sampling_session_id": "ss-1"})
+        tc._service.enqueue_operation.return_value = handle
+        tc._service.get_sampling_client.return_value = MagicMock()
+        tc.save_weights_and_get_sampling_client()
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert body["ttl_seconds"] == 86400
+
+    def test_explicit_none_no_ttl_in_body(self):
+        tc = _make_training_client()
+        handle = _make_handle({"model_path": "weaver://path", "sampling_session_id": "ss-1"})
+        tc._service.enqueue_operation.return_value = handle
+        tc._service.get_sampling_client.return_value = MagicMock()
+        tc.save_weights_and_get_sampling_client(ttl_seconds=None)
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert "ttl_seconds" not in body
+
+    def test_custom_ttl(self):
+        tc = _make_training_client()
+        handle = _make_handle({"model_path": "weaver://path", "sampling_session_id": "ss-1"})
+        tc._service.enqueue_operation.return_value = handle
+        tc._service.get_sampling_client.return_value = MagicMock()
+        tc.save_weights_and_get_sampling_client(ttl_seconds=7200)
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert body["ttl_seconds"] == 7200
+
+
+# ---------------------------------------------------------------------------
+# set_checkpoint_ttl
+# ---------------------------------------------------------------------------
+
+
+class TestSetCheckpointTTL:
+    def test_set_ttl_with_int(self):
+        tc = _make_training_client()
+        tc._service.http.patch.return_value = {"status": "ok"}
+        result = tc.set_checkpoint_ttl("weaver://ckpt-1", ttl_seconds=604800)
+        tc._service.http.patch.assert_called_once_with(
+            "/api/v1/models/mdl-123/checkpoints/ttl",
+            json={"path": "weaver://ckpt-1", "ttl_seconds": 604800},
+        )
+        assert result == {"status": "ok"}
+
+    def test_set_ttl_none_cancels_expiration(self):
+        tc = _make_training_client()
+        tc._service.http.patch.return_value = {"status": "ok"}
+        tc.set_checkpoint_ttl("weaver://ckpt-1", ttl_seconds=None)
+        body = tc._service.http.patch.call_args[1]["json"]
+        assert body["ttl_seconds"] is None
+
+    def test_set_ttl_with_checkpoint_object(self):
+        tc = _make_training_client()
+        tc._service.http.patch.return_value = {"status": "ok"}
+        ckpt = Checkpoint(id="ckpt-1", path="weaver://ckpt-1")
+        tc.set_checkpoint_ttl(ckpt, ttl_seconds=3600)
+        body = tc._service.http.patch.call_args[1]["json"]
+        assert body["path"] == "weaver://ckpt-1"
+        assert body["ttl_seconds"] == 3600

--- a/weaver/_utils.py
+++ b/weaver/_utils.py
@@ -19,6 +19,26 @@ from __future__ import annotations
 from typing import Any, Dict
 
 
+class _UnsetType:
+    """Sentinel to distinguish 'parameter not passed' from explicit ``None``."""
+
+    _instance: _UnsetType | None = None
+
+    def __new__(cls) -> _UnsetType:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "<UNSET>"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET = _UnsetType()
+
+
 def lookup_case_insensitive(payload: Dict[str, Any], name: str) -> Any:
     variants = {
         name,

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -171,12 +171,19 @@ def display_training_run_detail(data: Dict[str, Any]) -> None:
         checkpoint_table.add_column("ID", style="cyan", no_wrap=True)
         checkpoint_table.add_column("Created At", style="magenta")
         checkpoint_table.add_column("Full Path", style="green")
+        checkpoint_table.add_column("TTL", style="yellow")
+        checkpoint_table.add_column("Expires At", style="red")
 
         for cp in checkpoints:
+            ttl = cp.get("ttl_seconds")
+            ttl_display = f"{ttl}s" if ttl is not None else "permanent"
+            expires = format_date(cp.get("expires_at")) if cp.get("expires_at") else "never"
             checkpoint_table.add_row(
                 str(cp.get("id", ""))[:8],
                 format_date(cp.get("created_at")),
                 cp.get("path", "N/A"),
+                ttl_display,
+                expires,
             )
         console.print(checkpoint_table)
         console.print("\n[dim]Tip: Copy the full path to use with sampling clients[/dim]")
@@ -231,6 +238,11 @@ def list():  # pylint: disable=redefined-builtin
 @cli.group()
 def show():
     """Show detailed information about a specific resource."""
+
+
+@cli.group()
+def checkpoint():
+    """Manage checkpoints."""
 
 
 @list.command("training-runs")
@@ -355,6 +367,48 @@ def show_model_cmd(
                 format_json_output(result)
             else:
                 display_model_detail(result)
+    except Exception as e:
+        handle_error(e)
+
+
+@checkpoint.command("set-ttl")
+@click.argument("model_id")
+@click.argument("path")
+@click.argument("seconds", type=int, required=False, default=None)
+@click.option("--remove", is_flag=True, help="Cancel expiration (make permanent)")
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def checkpoint_set_ttl_cmd(  # pylint: disable=too-many-positional-arguments
+    model_id: str,
+    path: str,
+    seconds: Optional[int],
+    remove: bool,
+    base_url: Optional[str],
+    api_key: Optional[str],
+):
+    """Set or remove TTL for a checkpoint.
+
+    MODEL_ID is the model that owns the checkpoint.
+    PATH is the checkpoint storage path (weaver://...).
+    SECONDS is the TTL in seconds (omit when using --remove).
+    """
+    try:
+        if remove and seconds is not None:
+            raise click.UsageError("Cannot specify both SECONDS and --remove")
+        if not remove and seconds is None:
+            raise click.UsageError("Provide SECONDS or use --remove")
+
+        ttl_value: Optional[int] = None if remove else seconds
+
+        with ServiceClient(base_url=base_url, api_key=api_key) as client:
+            client.http.patch(
+                f"/api/v1/models/{model_id}/checkpoints/ttl",
+                json={"path": path, "ttl_seconds": ttl_value},
+            )
+            if remove:
+                console.print(f"[green]Expiration removed for checkpoint:[/green] {path}")
+            else:
+                console.print(f"[green]TTL set to {seconds}s for checkpoint:[/green] {path}")
     except Exception as e:
         handle_error(e)
 

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -20,7 +20,7 @@ import logging
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
-from ._utils import lookup_case_insensitive
+from ._utils import UNSET, _UnsetType, lookup_case_insensitive
 from .operations import OperationHandle
 from .service_client import ServiceClient
 from .types import AdamParams, Datum
@@ -218,6 +218,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
+        ttl_seconds: int | None = ...,
         wait: Literal[True] = True,
     ) -> str: ...
 
@@ -226,6 +227,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
+        ttl_seconds: int | None = ...,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -233,12 +235,17 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
+        ttl_seconds: int | None | _UnsetType = UNSET,
         wait: bool = True,
     ) -> str | OperationHandle:
         """Export model weights for sampling.
 
         Args:
             name: Optional custom path name for the exported weights
+            ttl_seconds: Time-to-live in seconds for the exported checkpoint.
+                Defaults to ``None`` (permanent, backward-compatible).
+                Pass an integer to set auto-expiration, or explicit ``None``
+                to ensure permanent retention.
             wait: If True (default), waits for export to complete and returns path.
                   If False, returns an OperationHandle immediately.
 
@@ -251,6 +258,8 @@ class TrainingClient:
         body: Dict[str, Any] = {"seq_id": self._next_seq()}
         if name:
             body["path"] = name
+        if not isinstance(ttl_seconds, _UnsetType):
+            body["ttl_seconds"] = ttl_seconds
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/export-sampler",
             body,
@@ -270,6 +279,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
+        ttl_seconds: int | None = 86400,
         wait: Literal[True] = True,
     ) -> "SamplingClient": ...
 
@@ -278,6 +288,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
+        ttl_seconds: int | None = 86400,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -285,6 +296,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
+        ttl_seconds: int | None = 86400,
         wait: bool = True,
     ) -> "SamplingClient" | OperationHandle:
         """Export model weights and create a sampling client.
@@ -292,8 +304,14 @@ class TrainingClient:
         This is a convenience method that combines save_weights_for_sampler
         and get_sampling_client. For more control, use those methods separately.
 
+        Because this method is designed for frequent RL weight-sync calls,
+        the default TTL is **1 day (86400 s)**.  Pass ``ttl_seconds=None``
+        to keep the checkpoint permanently.
+
         Args:
             name: Optional custom path name for the exported weights
+            ttl_seconds: Time-to-live in seconds for the exported checkpoint.
+                Defaults to ``86400`` (1 day).  Pass ``None`` for permanent.
             wait: If True (default), waits for export and returns SamplingClient.
                   If False, returns an OperationHandle immediately.
 
@@ -306,6 +324,8 @@ class TrainingClient:
         body: Dict[str, Any] = {"seq_id": self._next_seq()}
         if name:
             body["path"] = name
+        if ttl_seconds is not None:
+            body["ttl_seconds"] = ttl_seconds
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/export-sampler",
             body,
@@ -355,6 +375,7 @@ class TrainingClient:
         *,
         name: str | None = None,
         checkpoint_type: str = "weight",
+        ttl_seconds: int | None = ...,
         wait: Literal[True] = True,
     ) -> Checkpoint: ...
 
@@ -364,6 +385,7 @@ class TrainingClient:
         *,
         name: str | None = None,
         checkpoint_type: str = "weight",
+        ttl_seconds: int | None = ...,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -372,6 +394,7 @@ class TrainingClient:
         *,
         name: str | None = None,
         checkpoint_type: str = "weight",
+        ttl_seconds: int | None | _UnsetType = UNSET,
         wait: bool = True,
     ) -> Checkpoint | OperationHandle:
         """Save the current model weights as a checkpoint.
@@ -385,6 +408,10 @@ class TrainingClient:
                 the model ID automatically.
             checkpoint_type: ``"weight"`` (default) or
                 ``"weight_and_optimizer"``.
+            ttl_seconds: Time-to-live in seconds for the checkpoint.
+                Defaults to ``None`` (permanent, backward-compatible).
+                Pass an integer to set auto-expiration, or explicit ``None``
+                to ensure permanent retention.
             wait: If True (default), blocks until the save completes and
                 returns a :class:`~weaver.types.Checkpoint`.
 
@@ -395,6 +422,8 @@ class TrainingClient:
         body: Dict[str, Any] = {"type": checkpoint_type}
         if name is not None:
             body["name"] = name
+        if not isinstance(ttl_seconds, _UnsetType):
+            body["ttl_seconds"] = ttl_seconds
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/checkpoints",
             body,
@@ -507,6 +536,33 @@ class TrainingClient:
         )
         items = (response or {}).get("items", []) if isinstance(response, dict) else []
         return [Checkpoint.from_payload(item) for item in items if isinstance(item, dict)]
+
+    def set_checkpoint_ttl(
+        self,
+        path: str | Checkpoint,
+        ttl_seconds: int | None,
+    ) -> Dict[str, Any]:
+        """Set or cancel the TTL (time-to-live) for a checkpoint.
+
+        Args:
+            path: Checkpoint storage path (``weaver://...`` URI), or a
+                :class:`~weaver.types.Checkpoint` object whose ``.path``
+                will be used.
+            ttl_seconds: TTL in seconds.  Pass ``None`` to cancel
+                expiration (make the checkpoint permanent).
+
+        Returns:
+            Server response dict confirming the TTL update.
+        """
+        checkpoint_path = path.path if isinstance(path, Checkpoint) else path
+        body: Dict[str, Any] = {
+            "path": checkpoint_path,
+            "ttl_seconds": ttl_seconds,
+        }
+        return self._service.http.patch(
+            f"/api/v1/models/{self.model_id}/checkpoints/ttl",
+            json=body,
+        )
 
     def terminate(self, instance_types: list[str] | None = None) -> Dict[str, Any]:
         """Terminate trainer and/or inference instances for this model.

--- a/weaver/types/checkpoint.py
+++ b/weaver/types/checkpoint.py
@@ -36,6 +36,10 @@ class Checkpoint:
             the server did not report this field).
         train_mlp: Whether MLP layers were trained.
         train_attn: Whether attention layers were trained.
+        ttl_seconds: Time-to-live in seconds, or ``None`` for permanent.
+        created_at: ISO 8601 creation timestamp (server-generated).
+        expires_at: ISO 8601 expiration timestamp (server-generated),
+            or ``None`` if permanent.
     """
 
     id: str
@@ -46,6 +50,9 @@ class Checkpoint:
     train_unembed: bool | None = None
     train_mlp: bool | None = None
     train_attn: bool | None = None
+    ttl_seconds: int | None = None
+    created_at: str | None = None
+    expires_at: str | None = None
 
     @classmethod
     def from_payload(cls, payload: dict[str, Any]) -> Checkpoint:
@@ -72,6 +79,9 @@ class Checkpoint:
             train_unembed=_bool_or_none(lookup_case_insensitive(payload, "train_unembed")),
             train_mlp=_bool_or_none(lookup_case_insensitive(payload, "train_mlp")),
             train_attn=_bool_or_none(lookup_case_insensitive(payload, "train_attn")),
+            ttl_seconds=_int_or_none(lookup_case_insensitive(payload, "ttl_seconds")),
+            created_at=_str_or_none(lookup_case_insensitive(payload, "created_at")),
+            expires_at=_str_or_none(lookup_case_insensitive(payload, "expires_at")),
         )
 
 
@@ -81,3 +91,7 @@ def _str_or_none(value: Any) -> str | None:
 
 def _bool_or_none(value: Any) -> bool | None:
     return bool(value) if value is not None else None
+
+
+def _int_or_none(value: Any) -> int | None:
+    return int(value) if value is not None else None


### PR DESCRIPTION
## Summary

- Add `ttl_seconds` parameter to `save_state`, `save_weights_for_sampler`, and `save_weights_and_get_sampling_client` (default 86400s for RL sync use case)
- Add `set_checkpoint_ttl()` method on `TrainingClient` to modify/cancel TTL on existing checkpoints
- Extend `Checkpoint` dataclass with `ttl_seconds`, `created_at`, `expires_at` fields
- Add CLI command `weaver checkpoint set-ttl MODEL_ID PATH SECONDS [--remove]`
- Add `UNSET` sentinel in `_utils.py` to distinguish "not passed" from explicit `None`

## Testing

- [x] `pytest tests/test_training_checkpoint.py` — 32 tests pass (14 new)
- [x] `pytest tests/` — full suite 90 tests pass
- [x] `make format` clean
- [x] `make lint` clean (pylint 10/10, mypy success)
- [x] Pre-commit hooks pass

## Related Issues

Fixes #49