### PR TITLE
Add OperationHandle.wait_all() and export OperationHandle

### DIFF
--- a/weaver/__init__.py
+++ b/weaver/__init__.py
@@ -24,6 +24,7 @@ except Exception:
     __version__ = "0.3.0"
 
 from . import types  # noqa: F401
+from .operations import OperationHandle  # noqa: F401
 from .service_client import ServiceClient  # noqa: F401
 
-__all__ = ["ServiceClient", "types", "__version__"]
+__all__ = ["ServiceClient", "OperationHandle", "types", "__version__"]

--- a/weaver/operations.py
+++ b/weaver/operations.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ._http import APIClient, WeaverAPIError, backoff_delays
 from ._utils import extract_id, lookup_case_insensitive
@@ -82,6 +82,18 @@ class OperationHandle:
     def result(self) -> Any:
         payload = self.wait()
         return lookup_case_insensitive(payload, "response")
+
+    @classmethod
+    def wait_all(cls, handles: List["OperationHandle"]) -> List[Any]:
+        """Wait for all handles to complete and return their results.
+
+        Args:
+            handles: List of OperationHandle instances to wait on.
+
+        Returns:
+            List of results in the same order as the input handles.
+        """
+        return [h.result() for h in handles]
 
 
 def build_operation_handle(client: APIClient, payload: Dict[str, Any]) -> OperationHandle:


### PR DESCRIPTION
## Summary

- Export `OperationHandle` from the package's public API (`weaver/__init__.py`)
- Add `OperationHandle.wait_all(handles)` class method for waiting on multiple async operations

## Context

NexRL pipeline training (china-qijizhifeng/NexRL#216) needs to submit training operations with `wait=False` and coordinate multiple handles. The SDK already supports `wait=False` on all training methods — this PR makes the handle class publicly accessible and adds a batch-wait convenience method.

## Test plan

- [x] Existing integration tests pass
- [x] Manual: `from weaver import OperationHandle` works

Refs #54