### PR TITLE
feat: default save_weights_for_sampler ttl to 1 day

### DIFF
--- a/tests/test_training_checkpoint.py
+++ b/tests/test_training_checkpoint.py
@@ -390,22 +390,21 @@ class TestSaveStateTTL:
 
 
 class TestSaveWeightsForSamplerTTL:
-    def test_default_no_ttl_in_body(self):
+    def test_default_is_one_day(self):
         tc = _make_training_client()
         handle = _make_handle({"model_path": "weaver://path"})
         tc._service.enqueue_operation.return_value = handle
         tc.save_weights_for_sampler(name="test")
         body = tc._service.enqueue_operation.call_args[0][1]
-        assert "ttl_seconds" not in body
+        assert body["ttl_seconds"] == 86400
 
-    def test_explicit_none_sends_null(self):
+    def test_explicit_none_no_ttl_in_body(self):
         tc = _make_training_client()
         handle = _make_handle({"model_path": "weaver://path"})
         tc._service.enqueue_operation.return_value = handle
         tc.save_weights_for_sampler(name="test", ttl_seconds=None)
         body = tc._service.enqueue_operation.call_args[0][1]
-        assert "ttl_seconds" in body
-        assert body["ttl_seconds"] is None
+        assert "ttl_seconds" not in body
 
     def test_with_ttl_seconds(self):
         tc = _make_training_client()

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -265,7 +265,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = ...,
+        ttl_seconds: int | None = 86400,
         wait: Literal[True] = True,
     ) -> str: ...
 
@@ -274,7 +274,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = ...,
+        ttl_seconds: int | None = 86400,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -282,17 +282,20 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None | _UnsetType = UNSET,
+        ttl_seconds: int | None = 86400,
         wait: bool = True,
     ) -> str | OperationHandle:
         """Export model weights for sampling.
 
+        Sampler weights are intended for short-lived RL weight-sync use, so
+        the default TTL is **1 day (86400 s)**.  Pass ``ttl_seconds=None`` to
+        keep the exported checkpoint permanently (use ``save_state`` if you
+        need a durable checkpoint instead).
+
         Args:
             name: Optional custom path name for the exported weights
             ttl_seconds: Time-to-live in seconds for the exported checkpoint.
-                Defaults to ``None`` (permanent, backward-compatible).
-                Pass an integer to set auto-expiration, or explicit ``None``
-                to ensure permanent retention.
+                Defaults to ``86400`` (1 day).  Pass ``None`` for permanent.
             wait: If True (default), waits for export to complete and returns path.
                   If False, returns an OperationHandle immediately.
 
@@ -305,7 +308,7 @@ class TrainingClient:
         body: Dict[str, Any] = {"seq_id": self._next_seq()}
         if name:
             body["path"] = name
-        if not isinstance(ttl_seconds, _UnsetType):
+        if ttl_seconds is not None:
             body["ttl_seconds"] = ttl_seconds
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/export-sampler",


### PR DESCRIPTION
## Summary
- `save_weights_for_sampler` now defaults to `ttl_seconds=86400` (1 day), matching `save_weights_and_get_sampling_client`. Pass `ttl_seconds=None` to retain permanently.
- `save_state` is unchanged — defaults remain `UNSET` / permanent for durable checkpoints.

## Why
Sampler weights are short-lived RL weight-sync artifacts. The previous default omitted the field, so server-side `expires_at` stayed NULL and the TTL-based GC never reclaimed them. We observed 2200+ orphan checkpoint rows on `/gpfs/shared_data/.weaver/checkpoints` (24 model dirs, every row `expires_at IS NULL`).

## Test plan
- [x] `pytest tests/test_training_checkpoint.py` — 32 passed
- [ ] Manual: existing callers of `save_weights_for_sampler` without `ttl_seconds` will now auto-expire; confirmed acceptable with `save_state` unchanged for durable use