### PR TITLE
feat: support temperature for training logprobs

### DIFF
--- a/tests/test_temperature_payload.py
+++ b/tests/test_temperature_payload.py
@@ -1,0 +1,88 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any
+from unittest.mock import MagicMock
+
+import torch
+
+from weaver.training_client import TrainingClient
+from weaver.types import Datum, LogprobsParams, ModelInput
+
+
+def _make_training_client() -> TrainingClient:
+    service = MagicMock()
+    service.next_operation_seq.return_value = 1
+    return TrainingClient(
+        service=service,
+        model_id="model-123",
+        base_model="Qwen/Qwen3-8B",
+        session_id="session-123",
+    )
+
+
+def test_forward_backward_sends_temperature_in_loss_fn_config() -> None:
+    client = _make_training_client()
+    handle = MagicMock()
+    client._service.enqueue_operation.return_value = handle
+
+    result = client.forward_backward(
+        [], "cross_entropy", loss_fn_config={"temperature": 0.7}, wait=False
+    )
+
+    assert result is handle
+    body = client._service.enqueue_operation.call_args[0][1]
+    assert body["payload"]["forward_backward_input"]["loss_fn_config"]["temperature"] == 0.7
+
+
+def test_forward_backward_custom_reuses_loss_fn_config() -> None:
+    client = _make_training_client()
+    datum = Datum.from_raw(
+        model_input=ModelInput.from_ints([1, 2]),
+        loss_fn_inputs={"target_tokens": [2]},
+    )
+    calls: list[dict[str, Any]] = []
+
+    def fake_forward_backward(
+        self: TrainingClient,
+        data: list[Datum],
+        loss_fn: str,
+        *,
+        loss_fn_config: dict[str, float] | None = None,
+        wait: bool = True,
+    ) -> dict[str, Any]:
+        calls.append({"loss_fn": loss_fn, "loss_fn_config": loss_fn_config})
+        if loss_fn == "forward_logprob":
+            return {"result": {"loss_fn_outputs": [{"logprobs": [1.0]}]}}
+        return {"result": {}}
+
+    client.forward_backward = MethodType(fake_forward_backward, client)
+
+    def loss_fn(_data: list[Datum], logprob_tensors: list[torch.Tensor]):
+        return logprob_tensors[0].sum(), {}
+
+    client.forward_backward_custom([datum], loss_fn, loss_fn_config={"temperature": 0.7})
+
+    assert calls == [
+        {"loss_fn": "forward_logprob", "loss_fn_config": {"temperature": 0.7}},
+        {"loss_fn": "surrogate", "loss_fn_config": {"temperature": 0.7}},
+    ]
+
+
+def test_logprobs_params_sends_loss_fn_config() -> None:
+    payload = LogprobsParams(loss_fn_config={"temperature": 0.7}).to_payload()
+    assert payload["loss_fn_config"] == {"temperature": 0.7}

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -195,11 +195,7 @@ class TrainingClient:
         self.forward_backward(surrogate_data, "surrogate", loss_fn_config=loss_fn_config, wait=True)
 
         # Step G: return loss and metrics
-        return {
-            "loss": loss.detach(),
-            "metrics": metrics,
-            "debug_forward_outputs": outputs,
-        }
+        return {"loss": loss.detach(), "metrics": metrics}
 
     @overload
     def optim_step(self, params: AdamParams, *, wait: Literal[True] = True) -> Dict[str, Any]: ...

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -110,6 +110,8 @@ class TrainingClient:
         loss_fn: Callable[
             [Sequence[Datum], List["torch.Tensor"]], Tuple["torch.Tensor", Dict[str, Any]]
         ],
