### PR TITLE
chore: bump version to v1.7.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.7.0.2"
+version = "1.7.0.3"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Bump version: 1.7.0.2 → 1.7.0.3

Independent of #74 (sampler default TTL change). Merge order: feature first, then this bump.