### PR TITLE
Add training forward API

### DIFF
--- a/tests/test_temperature_payload.py
+++ b/tests/test_temperature_payload.py
@@ -49,7 +49,34 @@ def test_forward_backward_sends_temperature_in_loss_fn_config() -> None:
     assert body["payload"]["forward_backward_input"]["loss_fn_config"]["temperature"] == 0.7
 
 
-def test_forward_backward_custom_reuses_loss_fn_config() -> None:
+def test_forward_sends_temperature_in_loss_fn_config() -> None:
+    client = _make_training_client()
+    handle = MagicMock()
+    client._service.enqueue_operation.return_value = handle
+
+    result = client.forward([], "cross_entropy", loss_fn_config={"temperature": 0.7}, wait=False)
+
+    assert result is handle
+    path, body = client._service.enqueue_operation.call_args[0]
+    assert path == "/api/v1/models/model-123/forward-passes"
+    assert body["payload"]["forward_input"]["loss_fn_config"]["temperature"] == 0.7
+    assert body["payload"]["forward_input"]["loss_fn"] == "cross_entropy"
+    assert "forward_backward_input" not in body["payload"]
+
+
+def test_forward_waits_for_result_by_default() -> None:
+    client = _make_training_client()
+    handle = MagicMock()
+    handle.result.return_value = {"result": {"loss": 1.23}}
+    client._service.enqueue_operation.return_value = handle
+
+    result = client.forward([], "cross_entropy")
+
+    assert result == {"result": {"loss": 1.23}}
+    handle.result.assert_called_once_with()
+
+
+def test_forward_backward_custom_uses_forward_and_reuses_loss_fn_config() -> None:
     client = _make_training_client()
     datum = Datum.from_raw(
         model_input=ModelInput.from_ints([1, 2]),
@@ -57,7 +84,7 @@ def test_forward_backward_custom_reuses_loss_fn_config() -> None:
     )
     calls: list[dict[str, Any]] = []
 
-    def fake_forward_backward(
+    def fake_forward(
         self: TrainingClient,
         data: list[Datum],
         loss_fn: str,
@@ -70,6 +97,18 @@ def test_forward_backward_custom_reuses_loss_fn_config() -> None:
             return {"result": {"loss_fn_outputs": [{"logprobs": [1.0]}]}}
         return {"result": {}}
 
+    def fake_forward_backward(
+        self: TrainingClient,
+        data: list[Datum],
+        loss_fn: str,
+        *,
+        loss_fn_config: dict[str, float] | None = None,
+        wait: bool = True,
+    ) -> dict[str, Any]:
+        calls.append({"loss_fn": loss_fn, "loss_fn_config": loss_fn_config})
+        return {"result": {}}
+
+    client.forward = MethodType(fake_forward, client)
     client.forward_backward = MethodType(fake_forward_backward, client)
 
     def loss_fn(_data: list[Datum], logprob_tensors: list[torch.Tensor]):

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -61,6 +61,51 @@ class TrainingClient:
         return [datum.to_payload() for datum in data]
 
     @overload
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: Literal[True] = True,
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: Literal[False],
+    ) -> OperationHandle: ...
+
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: bool = True,
+    ) -> OperationHandle | Dict[str, Any]:
+        """Compute a forward pass without accumulating gradients."""
+        payload: Dict[str, Any] = {
+            "model_id": self.model_id,
+            "seq_id": self._next_seq(),
+            "forward_input": {
+                "loss_fn": loss_fn,
+                "data": self._serialize_data(data),
+            },
+        }
+        if loss_fn_config:
+            payload["forward_input"]["loss_fn_config"] = dict(loss_fn_config)
+        handle = self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/forward-passes",
+            {"payload": payload},
+        )
+        return handle.result() if wait else handle
+
+    @overload
     def forward_backward(
         self,
         data: Sequence[Datum],
@@ -132,9 +177,7 @@ class TrainingClient:
         import torch
 
         # Step A: forward pass to get logprobs
-        fwd_result = self.forward_backward(
-            data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True
-        )
+        fwd_result = self.forward(data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True)
 
         # Step B: parse logprobs from response
         outputs = fwd_result.get("result", {}).get("loss_fn_outputs", [])


### PR DESCRIPTION
## Summary
- Add `TrainingClient.forward()` for forward-only training jobs via `/api/v1/models/:id/forward-passes`.
- Route custom-loss logprob probing through `forward()` instead of `forward_backward()`.
- Add SDK tests for forward payload shape, wait behavior, and custom-loss routing.

## Tests
- `python -m compileall weaver`
- `pytest tests/test_temperature_payload.py`
- `pytest tests`
- Commit hooks: black, isort, license header, pylint, mypy
- Live dev smoke test: `training.forward([datum], "forward_logprob", wait=True)` completed successfully, returned `ForwardLogprob` outputs, and advanced model seq `1 -> 2` through `task_type="forward"`.

### Sanitized Smoke Test Request

```json
{
  "method": "POST",
  "path": "/api/v1/models/<model_id>/forward-passes",
  "json": {
    "payload": {
      "model_id": "<model_id>",
      "seq_id": 2,
      "forward_input": {
        "loss_fn": "forward_logprob",
        "data": [
          {
            "model_input": {
              "chunks": [
                {
                  "type": "encoded_text",
                  "tokens": [22574, 25, 43096, 198, 47, 343, 19458, 25, 458, 3362, 1455, 352]
                }
              ]
            },
            "loss_fn_inputs": {
              "target_tokens": {
                "data": [25, 43096, 198, 47, 343, 19458, 25, 458, 3362, 1455, 352, 198],
                "dtype": "int64"
              },
              "weights": {
                "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
                "dtype": "float32"
              }
            }
          }
        ]
      }
    }
  }
}
```

### Sanitized Smoke Test Response

```json
{
  "metrics": {"tokens": 12},
  "model_id": "<model_id>",
  "result": {
    "loss_fn_output_type": "ForwardLogprob",
    "loss_fn_outputs": [
      {
        "logprobs": {
          "data": [-6.234926, -13.017095, -3.157308, -4.53581, -2.914106, -0.001123, -0.025855, -0.101073, -0.101303, -1.499256, -0.225741, -0.273494],
          "dtype": "float32",
          "shape": [12]
        }
      }
    ],
    "metrics": {"tokens": 12}
  },
  "status": "succeeded",
  "task_type": "forward"
}
```