+        *,
+        loss_fn_config: Mapping[str, float] | None = None,
     ) -> Dict[str, Any]:
         """Run a custom loss function with surrogate-based gradient propagation.
 
@@ -130,7 +132,9 @@ class TrainingClient:
         import torch
 
         # Step A: forward pass to get logprobs
-        fwd_result = self.forward_backward(data, "forward_logprob", wait=True)
+        fwd_result = self.forward_backward(
+            data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True
+        )
 
         # Step B: parse logprobs from response
         outputs = fwd_result.get("result", {}).get("loss_fn_outputs", [])
@@ -187,11 +191,22 @@ class TrainingClient:
             )
             surrogate_data.append(surrogate_datum)
 
+        debug_surrogate_weights: List["torch.Tensor"] = []
+        for t in logprob_tensors:
+            grad = t.grad
+            if grad is not None:
+                debug_surrogate_weights.append(grad.detach().cpu())
+
         # Step F: surrogate backward pass
-        self.forward_backward(surrogate_data, "surrogate", wait=True)
+        self.forward_backward(surrogate_data, "surrogate", loss_fn_config=loss_fn_config, wait=True)
 
         # Step G: return loss and metrics
-        return {"loss": loss.detach(), "metrics": metrics}
+        return {
+            "loss": loss.detach(),
+            "metrics": metrics,
+            "debug_forward_outputs": outputs,
+            "debug_surrogate_weights": debug_surrogate_weights,
+        }
 
     @overload
     def optim_step(self, params: AdamParams, *, wait: Literal[True] = True) -> Dict[str, Any]: ...

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -66,7 +66,7 @@ class TrainingClient:
         data: Sequence[Datum],
         loss_fn: str,
         *,
-        loss_fn_config: Mapping[str, float] | None = None,
+        loss_fn_config: Mapping[str, Any] | None = None,
         wait: Literal[True] = True,
     ) -> Dict[str, Any]: ...
 
@@ -76,7 +76,7 @@ class TrainingClient:
         data: Sequence[Datum],
         loss_fn: str,
         *,
-        loss_fn_config: Mapping[str, float] | None = None,
+        loss_fn_config: Mapping[str, Any] | None = None,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -85,7 +85,7 @@ class TrainingClient:
         data: Sequence[Datum],
         loss_fn: str,
         *,
-        loss_fn_config: Mapping[str, float] | None = None,
+        loss_fn_config: Mapping[str, Any] | None = None,
         wait: bool = True,
     ) -> OperationHandle | Dict[str, Any]:
         payload: Dict[str, Any] = {
@@ -111,7 +111,7 @@ class TrainingClient:
             [Sequence[Datum], List["torch.Tensor"]], Tuple["torch.Tensor", Dict[str, Any]]
         ],
         *,
-        loss_fn_config: Mapping[str, float] | None = None,
+        loss_fn_config: Mapping[str, Any] | None = None,
     ) -> Dict[str, Any]:
         """Run a custom loss function with surrogate-based gradient propagation.
 
@@ -191,12 +191,6 @@ class TrainingClient:
             )
             surrogate_data.append(surrogate_datum)
 
-        debug_surrogate_weights: List["torch.Tensor"] = []
-        for t in logprob_tensors:
-            grad = t.grad
-            if grad is not None:
-                debug_surrogate_weights.append(grad.detach().cpu())
-
         # Step F: surrogate backward pass
         self.forward_backward(surrogate_data, "surrogate", loss_fn_config=loss_fn_config, wait=True)
 
@@ -205,7 +199,6 @@ class TrainingClient:
             "loss": loss.detach(),
             "metrics": metrics,
             "debug_forward_outputs": outputs,
-            "debug_surrogate_weights": debug_surrogate_weights,
         }
 
     @overload

--- a/weaver/types/logprobs.py
+++ b/weaver/types/logprobs.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Any, Mapping
 
 
 @dataclass(slots=True)
@@ -25,7 +25,7 @@ class LogprobsParams:
     """Parameters for compute_logprobs requests."""
 
     return_rollout_token_expert: bool = False
-    loss_fn_config: Mapping[str, float] | None = None
+    loss_fn_config: Mapping[str, Any] | None = None
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {}

--- a/weaver/types/logprobs.py
+++ b/weaver/types/logprobs.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Mapping
 
 
 @dataclass(slots=True)
@@ -24,9 +25,12 @@ class LogprobsParams:
     """Parameters for compute_logprobs requests."""
 
     return_rollout_token_expert: bool = False
+    loss_fn_config: Mapping[str, float] | None = None
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {}
+        if self.loss_fn_config:
+            payload["loss_fn_config"] = dict(self.loss_fn_config)
         if self.return_rollout_token_expert:
             payload["return_rollout_token_expert"] = True
         return payload


### PR DESCRIPTION
## Summary
- add temperature to training forward/backward requests
- pass temperature through custom forward-logprob/surrogate flow
- include temperature in compute_logprobs params

## Tests
- python -m pytest tests/test_temperature_payload.py

Related: china-qijizhifeng/nex-taas-feedback#144
Sub-issue: nex-agi/weaver#63