### PR TITLE
chore: bump version to v1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.6.3"
+version = "1.7.0"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Bump version from 1.6.3 to 1.7.0 for the v1.7.0 release.