### PR TITLE
chore: bump version to v1.7.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.7.0.1"
+version = "1.7.0.2"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Bump version from `v1.7.0.1` to `v1.7.0.2` in `pyproject.toml`.