### PR TITLE
Document logprob alignment contracts

### DIFF
--- a/tests/test_temperature_payload.py
+++ b/tests/test_temperature_payload.py
@@ -49,7 +49,34 @@ def test_forward_backward_sends_temperature_in_loss_fn_config() -> None:
     assert body["payload"]["forward_backward_input"]["loss_fn_config"]["temperature"] == 0.7
 
 
-def test_forward_backward_custom_reuses_loss_fn_config() -> None:
+def test_forward_sends_temperature_in_loss_fn_config() -> None:
+    client = _make_training_client()
+    handle = MagicMock()
+    client._service.enqueue_operation.return_value = handle
+
+    result = client.forward([], "cross_entropy", loss_fn_config={"temperature": 0.7}, wait=False)
+
+    assert result is handle
+    path, body = client._service.enqueue_operation.call_args[0]
+    assert path == "/api/v1/models/model-123/forward-passes"
+    assert body["payload"]["forward_input"]["loss_fn_config"]["temperature"] == 0.7
+    assert body["payload"]["forward_input"]["loss_fn"] == "cross_entropy"
+    assert "forward_backward_input" not in body["payload"]
+
+
+def test_forward_waits_for_result_by_default() -> None:
+    client = _make_training_client()
+    handle = MagicMock()
+    handle.result.return_value = {"result": {"loss": 1.23}}
+    client._service.enqueue_operation.return_value = handle
+
+    result = client.forward([], "cross_entropy")
+
+    assert result == {"result": {"loss": 1.23}}
+    handle.result.assert_called_once_with()
+
+
+def test_forward_backward_custom_uses_forward_and_reuses_loss_fn_config() -> None:
     client = _make_training_client()
     datum = Datum.from_raw(
         model_input=ModelInput.from_ints([1, 2]),
@@ -57,7 +84,7 @@ def test_forward_backward_custom_reuses_loss_fn_config() -> None:
     )
     calls: list[dict[str, Any]] = []
 
-    def fake_forward_backward(
+    def fake_forward(
         self: TrainingClient,
         data: list[Datum],
         loss_fn: str,
@@ -70,6 +97,18 @@ def test_forward_backward_custom_reuses_loss_fn_config() -> None:
             return {"result": {"loss_fn_outputs": [{"logprobs": [1.0]}]}}
         return {"result": {}}
 
+    def fake_forward_backward(
+        self: TrainingClient,
+        data: list[Datum],
+        loss_fn: str,
+        *,
+        loss_fn_config: dict[str, float] | None = None,
+        wait: bool = True,
+    ) -> dict[str, Any]:
+        calls.append({"loss_fn": loss_fn, "loss_fn_config": loss_fn_config})
+        return {"result": {}}
+
+    client.forward = MethodType(fake_forward, client)
     client.forward_backward = MethodType(fake_forward_backward, client)
 
     def loss_fn(_data: list[Datum], logprob_tensors: list[torch.Tensor]):

--- a/weaver/sampling_client.py
+++ b/weaver/sampling_client.py
@@ -86,6 +86,17 @@ class SamplingClient:
     ) -> List[float | None] | Dict[str, Any]:
         """Compute log-probabilities for the given prompt.
 
+        This method exposes the sampling-client contract: returned logprobs are
+        aligned with the prompt tokens and therefore have length
+        ``len(prompt_tokens)``. Position 0 is ``None`` because the first token has
+        no previous token context to score.
+
+        This differs from ``TrainingClient.forward(..., loss_fn="forward_logprob")``.
+        Trainer forward consumes explicit ``model_input`` and ``target_tokens``
+        and returns logprobs aligned with ``target_tokens``; callers that send
+        ``model_input=tokens[:-1]`` and ``target_tokens=tokens[1:]`` receive
+        ``len(tokens) - 1`` logprobs, with no leading ``None`` placeholder.
+
         Args:
             prompt: The model input (tokens) to compute logprobs for.
             logprobs_params: Optional parameters (e.g. return_rollout_token_expert for MoE router replay).

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -61,6 +61,51 @@ class TrainingClient:
         return [datum.to_payload() for datum in data]
 
     @overload
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: Literal[True] = True,
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: Literal[False],
+    ) -> OperationHandle: ...
+
+    def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        wait: bool = True,
+    ) -> OperationHandle | Dict[str, Any]:
+        """Compute a forward pass without accumulating gradients."""
+        payload: Dict[str, Any] = {
+            "model_id": self.model_id,
+            "seq_id": self._next_seq(),
+            "forward_input": {
+                "loss_fn": loss_fn,
+                "data": self._serialize_data(data),
+            },
+        }
+        if loss_fn_config:
+            payload["forward_input"]["loss_fn_config"] = dict(loss_fn_config)
+        handle = self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/forward-passes",
+            {"payload": payload},
+        )
+        return handle.result() if wait else handle
+
+    @overload
     def forward_backward(
         self,
         data: Sequence[Datum],
@@ -132,9 +177,7 @@ class TrainingClient:
         import torch
 
         # Step A: forward pass to get logprobs
-        fwd_result = self.forward_backward(
-            data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True
-        )
+        fwd_result = self.forward(data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True)
 
         # Step B: parse logprobs from response
         outputs = fwd_result.get("result", {}).get("loss_fn_outputs", [])

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -88,7 +88,19 @@ class TrainingClient:
         *,
         wait: bool = True,
     ) -> OperationHandle | Dict[str, Any]:
-        """Compute a forward pass without accumulating gradients."""
+        """Compute a forward pass without accumulating gradients.
+
+        For ``loss_fn="forward_logprob"``, the trainer-forward contract is
+        target-aligned: each datum must provide ``model_input`` and
+        ``loss_fn_inputs["target_tokens"]`` with the same length, and the result
+        contains one logprob per target token. For a full token sequence
+        ``tokens``, send ``model_input=tokens[:-1]`` and
+        ``target_tokens=tokens[1:]`` to score next-token targets.
+
+        This is intentionally different from ``SamplingClient.compute_logprobs``,
+        whose public result is prompt-token-aligned and includes a leading
+        ``None`` placeholder at index 0.
+        """
         payload: Dict[str, Any] = {
             "model_id": self.model_id,
             "seq_id": self._next_seq(),


### PR DESCRIPTION
## Summary
- Document the alignment difference between SamplingClient.compute_logprobs and TrainingClient.forward(..., loss_fn="forward_logprob")
- Clarify token-aligned prompt logprobs with leading None vs target-aligned trainer logprobs

## Verification
- python -m py_compile weaver/sampling_client.py weaver/training_client.py
- commit hooks passed