### PR TITLE
Add sampling mask to logprobs params

### DIFF
--- a/tests/test_temperature_payload.py
+++ b/tests/test_temperature_payload.py
@@ -49,6 +49,29 @@ def test_forward_backward_sends_temperature_in_loss_fn_config() -> None:
     assert body["payload"]["forward_backward_input"]["loss_fn_config"]["temperature"] == 0.7
 
 
+def test_forward_sends_loss_fn_inputs_to_trainer_backend() -> None:
+    client = _make_training_client()
+    handle = MagicMock()
+    client._service.enqueue_operation.return_value = handle
+    datum = Datum.from_raw(
+        model_input=ModelInput.from_ints([10, 11, 12]),
+        loss_fn_inputs={
+            "target_tokens": [11, 12],
+            "sampling_mask": [[11, 99], [12]],
+        },
+    )
+
+    result = client.forward([datum], "forward_logprob", wait=False)
+
+    assert result is handle
+    path, body = client._service.enqueue_operation.call_args[0]
+    assert path == "/api/v1/models/model-123/forward-passes"
+    forward_input = body["payload"]["forward_input"]
+    assert forward_input["loss_fn"] == "forward_logprob"
+    assert forward_input["data"][0]["loss_fn_inputs"]["target_tokens"]["data"] == [11, 12]
+    assert forward_input["data"][0]["loss_fn_inputs"]["sampling_mask"] == [[11, 99], [12]]
+
+
 def test_forward_backward_custom_reuses_loss_fn_config() -> None:
     client = _make_training_client()
     datum = Datum.from_raw(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -74,24 +74,6 @@ def test_model_input_creation():
     assert model_input.chunks[0].tokens == [1, 2, 3]
 
 
-def test_logprobs_params_accepts_sampling_mask():
-    params = LogprobsParams(sampling_mask=[[1, 2], [3]])
-
-    assert params.to_payload() == {"sampling_mask": [[1, 2], [3]]}
-
-
-def test_logprobs_params_combines_loss_config_and_sampling_mask():
-    params = LogprobsParams(
-        loss_fn_config={"temperature": 0.7},
-        sampling_mask=[[1, 2], [3]],
-    )
-
-    assert params.to_payload() == {
-        "loss_fn_config": {"temperature": 0.7},
-        "sampling_mask": [[1, 2], [3]],
-    }
-
-
 def test_model_input_to_ints():
     """Test ModelInput conversion to ints."""
     model_input = ModelInput.from_ints([1, 2, 3, 4, 5])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,6 +17,7 @@
 import torch
 
 from weaver.types.datum import Datum
+from weaver.types.logprobs import LogprobsParams
 from weaver.types.model_input import ModelInput
 from weaver.types.tensor import TensorData, tensor_payload
 
@@ -71,6 +72,24 @@ def test_model_input_creation():
     model_input = ModelInput.from_ints([1, 2, 3])
     assert len(model_input.chunks) == 1
     assert model_input.chunks[0].tokens == [1, 2, 3]
+
+
+def test_logprobs_params_accepts_sampling_mask():
+    params = LogprobsParams(sampling_mask=[[1, 2], [3]])
+
+    assert params.to_payload() == {"sampling_mask": [[1, 2], [3]]}
+
+
+def test_logprobs_params_combines_loss_config_and_sampling_mask():
+    params = LogprobsParams(
+        loss_fn_config={"temperature": 0.7},
+        sampling_mask=[[1, 2], [3]],
+    )
+
+    assert params.to_payload() == {
+        "loss_fn_config": {"temperature": 0.7},
+        "sampling_mask": [[1, 2], [3]],
+    }
 
 
 def test_model_input_to_ints():

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -61,6 +61,51 @@ class TrainingClient:
         return [datum.to_payload() for datum in data]
 
     @overload
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: Literal[True] = True,
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: Literal[False],
+    ) -> OperationHandle: ...
+
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: bool = True,
+    ) -> OperationHandle | Dict[str, Any]:
+        """Compute a forward pass without accumulating gradients."""
+        payload: Dict[str, Any] = {
+            "model_id": self.model_id,
+            "seq_id": self._next_seq(),
+            "forward_input": {
+                "loss_fn": loss_fn,
+                "data": self._serialize_data(data),
+            },
+        }
+        if loss_fn_config:
+            payload["forward_input"]["loss_fn_config"] = dict(loss_fn_config)
+        handle = self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/forward-passes",
+            {"payload": payload},
+        )
+        return handle.result() if wait else handle
+
+    @overload
     def forward_backward(
         self,
         data: Sequence[Datum],

--- a/weaver/types/logprobs.py
+++ b/weaver/types/logprobs.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 
 @dataclass(slots=True)
@@ -26,6 +26,7 @@ class LogprobsParams:
 
     return_rollout_token_expert: bool = False
     loss_fn_config: Mapping[str, Any] | None = None
+    sampling_mask: Sequence[Sequence[int]] | None = None
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {}
@@ -33,4 +34,8 @@ class LogprobsParams:
             payload["loss_fn_config"] = dict(self.loss_fn_config)
         if self.return_rollout_token_expert:
             payload["return_rollout_token_expert"] = True
+        if self.sampling_mask is not None:
+            payload["sampling_mask"] = [
+                [int(token_id) for token_id in token_mask] for token_mask in self.sampling_mask
+            ]
         return payload

--- a/weaver/types/logprobs.py
+++ b/weaver/types/logprobs.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping
 
 
 @dataclass(slots=True)
@@ -26,7 +26,6 @@ class LogprobsParams:
 
     return_rollout_token_expert: bool = False
     loss_fn_config: Mapping[str, Any] | None = None
-    sampling_mask: Sequence[Sequence[int]] | None = None
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {}
@@ -34,8 +33,4 @@ class LogprobsParams:
             payload["loss_fn_config"] = dict(self.loss_fn_config)
         if self.return_rollout_token_expert:
             payload["return_rollout_token_expert"] = True
-        if self.sampling_mask is not None:
-            payload["sampling_mask"] = [
-                [int(token_id) for token_id in token_mask] for token_mask in self.sampling_mask
-            ]
         return payload


### PR DESCRIPTION
## Summary
- add `TrainingClient.forward()` for trainer-side forward passes without gradient accumulation
- carry recompute masks through `Datum.loss_fn_inputs[\"sampling_mask\"]` on `forward_logprob`
- remove the obsolete `sampling_mask` field from rollout `LogprobsParams`

## Tests
- `pytest -q tests/test_temperature_payload.py tests/test_types.py`
- commit hook: black, isort, license check, pylint, mypy

## Related PRs
- NexRL: https://github.com/china-qijizhifeng/NexRL/pull/246
- Weaver SDK: https://github.com/nex-agi/weaver/pull/69
- weaver-trainer: https://github.com/china-qijizhifeng/weaver-trainer/pull/187

## E2E Test Report (2026-04-29)
- Debug env: `Tian/Qwen3-8B-test`, model `12c03c70-2880-565f-97a4-1aefb8964574`.
- Code under test: NexRL `b5229ae`, Weaver SDK `2bb4f73`, weaver-trainer `b5cd281`.
- Command: `PYTHONPATH=/gpfs/users/tangtian/Weaver/NexRL-recompute-logprobs-sampling-mask:/gpfs/users/tangtian/Weaver/weaver-logprobs-sampling-mask:$PYTHONPATH python3 /tmp/weaver_pr246_e2e_sampling_mask.py`.
- Result: operation `9e7395e0-35b4-472d-a698-ae0b042aed65` used backend `training_forward` and completed with `recompute_logprobs/replaced=1`, `recompute_logprobs/failed=0`, `recompute_logprobs/total=1`.
- Payload proof: stored trainer task payload had `data[0].loss_fn_inputs` keys `sampling_mask` and `target_tokens`; mask included jagged rows `[220, 237]` and `[17, 34]`.
- Trainer proof: `/workspace/trainer.log` showed `Processing 1 forward tasks` for task `9e7395e0-35b4-472d-a698-ae0b042aed65`, then `Handled results ... completed 1 tasks`.