### PR TITLE
feat(router-replay): support metadata and moe topk

### DIFF
--- a/tests/test_router_replay_types.py
+++ b/tests/test_router_replay_types.py
@@ -16,6 +16,8 @@
 
 import json
 
+import pytest
+
 from weaver.types.payload_ref import materialize_payload_ref
 from weaver.types.router_replay import (
     ROUTER_REPLAY_DATUM_SCHEMA,
@@ -56,29 +58,40 @@ def test_router_replay_metadata_to_payload():
     metadata = RouterReplayMetadata(
         mode=ROUTER_REPLAY_MODE_R2,
         source=ROUTER_REPLAY_SOURCE_RECOMPUTE,
-        indices=RouterReplayIndices(value=[[[7, 8]]], num_layers=1, topk=2),
+        action="REPLAY",
+        sample_ref=router_replay_sample_uri("model-a", "set-1", 7),
+        index_set_uri=router_replay_set_uri("model-a", "set-1"),
+        manifest_uri=router_replay_manifest_uri("model-a", "set-1"),
     )
 
     assert metadata.to_payload() == {
         "schema": ROUTER_REPLAY_DATUM_SCHEMA,
         "mode": "R2",
         "source": "recompute",
-        "indices": {
-            "format": ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
-            "value": [[[7, 8]]],
-            "token_alignment": ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED,
-            "num_layers": 1,
-            "topk": 2,
-        },
         "fail_fast": True,
+        "sample_ref": "weaver://model-a/router-replay/set-1/samples/7",
+        "index_set_uri": "weaver://model-a/router-replay/set-1",
+        "manifest_uri": "weaver://model-a/router-replay/set-1/manifest.json",
+        "action": "REPLAY",
     }
 
 
-def test_router_replay_metadata_to_payload_preserves_fail_fast_false():
+def test_router_replay_metadata_rejects_sdk_visible_indices():
     metadata = RouterReplayMetadata(
-        mode=ROUTER_REPLAY_MODE_R3,
-        source=ROUTER_REPLAY_SOURCE_ROLLOUT,
+        mode=ROUTER_REPLAY_MODE_R2,
+        source=ROUTER_REPLAY_SOURCE_RECOMPUTE,
         indices=RouterReplayIndices(value=[[[7, 8]]], num_layers=1, topk=2),
+    )
+
+    with pytest.raises(ValueError, match="indices is no longer SDK-visible"):
+        metadata.to_payload()
+
+
+def test_router_replay_metadata_to_payload_preserves_fail_fast_false():
+    metadata = RouterReplayMetadata.r3_replay(
+        sample_ref=router_replay_sample_uri("model-a", "set-1", 3),
+        index_set_uri=router_replay_set_uri("model-a", "set-1"),
+        manifest_uri=router_replay_manifest_uri("model-a", "set-1"),
         fail_fast=False,
     )
 
@@ -99,16 +112,13 @@ def test_router_replay_r2_record_has_no_indices():
 
 def test_router_replay_metadata_supports_datum_ref_uris():
     metadata = RouterReplayMetadata.r3_replay(
-        RouterReplayIndices(value=[[[1, 2]]], num_layers=1, topk=2),
-        sample_index=3,
-        index_uri=router_replay_sample_uri("model-a", "set-1", 3),
+        sample_ref=router_replay_sample_uri("model-a", "set-1", 3),
         index_set_uri=router_replay_set_uri("model-a", "set-1"),
         manifest_uri=router_replay_manifest_uri("model-a", "set-1"),
     )
 
     payload = metadata.to_payload()
-    assert payload["sample_index"] == 3
-    assert payload["index_uri"] == "weaver://model-a/router-replay/set-1/samples/3"
+    assert payload["sample_ref"] == "weaver://model-a/router-replay/set-1/samples/3"
     assert payload["index_set_uri"] == "weaver://model-a/router-replay/set-1"
     assert payload["manifest_uri"] == "weaver://model-a/router-replay/set-1/manifest.json"
 
@@ -140,7 +150,10 @@ def test_router_replay_indices_support_ref_shards():
 def test_materialize_router_replay_indices_returns_inline_value():
     value = [[[1, 2]]]
 
-    assert materialize_router_replay_indices({"value": value}) == value
+    summary = materialize_router_replay_indices({"value": value})
+    assert summary["kind"] == "router_replay_ref"
+    assert summary["materialized"] is False
+    assert materialize_router_replay_indices({"value": value}, trusted=True) == value
 
 
 def test_materialize_router_replay_indices_combines_pipeline_shards():
@@ -184,7 +197,7 @@ def test_materialize_router_replay_indices_combines_pipeline_shards():
         ],
     }
 
-    assert materialize_router_replay_indices(envelope) == [
+    assert materialize_router_replay_indices(envelope, trusted=True) == [
         [
             [[1, 2], [3, 4], [9, 10], [11, 12]],
             [[5, 6], [7, 8], [13, 14], [15, 16]],
@@ -219,7 +232,7 @@ def test_materialize_router_replay_indices_handles_seq_major_microbatch():
         ],
     }
 
-    assert materialize_router_replay_indices(envelope) == [
+    assert materialize_router_replay_indices(envelope, trusted=True) == [
         [["s0-t0"], ["s0-t1"], ["s0-t2"]],
         [["s2-t0"], ["s2-t1"], ["s2-t2"]],
         [["s4-t0"], ["s4-t1"], ["s4-t2"]],
@@ -252,9 +265,14 @@ def test_materialize_router_replay_index_selects_sample_from_manifest(tmp_path, 
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     monkeypatch.setenv("WEAVER_PAYLOAD_REF_ROOT", str(tmp_path))
 
-    assert materialize_router_replay_index("weaver://model-a/router-replay/set-1/samples/3") == [
-        [["s3-pp0"], ["s3-pp1"]]
-    ]
+    summary = materialize_router_replay_index("weaver://model-a/router-replay/set-1/samples/3")
+    assert summary["materialized"] is False
+    assert summary["kind"] == "router_replay_sample_ref"
+
+    assert materialize_router_replay_index(
+        "weaver://model-a/router-replay/set-1/samples/3",
+        trusted=True,
+    ) == [[["s3-pp0"], ["s3-pp1"]]]
 
 
 def test_materialize_payload_ref_resolves_relative_path_with_root(tmp_path, monkeypatch):

--- a/tests/test_router_replay_types.py
+++ b/tests/test_router_replay_types.py
@@ -14,6 +14,7 @@
 
 """Tests for Router Replay contract helpers."""
 
+from weaver.types.payload_ref import materialize_payload_ref
 from weaver.types.router_replay import (
     ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
     ROUTER_REPLAY_MODE_R2,
@@ -24,6 +25,7 @@ from weaver.types.router_replay import (
     RouterReplayIndices,
     RouterReplayMetadata,
     RouterReplayModelConfig,
+    materialize_router_replay_indices,
 )
 
 
@@ -73,6 +75,114 @@ def test_router_replay_metadata_to_payload_preserves_fail_fast_false():
     )
 
     assert metadata.to_payload()["fail_fast"] is False
+
+
+def test_router_replay_r2_record_has_no_indices():
+    metadata = RouterReplayMetadata.r2_record()
+
+    assert metadata.to_payload() == {
+        "mode": "R2",
+        "source": "recompute",
+        "fail_fast": True,
+        "action": "RECORD",
+    }
+
+
+def test_router_replay_indices_support_ref_shards():
+    indices = RouterReplayIndices(
+        num_layers=2,
+        topk=2,
+        shards=[
+            {
+                "sample_indices": [0],
+                "local_tokens_per_sample": 1,
+                "value_ref": {
+                    "storage": "gpfs",
+                    "format": "torch.save",
+                    "relative_path": "op/dp0.pt",
+                },
+            }
+        ],
+        transport="gpfs_torch_save",
+    )
+
+    payload = indices.to_payload()
+    assert "value" not in payload
+    assert payload["transport"] == "gpfs_torch_save"
+    assert payload["shards"][0]["value_ref"]["relative_path"] == "op/dp0.pt"
+
+
+def test_materialize_router_replay_indices_returns_inline_value():
+    value = [[[1, 2]]]
+
+    assert materialize_router_replay_indices({"value": value}) == value
+
+
+def test_materialize_router_replay_indices_combines_pipeline_shards():
+    envelope = {
+        "transport": "gpfs_torch_save",
+        "format": "token_layer_topk",
+        "shards": [
+            {
+                "dp_rank": 0,
+                "tp_rank": 0,
+                "pp_rank": 0,
+                "sample_indices": [0],
+                "local_tokens_per_sample": 2,
+                "value": [
+                    [[1, 2], [3, 4]],
+                    [[5, 6], [7, 8]],
+                ],
+            },
+            {
+                "dp_rank": 0,
+                "tp_rank": 0,
+                "pp_rank": 1,
+                "sample_indices": [0],
+                "local_tokens_per_sample": 2,
+                "value": [
+                    [[9, 10], [11, 12]],
+                    [[13, 14], [15, 16]],
+                ],
+            },
+            {
+                "dp_rank": 0,
+                "tp_rank": 1,
+                "pp_rank": 0,
+                "sample_indices": [0],
+                "local_tokens_per_sample": 2,
+                "value": [
+                    [[101, 102], [103, 104]],
+                    [[105, 106], [107, 108]],
+                ],
+            },
+        ],
+    }
+
+    assert materialize_router_replay_indices(envelope) == [
+        [
+            [[1, 2], [3, 4], [9, 10], [11, 12]],
+            [[5, 6], [7, 8], [13, 14], [15, 16]],
+        ]
+    ]
+
+
+def test_materialize_payload_ref_resolves_relative_path_with_root(tmp_path, monkeypatch):
+    ref_root = tmp_path / "payload_refs"
+    ref_root.mkdir()
+    payload_path = ref_root / "op-1" / "payload.json"
+    payload_path.parent.mkdir()
+    payload_path.write_text('{"indices": [1, 2, 3]}')
+    monkeypatch.setenv("WEAVER_PAYLOAD_REF_ROOT", str(ref_root))
+
+    assert materialize_payload_ref(
+        {
+            "storage": "gpfs",
+            "format": "json",
+            "relative_path": "op-1/payload.json",
+        },
+        field="indices",
+    ) == [1, 2, 3]
 
 
 def test_router_replay_model_config_to_payload():

--- a/tests/test_router_replay_types.py
+++ b/tests/test_router_replay_types.py
@@ -14,8 +14,11 @@
 
 """Tests for Router Replay contract helpers."""
 
+import json
+
 from weaver.types.payload_ref import materialize_payload_ref
 from weaver.types.router_replay import (
+    ROUTER_REPLAY_DATUM_SCHEMA,
     ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
     ROUTER_REPLAY_MODE_R2,
     ROUTER_REPLAY_MODE_R3,
@@ -25,7 +28,11 @@ from weaver.types.router_replay import (
     RouterReplayIndices,
     RouterReplayMetadata,
     RouterReplayModelConfig,
+    materialize_router_replay_index,
     materialize_router_replay_indices,
+    router_replay_manifest_uri,
+    router_replay_sample_uri,
+    router_replay_set_uri,
 )
 
 
@@ -53,6 +60,7 @@ def test_router_replay_metadata_to_payload():
     )
 
     assert metadata.to_payload() == {
+        "schema": ROUTER_REPLAY_DATUM_SCHEMA,
         "mode": "R2",
         "source": "recompute",
         "indices": {
@@ -81,11 +89,28 @@ def test_router_replay_r2_record_has_no_indices():
     metadata = RouterReplayMetadata.r2_record()
 
     assert metadata.to_payload() == {
+        "schema": ROUTER_REPLAY_DATUM_SCHEMA,
         "mode": "R2",
         "source": "recompute",
         "fail_fast": True,
         "action": "RECORD",
     }
+
+
+def test_router_replay_metadata_supports_datum_ref_uris():
+    metadata = RouterReplayMetadata.r3_replay(
+        RouterReplayIndices(value=[[[1, 2]]], num_layers=1, topk=2),
+        sample_index=3,
+        index_uri=router_replay_sample_uri("model-a", "set-1", 3),
+        index_set_uri=router_replay_set_uri("model-a", "set-1"),
+        manifest_uri=router_replay_manifest_uri("model-a", "set-1"),
+    )
+
+    payload = metadata.to_payload()
+    assert payload["sample_index"] == 3
+    assert payload["index_uri"] == "weaver://model-a/router-replay/set-1/samples/3"
+    assert payload["index_set_uri"] == "weaver://model-a/router-replay/set-1"
+    assert payload["manifest_uri"] == "weaver://model-a/router-replay/set-1/manifest.json"
 
 
 def test_router_replay_indices_support_ref_shards():
@@ -164,6 +189,71 @@ def test_materialize_router_replay_indices_combines_pipeline_shards():
             [[1, 2], [3, 4], [9, 10], [11, 12]],
             [[5, 6], [7, 8], [13, 14], [15, 16]],
         ]
+    ]
+
+
+def test_materialize_router_replay_indices_handles_seq_major_microbatch():
+    envelope = {
+        "format": "token_layer_topk",
+        "shards": [
+            {
+                "dp_rank": 0,
+                "tp_rank": 0,
+                "pp_rank": 0,
+                "sample_indices": [0, 2, 4],
+                "local_tokens_per_sample": 3,
+                "microbatch_sizes": [3],
+                "row_layout": "seq_major_microbatch",
+                "value": [
+                    ["s0-t0"],
+                    ["s2-t0"],
+                    ["s4-t0"],
+                    ["s0-t1"],
+                    ["s2-t1"],
+                    ["s4-t1"],
+                    ["s0-t2"],
+                    ["s2-t2"],
+                    ["s4-t2"],
+                ],
+            }
+        ],
+    }
+
+    assert materialize_router_replay_indices(envelope) == [
+        [["s0-t0"], ["s0-t1"], ["s0-t2"]],
+        [["s2-t0"], ["s2-t1"], ["s2-t2"]],
+        [["s4-t0"], ["s4-t1"], ["s4-t2"]],
+    ]
+
+
+def test_materialize_router_replay_index_selects_sample_from_manifest(tmp_path, monkeypatch):
+    manifest = {
+        "format": "token_layer_topk",
+        "token_alignment": "target_aligned",
+        "num_layers": 2,
+        "topk": 1,
+        "shards": [
+            {
+                "pp_rank": 0,
+                "sample_indices": [3, 1],
+                "local_tokens_per_sample": 1,
+                "value": [[["s3-pp0"]], [["s1-pp0"]]],
+            },
+            {
+                "pp_rank": 1,
+                "sample_indices": [3, 1],
+                "local_tokens_per_sample": 1,
+                "value": [[["s3-pp1"]], [["s1-pp1"]]],
+            },
+        ],
+    }
+    manifest_path = tmp_path / "model-a" / "router-replay" / "set-1" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setenv("WEAVER_PAYLOAD_REF_ROOT", str(tmp_path))
+
+    assert materialize_router_replay_index("weaver://model-a/router-replay/set-1/samples/3") == [
+        [["s3-pp0"], ["s3-pp1"]]
     ]
 
 

--- a/tests/test_router_replay_types.py
+++ b/tests/test_router_replay_types.py
@@ -1,0 +1,79 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Router Replay contract helpers."""
+
+from weaver.types.router_replay import (
+    ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
+    ROUTER_REPLAY_MODE_R2,
+    ROUTER_REPLAY_SOURCE_RECOMPUTE,
+    ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED,
+    RouterReplayIndices,
+    RouterReplayMetadata,
+    RouterReplayModelConfig,
+)
+
+
+def test_router_replay_indices_to_payload():
+    indices = RouterReplayIndices(
+        value=[[[1, 2], [3, 4]]],
+        num_layers=2,
+        topk=2,
+    )
+
+    assert indices.to_payload() == {
+        "format": ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
+        "value": [[[1, 2], [3, 4]]],
+        "token_alignment": ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED,
+        "num_layers": 2,
+        "topk": 2,
+    }
+
+
+def test_router_replay_metadata_to_payload():
+    metadata = RouterReplayMetadata(
+        mode=ROUTER_REPLAY_MODE_R2,
+        source=ROUTER_REPLAY_SOURCE_RECOMPUTE,
+        indices=RouterReplayIndices(value=[[[7, 8]]], num_layers=1, topk=2),
+    )
+
+    assert metadata.to_payload() == {
+        "mode": "R2",
+        "source": "recompute",
+        "indices": {
+            "format": ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
+            "value": [[[7, 8]]],
+            "token_alignment": ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED,
+            "num_layers": 1,
+            "topk": 2,
+        },
+        "fail_fast": True,
+    }
+
+
+def test_router_replay_model_config_to_payload():
+    config = RouterReplayModelConfig(
+        enabled=True,
+        mode=ROUTER_REPLAY_MODE_R2,
+        num_layers=64,
+        topk=8,
+    )
+
+    assert config.to_payload() == {
+        "enabled": True,
+        "mode": "R2",
+        "num_layers": 64,
+        "topk": 8,
+        "fail_fast": True,
+    }

--- a/tests/test_router_replay_types.py
+++ b/tests/test_router_replay_types.py
@@ -17,7 +17,9 @@
 from weaver.types.router_replay import (
     ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
     ROUTER_REPLAY_MODE_R2,
+    ROUTER_REPLAY_MODE_R3,
     ROUTER_REPLAY_SOURCE_RECOMPUTE,
+    ROUTER_REPLAY_SOURCE_ROLLOUT,
     ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED,
     RouterReplayIndices,
     RouterReplayMetadata,
@@ -62,6 +64,17 @@ def test_router_replay_metadata_to_payload():
     }
 
 
+def test_router_replay_metadata_to_payload_preserves_fail_fast_false():
+    metadata = RouterReplayMetadata(
+        mode=ROUTER_REPLAY_MODE_R3,
+        source=ROUTER_REPLAY_SOURCE_ROLLOUT,
+        indices=RouterReplayIndices(value=[[[7, 8]]], num_layers=1, topk=2),
+        fail_fast=False,
+    )
+
+    assert metadata.to_payload()["fail_fast"] is False
+
+
 def test_router_replay_model_config_to_payload():
     config = RouterReplayModelConfig(
         enabled=True,
@@ -77,3 +90,9 @@ def test_router_replay_model_config_to_payload():
         "topk": 8,
         "fail_fast": True,
     }
+
+
+def test_router_replay_model_config_to_payload_preserves_fail_fast_false():
+    config = RouterReplayModelConfig(enabled=False, fail_fast=False)
+
+    assert config.to_payload() == {"enabled": False, "fail_fast": False}

--- a/tests/test_sampling_moe_topk_indices.py
+++ b/tests/test_sampling_moe_topk_indices.py
@@ -1,0 +1,140 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for return_moe_topk_indices support in SamplingClient."""
+
+from unittest.mock import MagicMock
+
+from weaver.sampling_client import SamplingClient
+from weaver.types import ModelInput
+
+
+def _make_client() -> tuple:
+    """Create a SamplingClient with a mock service and return (client, mock_service)."""
+    mock_service = MagicMock()
+    client = SamplingClient(
+        service=mock_service,
+        sampling_session_id="sess-001",
+        base_model="Qwen/Qwen3-8B",
+    )
+    return client, mock_service
+
+
+def test_sample_request_includes_return_moe_topk_indices_flag():
+    """When return_moe_topk_indices=True, the request body contains the flag at top level."""
+    client, mock_service = _make_client()
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = {
+        "result": {"sequences": [{"tokens": [1], "text": "a", "stop_reason": "stop"}]}
+    }
+    mock_service.enqueue_operation.return_value = mock_handle
+
+    prompt = ModelInput.from_ints([1, 2, 3])
+    client.sample(prompt=prompt, return_moe_topk_indices=True)
+
+    call_args = mock_service.enqueue_operation.call_args
+    body = call_args[0][1]
+    assert "return_moe_topk_indices" in body
+    assert body["return_moe_topk_indices"] is True
+    # Must NOT be inside sampling_params
+    assert "return_moe_topk_indices" not in body["sampling_params"]
+
+
+def test_sample_request_omits_flag_when_false():
+    """When return_moe_topk_indices=False (default), the key is absent from the request body."""
+    client, mock_service = _make_client()
+    mock_handle = MagicMock()
+    mock_handle.result.return_value = {
+        "result": {"sequences": [{"tokens": [1], "text": "a", "stop_reason": "stop"}]}
+    }
+    mock_service.enqueue_operation.return_value = mock_handle
+
+    prompt = ModelInput.from_ints([1, 2, 3])
+    client.sample(prompt=prompt)
+
+    call_args = mock_service.enqueue_operation.call_args
+    body = call_args[0][1]
+    assert "return_moe_topk_indices" not in body
+
+
+def test_normalize_preserves_moe_topk_indices():
+    """When the server response contains moe_topk_indices, the normalized result preserves it."""
+    client, _ = _make_client()
+    payload = {
+        "result": {
+            "sequences": [
+                {
+                    "tokens": [1, 2, 3],
+                    "text": "hello",
+                    "stop_reason": "stop",
+                    "logprobs": [-0.5, -0.3, -0.1],
+                    "moe_topk_indices": [[1, 7, 3, 5], [2, 4, 0, 6], [1, 3, 5, 7]],
+                }
+            ]
+        }
+    }
+
+    result = client._normalize_sample_result(payload)
+
+    assert "sequences" in result
+    seq = result["sequences"][0]
+    assert "moe_topk_indices" in seq
+    assert seq["moe_topk_indices"] == [[1, 7, 3, 5], [2, 4, 0, 6], [1, 3, 5, 7]]
+
+
+def test_normalize_omits_moe_topk_indices_when_absent():
+    """When moe_topk_indices is not in the response, it's not in the normalized result."""
+    client, _ = _make_client()
+    payload = {
+        "result": {
+            "sequences": [
+                {
+                    "tokens": [1, 2, 3],
+                    "text": "hello",
+                    "stop_reason": "stop",
+                    "logprobs": [-0.5, -0.3, -0.1],
+                }
+            ]
+        }
+    }
+
+    result = client._normalize_sample_result(payload)
+
+    assert "sequences" in result
+    seq = result["sequences"][0]
+    assert "moe_topk_indices" not in seq
+
+
+def test_normalize_omits_moe_topk_indices_when_none():
+    """When moe_topk_indices is None, it's not in the normalized result."""
+    client, _ = _make_client()
+    payload = {
+        "result": {
+            "sequences": [
+                {
+                    "tokens": [1, 2, 3],
+                    "text": "hello",
+                    "stop_reason": "stop",
+                    "logprobs": [-0.5, -0.3, -0.1],
+                    "moe_topk_indices": None,
+                }
+            ]
+        }
+    }
+
+    result = client._normalize_sample_result(payload)
+
+    assert "sequences" in result
+    seq = result["sequences"][0]
+    assert "moe_topk_indices" not in seq

--- a/tests/test_training_metadata.py
+++ b/tests/test_training_metadata.py
@@ -60,16 +60,13 @@ def _generic_metadata() -> Dict[str, Any]:
 def _router_replay_payload() -> Dict[str, Any]:
     """Sample datum-level router_replay metadata contract."""
     return {
+        "schema": "weaver.router_replay.datum.v1",
         "mode": "R3",
         "source": "rollout",
-        "sample_index": 7,
-        "indices": {
-            "format": "token_layer_topk",
-            "value": [[[1, 7], [3, 5]], [[2, 4], [0, 6]]],
-            "token_alignment": "target_aligned",
-            "num_layers": 2,
-            "topk": 2,
-        },
+        "action": "REPLAY",
+        "sample_ref": "weaver://model-a/router-replay/set-1/samples/7",
+        "index_set_uri": "weaver://model-a/router-replay/set-1",
+        "manifest_uri": "weaver://model-a/router-replay/set-1/manifest.json",
         "fail_fast": True,
     }
 
@@ -255,16 +252,17 @@ class TestRouterReplayMetadataType:
 
     def test_typed_datum_metadata_serialization(self):
         """RouterReplayMetadata.to_payload() can be attached to a Datum."""
-        from weaver.types.router_replay import RouterReplayIndices, RouterReplayMetadata
+        from weaver.types.router_replay import (
+            RouterReplayMetadata,
+            router_replay_manifest_uri,
+            router_replay_sample_uri,
+            router_replay_set_uri,
+        )
 
-        replay = RouterReplayMetadata(
-            mode="R3",
-            source="rollout",
-            indices=RouterReplayIndices(
-                value=[[[1, 7], [3, 5]], [[2, 4], [0, 6]]],
-                num_layers=2,
-                topk=2,
-            ),
+        replay = RouterReplayMetadata.r3_replay(
+            sample_ref=router_replay_sample_uri("model-a", "set-1", 7),
+            index_set_uri=router_replay_set_uri("model-a", "set-1"),
+            manifest_uri=router_replay_manifest_uri("model-a", "set-1"),
         )
 
         client = _make_training_client()
@@ -288,9 +286,8 @@ class TestRouterReplayMetadataType:
         rr = inner_payload["forward_backward_input"]["data"][0]["metadata"]["router_replay"]
         assert rr["mode"] == "R3"
         assert rr["source"] == "rollout"
-        assert rr["indices"]["format"] == "token_layer_topk"
-        assert rr["indices"]["num_layers"] == 2
-        assert rr["indices"]["topk"] == 2
+        assert rr["sample_ref"] == "weaver://model-a/router-replay/set-1/samples/7"
+        assert "indices" not in rr
         assert rr["fail_fast"] is True
 
     def test_forward_rejects_router_replay_argument(self):

--- a/tests/test_training_metadata.py
+++ b/tests/test_training_metadata.py
@@ -46,9 +46,7 @@ def _make_training_client() -> TrainingClient:
 
 def _make_datum() -> Datum:
     """Create a minimal Datum for testing."""
-    model_input = ModelInput(
-        chunks=[ModelInputChunk(type="encoded_text", tokens=[10, 20, 30])]
-    )
+    model_input = ModelInput(chunks=[ModelInputChunk(type="encoded_text", tokens=[10, 20, 30])])
     return Datum.from_raw(
         model_input=model_input,
         loss_fn_inputs={"target_tokens": [10, 20, 30]},
@@ -239,9 +237,7 @@ class TestForwardBackwardMetadata:
 
         meta = _router_replay_metadata()
         config = {"temperature": 0.7, "clip_ratio": 0.2}
-        client.forward_backward(
-            [_make_datum()], "grpo", loss_fn_config=config, metadata=meta
-        )
+        client.forward_backward([_make_datum()], "grpo", loss_fn_config=config, metadata=meta)
 
         inner_payload = captured_payloads[0]["payload"]
         # Both are present and independent
@@ -256,10 +252,7 @@ class TestRouterReplayMetadataType:
 
     def test_typed_metadata_serialization(self):
         """RouterReplayMetadata.to_payload() produces valid metadata dict."""
-        from weaver.types.router_replay import (
-            RouterReplayIndices,
-            RouterReplayMetadata,
-        )
+        from weaver.types.router_replay import RouterReplayIndices, RouterReplayMetadata
 
         replay = RouterReplayMetadata(
             mode="R3",

--- a/tests/test_training_metadata.py
+++ b/tests/test_training_metadata.py
@@ -53,21 +53,24 @@ def _make_datum() -> Datum:
     )
 
 
-def _router_replay_metadata() -> Dict[str, Any]:
-    """Sample router_replay metadata contract."""
+def _generic_metadata() -> Dict[str, Any]:
+    return {"trace_id": "abc", "priority": 3}
+
+
+def _router_replay_payload() -> Dict[str, Any]:
+    """Sample datum-level router_replay metadata contract."""
     return {
-        "router_replay": {
-            "mode": "R3",
-            "source": "rollout",
-            "indices": {
-                "format": "token_layer_topk",
-                "value": [[[1, 7], [3, 5]], [[2, 4], [0, 6]]],
-                "token_alignment": "target_aligned",
-                "num_layers": 2,
-                "topk": 2,
-            },
-            "fail_fast": True,
-        }
+        "mode": "R3",
+        "source": "rollout",
+        "sample_index": 7,
+        "indices": {
+            "format": "token_layer_topk",
+            "value": [[[1, 7], [3, 5]], [[2, 4], [0, 6]]],
+            "token_alignment": "target_aligned",
+            "num_layers": 2,
+            "topk": 2,
+        },
+        "fail_fast": True,
     }
 
 
@@ -88,7 +91,7 @@ class TestForwardMetadata:
 
         client._service.enqueue_operation = mock_enqueue
 
-        meta = _router_replay_metadata()
+        meta = _generic_metadata()
         client.forward([_make_datum()], "grpo", metadata=meta)
 
         assert len(captured_payloads) == 1
@@ -111,7 +114,7 @@ class TestForwardMetadata:
 
         client._service.enqueue_operation = mock_enqueue
 
-        meta = _router_replay_metadata()
+        meta = _generic_metadata()
         client.forward([_make_datum()], "grpo", metadata=meta)
 
         inner_payload = captured_payloads[0]["payload"]
@@ -173,7 +176,7 @@ class TestForwardBackwardMetadata:
 
         client._service.enqueue_operation = mock_enqueue
 
-        meta = _router_replay_metadata()
+        meta = _generic_metadata()
         client.forward_backward([_make_datum()], "grpo", metadata=meta)
 
         assert len(captured_payloads) == 1
@@ -195,7 +198,7 @@ class TestForwardBackwardMetadata:
 
         client._service.enqueue_operation = mock_enqueue
 
-        meta = _router_replay_metadata()
+        meta = _generic_metadata()
         client.forward_backward([_make_datum()], "grpo", metadata=meta)
 
         inner_payload = captured_payloads[0]["payload"]
@@ -235,7 +238,7 @@ class TestForwardBackwardMetadata:
 
         client._service.enqueue_operation = mock_enqueue
 
-        meta = _router_replay_metadata()
+        meta = _generic_metadata()
         config = {"temperature": 0.7, "clip_ratio": 0.2}
         client.forward_backward([_make_datum()], "grpo", loss_fn_config=config, metadata=meta)
 
@@ -248,10 +251,10 @@ class TestForwardBackwardMetadata:
 
 
 class TestRouterReplayMetadataType:
-    """Test using RouterReplayMetadata.to_payload() as metadata value."""
+    """Test datum-level router replay serialization and request-level rejection."""
 
-    def test_typed_metadata_serialization(self):
-        """RouterReplayMetadata.to_payload() produces valid metadata dict."""
+    def test_typed_datum_metadata_serialization(self):
+        """RouterReplayMetadata.to_payload() can be attached to a Datum."""
         from weaver.types.router_replay import RouterReplayIndices, RouterReplayMetadata
 
         replay = RouterReplayMetadata(
@@ -275,14 +278,14 @@ class TestRouterReplayMetadataType:
 
         client._service.enqueue_operation = mock_enqueue
 
-        client.forward_backward(
-            [_make_datum()],
-            "grpo",
-            metadata={"router_replay": replay.to_payload()},
-        )
+        datum = _make_datum()
+        datum.metadata["router_replay"] = replay.to_payload()
+
+        client.forward_backward([datum], "grpo")
 
         inner_payload = captured_payloads[0]["payload"]
-        rr = inner_payload["metadata"]["router_replay"]
+        assert "metadata" not in inner_payload
+        rr = inner_payload["forward_backward_input"]["data"][0]["metadata"]["router_replay"]
         assert rr["mode"] == "R3"
         assert rr["source"] == "rollout"
         assert rr["indices"]["format"] == "token_layer_topk"
@@ -290,45 +293,26 @@ class TestRouterReplayMetadataType:
         assert rr["indices"]["topk"] == 2
         assert rr["fail_fast"] is True
 
-    def test_forward_accepts_router_replay_argument(self):
-        """TrainingClient.forward serializes router_replay as per-call metadata."""
-        from weaver.types.router_replay import RouterReplayMetadata
-
-        client = _make_training_client()
-        captured_payloads = []
-
-        def mock_enqueue(path, payload):
-            captured_payloads.append(payload)
-            handle = MagicMock()
-            handle.result.return_value = {}
-            return handle
-
-        client._service.enqueue_operation = mock_enqueue
-
-        client.forward(
-            [_make_datum()],
-            "forward_logprob",
-            router_replay=RouterReplayMetadata.r2_record(),
-        )
-
-        rr = captured_payloads[0]["payload"]["metadata"]["router_replay"]
-        assert rr == {
-            "mode": "R2",
-            "source": "recompute",
-            "fail_fast": True,
-            "action": "RECORD",
-        }
-
-    def test_forward_backward_rejects_router_replay_conflict(self):
-        """Explicit router_replay cannot conflict with metadata.router_replay."""
+    def test_forward_rejects_router_replay_argument(self):
+        """Request-level router_replay is no longer accepted."""
         from weaver.types.router_replay import RouterReplayMetadata
 
         client = _make_training_client()
 
-        with pytest.raises(ValueError, match="router replay either"):
+        with pytest.raises(ValueError, match="datum.metadata"):
+            client.forward(
+                [_make_datum()],
+                "forward_logprob",
+                router_replay=RouterReplayMetadata.r2_record(),
+            )
+
+    def test_forward_backward_rejects_request_metadata_router_replay(self):
+        """Top-level metadata.router_replay is no longer accepted."""
+        client = _make_training_client()
+
+        with pytest.raises(ValueError, match="datum.metadata"):
             client.forward_backward(
                 [_make_datum()],
                 "grpo",
-                metadata=_router_replay_metadata(),
-                router_replay=RouterReplayMetadata.r2_record(),
+                metadata={"router_replay": _router_replay_payload()},
             )

--- a/tests/test_training_metadata.py
+++ b/tests/test_training_metadata.py
@@ -1,0 +1,298 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RFC-0001 T3: Tests for training request metadata passthrough.
+
+Validates that TrainingClient.forward() and forward_backward() pass metadata
+as a top-level payload key (not inside datum or loss_fn_inputs), and that it
+is omitted when not provided.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from weaver.service_client import ServiceClient
+from weaver.training_client import TrainingClient
+from weaver.types.datum import Datum
+from weaver.types.model_input import ModelInput, ModelInputChunk
+
+
+def _make_training_client() -> TrainingClient:
+    """Create a TrainingClient with a mock service."""
+    service = ServiceClient()
+    return TrainingClient(
+        service=service,
+        model_id="model-moe-001",
+        base_model="Qwen/Qwen2.5-MoE-A3B",
+        session_id="session-rfc0001",
+    )
+
+
+def _make_datum() -> Datum:
+    """Create a minimal Datum for testing."""
+    model_input = ModelInput(
+        chunks=[ModelInputChunk(type="encoded_text", tokens=[10, 20, 30])]
+    )
+    return Datum.from_raw(
+        model_input=model_input,
+        loss_fn_inputs={"target_tokens": [10, 20, 30]},
+    )
+
+
+def _router_replay_metadata() -> Dict[str, Any]:
+    """Sample router_replay metadata per RFC-0001 contract."""
+    return {
+        "router_replay": {
+            "mode": "R3",
+            "source": "rollout",
+            "indices": {
+                "format": "token_layer_topk",
+                "value": [[[1, 7], [3, 5]], [[2, 4], [0, 6]]],
+                "token_alignment": "target_aligned",
+                "num_layers": 2,
+                "topk": 2,
+            },
+            "fail_fast": True,
+        }
+    }
+
+
+class TestForwardMetadata:
+    """Test metadata parameter on TrainingClient.forward()."""
+
+    def test_metadata_included_in_payload(self):
+        """Metadata appears as top-level 'metadata' key in payload."""
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            # Return a mock handle whose .result() returns {}
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        meta = _router_replay_metadata()
+        client.forward([_make_datum()], "grpo", metadata=meta)
+
+        assert len(captured_payloads) == 1
+        inner_payload = captured_payloads[0]["payload"]
+        # metadata is at top level, not inside forward_input
+        assert "metadata" in inner_payload
+        assert inner_payload["metadata"] == meta
+        assert "metadata" not in inner_payload["forward_input"]
+
+    def test_metadata_not_in_datum(self):
+        """Metadata does not leak into datum serialization."""
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        meta = _router_replay_metadata()
+        client.forward([_make_datum()], "grpo", metadata=meta)
+
+        inner_payload = captured_payloads[0]["payload"]
+        data_items = inner_payload["forward_input"]["data"]
+        for datum_payload in data_items:
+            assert "metadata" not in datum_payload
+            assert "router_replay" not in datum_payload.get("loss_fn_inputs", {})
+
+    def test_no_metadata_when_none(self):
+        """When metadata is None, payload has no 'metadata' key."""
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        client.forward([_make_datum()], "cross_entropy")
+
+        inner_payload = captured_payloads[0]["payload"]
+        assert "metadata" not in inner_payload
+
+    def test_no_metadata_when_empty_dict(self):
+        """When metadata is empty dict, payload has no 'metadata' key (falsy)."""
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        client.forward([_make_datum()], "cross_entropy", metadata={})
+
+        inner_payload = captured_payloads[0]["payload"]
+        assert "metadata" not in inner_payload
+
+
+class TestForwardBackwardMetadata:
+    """Test metadata parameter on TrainingClient.forward_backward()."""
+
+    def test_metadata_included_in_payload(self):
+        """Metadata appears as top-level 'metadata' key in payload."""
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        meta = _router_replay_metadata()
+        client.forward_backward([_make_datum()], "grpo", metadata=meta)
+
+        assert len(captured_payloads) == 1
+        inner_payload = captured_payloads[0]["payload"]
+        assert "metadata" in inner_payload
+        assert inner_payload["metadata"] == meta
+        assert "metadata" not in inner_payload["forward_backward_input"]
+
+    def test_metadata_not_in_datum(self):
+        """Metadata does not leak into datum serialization."""
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        meta = _router_replay_metadata()
+        client.forward_backward([_make_datum()], "grpo", metadata=meta)
+
+        inner_payload = captured_payloads[0]["payload"]
+        data_items = inner_payload["forward_backward_input"]["data"]
+        for datum_payload in data_items:
+            assert "metadata" not in datum_payload
+            assert "router_replay" not in datum_payload.get("loss_fn_inputs", {})
+
+    def test_no_metadata_when_none(self):
+        """When metadata is None, payload has no 'metadata' key."""
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        client.forward_backward([_make_datum()], "cross_entropy")
+
+        inner_payload = captured_payloads[0]["payload"]
+        assert "metadata" not in inner_payload
+
+    def test_metadata_with_loss_fn_config(self):
+        """Metadata and loss_fn_config coexist without interference."""
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        meta = _router_replay_metadata()
+        config = {"temperature": 0.7, "clip_ratio": 0.2}
+        client.forward_backward(
+            [_make_datum()], "grpo", loss_fn_config=config, metadata=meta
+        )
+
+        inner_payload = captured_payloads[0]["payload"]
+        # Both are present and independent
+        assert inner_payload["metadata"] == meta
+        assert inner_payload["forward_backward_input"]["loss_fn_config"] == config
+        # metadata is not inside forward_backward_input
+        assert "metadata" not in inner_payload["forward_backward_input"]
+
+
+class TestRouterReplayMetadataType:
+    """Test using RouterReplayMetadata.to_payload() as metadata value."""
+
+    def test_typed_metadata_serialization(self):
+        """RouterReplayMetadata.to_payload() produces valid metadata dict."""
+        from weaver.types.router_replay import (
+            RouterReplayIndices,
+            RouterReplayMetadata,
+        )
+
+        replay = RouterReplayMetadata(
+            mode="R3",
+            source="rollout",
+            indices=RouterReplayIndices(
+                value=[[[1, 7], [3, 5]], [[2, 4], [0, 6]]],
+                num_layers=2,
+                topk=2,
+            ),
+        )
+
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        client.forward_backward(
+            [_make_datum()],
+            "grpo",
+            metadata={"router_replay": replay.to_payload()},
+        )
+
+        inner_payload = captured_payloads[0]["payload"]
+        rr = inner_payload["metadata"]["router_replay"]
+        assert rr["mode"] == "R3"
+        assert rr["source"] == "rollout"
+        assert rr["indices"]["format"] == "token_layer_topk"
+        assert rr["indices"]["num_layers"] == 2
+        assert rr["indices"]["topk"] == 2
+        assert rr["fail_fast"] is True

--- a/tests/test_training_metadata.py
+++ b/tests/test_training_metadata.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""RFC-0001 T3: Tests for training request metadata passthrough.
+"""Tests for training request metadata passthrough.
 
 Validates that TrainingClient.forward() and forward_backward() pass metadata
 as a top-level payload key (not inside datum or loss_fn_inputs), and that it
@@ -54,7 +54,7 @@ def _make_datum() -> Datum:
 
 
 def _router_replay_metadata() -> Dict[str, Any]:
-    """Sample router_replay metadata per RFC-0001 contract."""
+    """Sample router_replay metadata contract."""
     return {
         "router_replay": {
             "mode": "R3",

--- a/tests/test_training_metadata.py
+++ b/tests/test_training_metadata.py
@@ -289,3 +289,46 @@ class TestRouterReplayMetadataType:
         assert rr["indices"]["num_layers"] == 2
         assert rr["indices"]["topk"] == 2
         assert rr["fail_fast"] is True
+
+    def test_forward_accepts_router_replay_argument(self):
+        """TrainingClient.forward serializes router_replay as per-call metadata."""
+        from weaver.types.router_replay import RouterReplayMetadata
+
+        client = _make_training_client()
+        captured_payloads = []
+
+        def mock_enqueue(path, payload):
+            captured_payloads.append(payload)
+            handle = MagicMock()
+            handle.result.return_value = {}
+            return handle
+
+        client._service.enqueue_operation = mock_enqueue
+
+        client.forward(
+            [_make_datum()],
+            "forward_logprob",
+            router_replay=RouterReplayMetadata.r2_record(),
+        )
+
+        rr = captured_payloads[0]["payload"]["metadata"]["router_replay"]
+        assert rr == {
+            "mode": "R2",
+            "source": "recompute",
+            "fail_fast": True,
+            "action": "RECORD",
+        }
+
+    def test_forward_backward_rejects_router_replay_conflict(self):
+        """Explicit router_replay cannot conflict with metadata.router_replay."""
+        from weaver.types.router_replay import RouterReplayMetadata
+
+        client = _make_training_client()
+
+        with pytest.raises(ValueError, match="router replay either"):
+            client.forward_backward(
+                [_make_datum()],
+                "grpo",
+                metadata=_router_replay_metadata(),
+                router_replay=RouterReplayMetadata.r2_record(),
+            )

--- a/weaver/__init__.py
+++ b/weaver/__init__.py
@@ -18,7 +18,7 @@
 try:
     from importlib.metadata import version as _get_version
 
-    __version__ = _get_version("weaver")
+    __version__ = _get_version("nex-weaver")
 except Exception:
     # Fallback when package is not installed (e.g., development mode without pip install -e)
     __version__ = "0.3.0"

--- a/weaver/sampling_client.py
+++ b/weaver/sampling_client.py
@@ -55,6 +55,7 @@ class SamplingClient:
         topk_prompt_logprobs: int = 0,
         return_sampling_mask: bool = False,
         return_old_logprob: bool = False,
+        return_moe_topk_indices: bool = False,
         wait: bool = True,
     ) -> OperationHandle | Dict[str, Any]:
         params = sampling_params or SamplingParams()
@@ -69,6 +70,8 @@ class SamplingClient:
             body["return_sampling_mask"] = True
         if return_old_logprob:
             body["return_old_logprob"] = True
+        if return_moe_topk_indices:
+            body["return_moe_topk_indices"] = True
         handle = self._service.enqueue_operation(
             f"/api/v1/sampling-sessions/{self.sampling_session_id}/samples",
             body,
@@ -191,6 +194,8 @@ class SamplingClient:
                     sequence["old_logprobs"] = raw["old_logprobs"]
                 if "sampling_masks" in raw and raw["sampling_masks"] is not None:
                     sequence["sampling_masks"] = raw["sampling_masks"]
+                if "moe_topk_indices" in raw and raw["moe_topk_indices"] is not None:
+                    sequence["moe_topk_indices"] = raw["moe_topk_indices"]
                 sequences.append(sequence)
             return [seq for seq in sequences if seq["tokens"]]
 

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -66,22 +66,22 @@ class TrainingClient:
         metadata: Mapping[str, Any] | None,
         router_replay: "RouterReplayMetadata | Mapping[str, Any] | None",
     ) -> Dict[str, Any] | None:
+        if router_replay is not None:
+            raise ValueError(
+                "router_replay= is no longer accepted at request level. "
+                "Attach router replay metadata to each Datum via "
+                "datum.metadata['router_replay']."
+            )
         if not metadata and router_replay is None:
             return None
 
         payload = dict(metadata or {})
-        if router_replay is not None:
-            if "router_replay" in payload:
-                raise ValueError(
-                    "Pass router replay either via metadata['router_replay'] or "
-                    "router_replay=, not both."
-                )
-            to_payload = getattr(router_replay, "to_payload", None)
-            if callable(to_payload):
-                payload["router_replay"] = to_payload()
-            else:
-                assert isinstance(router_replay, Mapping)
-                payload["router_replay"] = dict(router_replay)
+        if "router_replay" in payload:
+            raise ValueError(
+                "metadata['router_replay'] is no longer accepted at request level. "
+                "Attach router replay metadata to each Datum via "
+                "datum.metadata['router_replay']."
+            )
         return payload or None
 
     @overload
@@ -125,11 +125,10 @@ class TrainingClient:
             loss_fn: Name of the loss function to use.
             loss_fn_config: Optional loss function configuration.
             metadata: Optional top-level request metadata (e.g. router_replay
-                context). Passed through to TrainerTask.metadata and does not
-                enter datum or loss_fn_inputs.
-            router_replay: Optional per-call Router Replay envelope. This is
-                serialized into top-level metadata.router_replay for this
-                forward call only.
+                context). Router replay metadata must be attached to each Datum
+                as ``datum.metadata["router_replay"]``.
+            router_replay: Deprecated request-level Router Replay envelope.
+                Passing this argument raises ``ValueError``.
             wait: If True, blocks until the operation completes.
         """
         payload: Dict[str, Any] = {
@@ -192,11 +191,10 @@ class TrainingClient:
             loss_fn: Name of the loss function to use.
             loss_fn_config: Optional loss function configuration.
             metadata: Optional top-level request metadata (e.g. router_replay
-                context). Passed through to TrainerTask.metadata and does not
-                enter datum or loss_fn_inputs.
-            router_replay: Optional per-call Router Replay envelope. This is
-                serialized into top-level metadata.router_replay for this
-                forward_backward call only.
+                context). Router replay metadata must be attached to each Datum
+                as ``datum.metadata["router_replay"]``.
+            router_replay: Deprecated request-level Router Replay envelope.
+                Passing this argument raises ``ValueError``.
             wait: If True, blocks until the operation completes.
         """
         payload: Dict[str, Any] = {

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -98,8 +98,8 @@ class TrainingClient:
             loss_fn: Name of the loss function to use.
             loss_fn_config: Optional loss function configuration.
             metadata: Optional top-level request metadata (e.g. router_replay
-                context). RFC-0001: passed through to TrainerTask.metadata,
-                does not enter datum or loss_fn_inputs.
+                context). Passed through to TrainerTask.metadata and does not
+                enter datum or loss_fn_inputs.
             wait: If True, blocks until the operation completes.
         """
         payload: Dict[str, Any] = {
@@ -158,8 +158,8 @@ class TrainingClient:
             loss_fn: Name of the loss function to use.
             loss_fn_config: Optional loss function configuration.
             metadata: Optional top-level request metadata (e.g. router_replay
-                context). RFC-0001: passed through to TrainerTask.metadata,
-                does not enter datum or loss_fn_inputs.
+                context). Passed through to TrainerTask.metadata and does not
+                enter datum or loss_fn_inputs.
             wait: If True, blocks until the operation completes.
         """
         payload: Dict[str, Any] = {

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -67,6 +67,7 @@ class TrainingClient:
         loss_fn: str,
         loss_fn_config: Mapping[str, Any] | None = None,
         *,
+        metadata: Mapping[str, Any] | None = None,
         wait: Literal[True] = True,
     ) -> Dict[str, Any]: ...
 
@@ -77,6 +78,7 @@ class TrainingClient:
         loss_fn: str,
         loss_fn_config: Mapping[str, Any] | None = None,
         *,
+        metadata: Mapping[str, Any] | None = None,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -86,9 +88,20 @@ class TrainingClient:
         loss_fn: str,
         loss_fn_config: Mapping[str, Any] | None = None,
         *,
+        metadata: Mapping[str, Any] | None = None,
         wait: bool = True,
     ) -> OperationHandle | Dict[str, Any]:
-        """Compute a forward pass without accumulating gradients."""
+        """Compute a forward pass without accumulating gradients.
+
+        Args:
+            data: Sequence of training data.
+            loss_fn: Name of the loss function to use.
+            loss_fn_config: Optional loss function configuration.
+            metadata: Optional top-level request metadata (e.g. router_replay
+                context). RFC-0001: passed through to TrainerTask.metadata,
+                does not enter datum or loss_fn_inputs.
+            wait: If True, blocks until the operation completes.
+        """
         payload: Dict[str, Any] = {
             "model_id": self.model_id,
             "seq_id": self._next_seq(),
@@ -99,6 +112,8 @@ class TrainingClient:
         }
         if loss_fn_config:
             payload["forward_input"]["loss_fn_config"] = dict(loss_fn_config)
+        if metadata:
+            payload["metadata"] = dict(metadata)
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/forward-passes",
             {"payload": payload},
@@ -112,6 +127,7 @@ class TrainingClient:
         loss_fn: str,
         *,
         loss_fn_config: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
         wait: Literal[True] = True,
     ) -> Dict[str, Any]: ...
 
@@ -122,6 +138,7 @@ class TrainingClient:
         loss_fn: str,
         *,
         loss_fn_config: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -131,8 +148,20 @@ class TrainingClient:
         loss_fn: str,
         *,
         loss_fn_config: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
         wait: bool = True,
     ) -> OperationHandle | Dict[str, Any]:
+        """Compute a forward and backward pass, accumulating gradients.
+
+        Args:
+            data: Sequence of training data.
+            loss_fn: Name of the loss function to use.
+            loss_fn_config: Optional loss function configuration.
+            metadata: Optional top-level request metadata (e.g. router_replay
+                context). RFC-0001: passed through to TrainerTask.metadata,
+                does not enter datum or loss_fn_inputs.
+            wait: If True, blocks until the operation completes.
+        """
         payload: Dict[str, Any] = {
             "model_id": self.model_id,
             "seq_id": self._next_seq(),
@@ -143,6 +172,8 @@ class TrainingClient:
         }
         if loss_fn_config:
             payload["forward_backward_input"]["loss_fn_config"] = dict(loss_fn_config)
+        if metadata:
+            payload["metadata"] = dict(metadata)
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/forward-backward-passes",
             {"payload": payload},

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     import torch
 
     from .sampling_client import SamplingClient
+    from .types.router_replay import RouterReplayMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,29 @@ class TrainingClient:
     def _serialize_data(self, data: Sequence[Datum]) -> Sequence[Dict[str, Any]]:
         return [datum.to_payload() for datum in data]
 
+    def _build_metadata(
+        self,
+        metadata: Mapping[str, Any] | None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None",
+    ) -> Dict[str, Any] | None:
+        if not metadata and router_replay is None:
+            return None
+
+        payload = dict(metadata or {})
+        if router_replay is not None:
+            if "router_replay" in payload:
+                raise ValueError(
+                    "Pass router replay either via metadata['router_replay'] or "
+                    "router_replay=, not both."
+                )
+            to_payload = getattr(router_replay, "to_payload", None)
+            if callable(to_payload):
+                payload["router_replay"] = to_payload()
+            else:
+                assert isinstance(router_replay, Mapping)
+                payload["router_replay"] = dict(router_replay)
+        return payload or None
+
     @overload
     def forward(
         self,
@@ -68,6 +92,7 @@ class TrainingClient:
         loss_fn_config: Mapping[str, Any] | None = None,
         *,
         metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
         wait: Literal[True] = True,
     ) -> Dict[str, Any]: ...
 
@@ -79,6 +104,7 @@ class TrainingClient:
         loss_fn_config: Mapping[str, Any] | None = None,
         *,
         metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -89,6 +115,7 @@ class TrainingClient:
         loss_fn_config: Mapping[str, Any] | None = None,
         *,
         metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
         wait: bool = True,
     ) -> OperationHandle | Dict[str, Any]:
         """Compute a forward pass without accumulating gradients.
@@ -100,6 +127,9 @@ class TrainingClient:
             metadata: Optional top-level request metadata (e.g. router_replay
                 context). Passed through to TrainerTask.metadata and does not
                 enter datum or loss_fn_inputs.
+            router_replay: Optional per-call Router Replay envelope. This is
+                serialized into top-level metadata.router_replay for this
+                forward call only.
             wait: If True, blocks until the operation completes.
         """
         payload: Dict[str, Any] = {
@@ -112,8 +142,9 @@ class TrainingClient:
         }
         if loss_fn_config:
             payload["forward_input"]["loss_fn_config"] = dict(loss_fn_config)
-        if metadata:
-            payload["metadata"] = dict(metadata)
+        request_metadata = self._build_metadata(metadata, router_replay)
+        if request_metadata:
+            payload["metadata"] = request_metadata
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/forward-passes",
             {"payload": payload},
@@ -128,6 +159,7 @@ class TrainingClient:
         *,
         loss_fn_config: Mapping[str, Any] | None = None,
         metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
         wait: Literal[True] = True,
     ) -> Dict[str, Any]: ...
 
@@ -139,6 +171,7 @@ class TrainingClient:
         *,
         loss_fn_config: Mapping[str, Any] | None = None,
         metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -149,6 +182,7 @@ class TrainingClient:
         *,
         loss_fn_config: Mapping[str, Any] | None = None,
         metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
         wait: bool = True,
     ) -> OperationHandle | Dict[str, Any]:
         """Compute a forward and backward pass, accumulating gradients.
@@ -160,6 +194,9 @@ class TrainingClient:
             metadata: Optional top-level request metadata (e.g. router_replay
                 context). Passed through to TrainerTask.metadata and does not
                 enter datum or loss_fn_inputs.
+            router_replay: Optional per-call Router Replay envelope. This is
+                serialized into top-level metadata.router_replay for this
+                forward_backward call only.
             wait: If True, blocks until the operation completes.
         """
         payload: Dict[str, Any] = {
@@ -172,8 +209,9 @@ class TrainingClient:
         }
         if loss_fn_config:
             payload["forward_backward_input"]["loss_fn_config"] = dict(loss_fn_config)
-        if metadata:
-            payload["metadata"] = dict(metadata)
+        request_metadata = self._build_metadata(metadata, router_replay)
+        if request_metadata:
+            payload["metadata"] = request_metadata
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/forward-backward-passes",
             {"payload": payload},

--- a/weaver/types/__init__.py
+++ b/weaver/types/__init__.py
@@ -20,6 +20,17 @@ from .logprobs import LogprobsParams
 from .lora_config import LoraConfig
 from .model_input import ModelInput, ModelInputChunk
 from .optim import AdamParams
+from .router_replay import (
+    ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
+    ROUTER_REPLAY_MODE_R2,
+    ROUTER_REPLAY_MODE_R3,
+    ROUTER_REPLAY_SOURCE_RECOMPUTE,
+    ROUTER_REPLAY_SOURCE_ROLLOUT,
+    ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED,
+    RouterReplayIndices,
+    RouterReplayMetadata,
+    RouterReplayModelConfig,
+)
 from .sampling import SamplingParams
 from .tensor import TensorData
 
@@ -31,6 +42,15 @@ __all__ = [
     "LogprobsParams",
     "ModelInput",
     "ModelInputChunk",
+    "ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK",
+    "ROUTER_REPLAY_MODE_R2",
+    "ROUTER_REPLAY_MODE_R3",
+    "ROUTER_REPLAY_SOURCE_RECOMPUTE",
+    "ROUTER_REPLAY_SOURCE_ROLLOUT",
+    "ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED",
+    "RouterReplayIndices",
+    "RouterReplayMetadata",
+    "RouterReplayModelConfig",
     "SamplingParams",
     "TensorData",
 ]

--- a/weaver/types/__init__.py
+++ b/weaver/types/__init__.py
@@ -20,6 +20,7 @@ from .logprobs import LogprobsParams
 from .lora_config import LoraConfig
 from .model_input import ModelInput, ModelInputChunk
 from .optim import AdamParams
+from .payload_ref import PayloadRef, PayloadRefMaterializationError, materialize_payload_ref
 from .router_replay import (
     ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
     ROUTER_REPLAY_MODE_R2,
@@ -30,6 +31,7 @@ from .router_replay import (
     RouterReplayIndices,
     RouterReplayMetadata,
     RouterReplayModelConfig,
+    materialize_router_replay_indices,
 )
 from .sampling import SamplingParams
 from .tensor import TensorData
@@ -42,6 +44,8 @@ __all__ = [
     "LogprobsParams",
     "ModelInput",
     "ModelInputChunk",
+    "PayloadRef",
+    "PayloadRefMaterializationError",
     "ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK",
     "ROUTER_REPLAY_MODE_R2",
     "ROUTER_REPLAY_MODE_R3",
@@ -53,4 +57,6 @@ __all__ = [
     "RouterReplayModelConfig",
     "SamplingParams",
     "TensorData",
+    "materialize_payload_ref",
+    "materialize_router_replay_indices",
 ]

--- a/weaver/types/__init__.py
+++ b/weaver/types/__init__.py
@@ -22,7 +22,9 @@ from .model_input import ModelInput, ModelInputChunk
 from .optim import AdamParams
 from .payload_ref import PayloadRef, PayloadRefMaterializationError, materialize_payload_ref
 from .router_replay import (
+    ROUTER_REPLAY_DATUM_SCHEMA,
     ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK,
+    ROUTER_REPLAY_INDEX_SET_SCHEMA,
     ROUTER_REPLAY_MODE_R2,
     ROUTER_REPLAY_MODE_R3,
     ROUTER_REPLAY_SOURCE_RECOMPUTE,
@@ -31,7 +33,12 @@ from .router_replay import (
     RouterReplayIndices,
     RouterReplayMetadata,
     RouterReplayModelConfig,
+    materialize_router_replay_index,
     materialize_router_replay_indices,
+    router_replay_manifest_uri,
+    router_replay_sample_uri,
+    router_replay_set_uri,
+    router_replay_shard_uri,
 )
 from .sampling import SamplingParams
 from .tensor import TensorData
@@ -52,11 +59,18 @@ __all__ = [
     "ROUTER_REPLAY_SOURCE_RECOMPUTE",
     "ROUTER_REPLAY_SOURCE_ROLLOUT",
     "ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED",
+    "ROUTER_REPLAY_DATUM_SCHEMA",
+    "ROUTER_REPLAY_INDEX_SET_SCHEMA",
     "RouterReplayIndices",
     "RouterReplayMetadata",
     "RouterReplayModelConfig",
     "SamplingParams",
     "TensorData",
     "materialize_payload_ref",
+    "materialize_router_replay_index",
     "materialize_router_replay_indices",
+    "router_replay_manifest_uri",
+    "router_replay_sample_uri",
+    "router_replay_set_uri",
+    "router_replay_shard_uri",
 ]

--- a/weaver/types/datum.py
+++ b/weaver/types/datum.py
@@ -29,6 +29,7 @@ from .tensor import TensorData, tensor_payload
 class Datum:
     model_input: ModelInput
     loss_fn_inputs: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         normalized: Dict[str, Any] = {}
@@ -61,6 +62,7 @@ class Datum:
                 )
                 for name, values in self.loss_fn_inputs.items()
             },
+            **({"metadata": dict(self.metadata)} if self.metadata else {}),
         }
 
     @classmethod
@@ -69,10 +71,12 @@ class Datum:
         *,
         model_input: ModelInput,
         loss_fn_inputs: Mapping[str, Any],
+        metadata: Mapping[str, Any] | None = None,
     ) -> "Datum":
         return cls(
             model_input=model_input,
             loss_fn_inputs=dict(loss_fn_inputs),  # type: ignore[arg-type]
+            metadata=dict(metadata or {}),
         )
 
     def tensors(self) -> Dict[str, TensorData]:

--- a/weaver/types/payload_ref.py
+++ b/weaver/types/payload_ref.py
@@ -38,6 +38,7 @@ class PayloadRef:
     format: str
     schema: str | None = None
     size_bytes: int | None = None
+    uri: str | None = None
     relative_path: str | None = None
     path: str | None = None
     dtype: str | None = None
@@ -50,6 +51,7 @@ class PayloadRef:
             "format",
             "schema",
             "size_bytes",
+            "uri",
             "relative_path",
             "path",
             "dtype",
@@ -60,6 +62,7 @@ class PayloadRef:
             format=str(payload.get("format", "")),
             schema=_optional_str(payload.get("schema")),
             size_bytes=_optional_int(payload.get("size_bytes")),
+            uri=_optional_str(payload.get("uri")),
             relative_path=_optional_str(payload.get("relative_path")),
             path=_optional_str(payload.get("path")),
             dtype=_optional_str(payload.get("dtype")),
@@ -75,6 +78,8 @@ class PayloadRef:
             payload["schema"] = self.schema
         if self.size_bytes is not None:
             payload["size_bytes"] = self.size_bytes
+        if self.uri is not None:
+            payload["uri"] = self.uri
         if self.relative_path is not None:
             payload["relative_path"] = self.relative_path
         if include_private and self.path is not None:
@@ -143,22 +148,47 @@ def materialize_payload_ref(
 def _resolve_local_ref_path(payload_ref: PayloadRef) -> Path | None:
     """Resolve local/GPFS refs without requiring callers to handle storage paths."""
 
-    if payload_ref.path:
-        legacy_path = Path(payload_ref.path)
-        if legacy_path.exists():
-            return legacy_path
+    legacy_path = _existing_path(payload_ref.path)
+    if legacy_path is not None:
+        return legacy_path
+    if payload_ref.uri and payload_ref.uri.startswith("weaver://"):
+        resolved = _resolve_weaver_uri(payload_ref.uri)
+        if resolved is not None:
+            return resolved
     if payload_ref.relative_path:
-        relative = Path(payload_ref.relative_path)
-        if relative.is_absolute():
-            return relative
-        for env_key in ("WEAVER_PAYLOAD_REF_ROOT", "WEAVER_ROUTER_REPLAY_REF_ROOT"):
-            root = os.environ.get(env_key)
-            if root:
-                return Path(root) / relative
-        return relative
+        return _resolve_relative_ref_path(payload_ref.relative_path)
     if payload_ref.path:
         return Path(payload_ref.path)
     return None
+
+
+def _existing_path(path: str | None) -> Path | None:
+    if not path:
+        return None
+    resolved = Path(path)
+    return resolved if resolved.exists() else None
+
+
+def _resolve_relative_ref_path(relative_path: str) -> Path:
+    relative = Path(relative_path)
+    if relative.is_absolute():
+        return relative
+    for env_key in ("WEAVER_PAYLOAD_REF_ROOT", "WEAVER_ROUTER_REPLAY_REF_ROOT"):
+        root = os.environ.get(env_key)
+        if root:
+            return Path(root) / relative
+    return relative
+
+
+def _resolve_weaver_uri(uri: str) -> Path | None:
+    relative = uri.removeprefix("weaver://").lstrip("/")
+    if not relative:
+        return None
+    for env_key in ("WEAVER_PAYLOAD_REF_ROOT", "WEAVER_ROUTER_REPLAY_REF_ROOT"):
+        root = os.environ.get(env_key)
+        if root:
+            return Path(root) / relative
+    return Path(relative)
 
 
 def _optional_str(value: Any) -> str | None:

--- a/weaver/types/payload_ref.py
+++ b/weaver/types/payload_ref.py
@@ -1,0 +1,171 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic large-payload reference helpers.
+
+Payload refs are an SDK-facing envelope for values that are too large or too
+expensive to move inline through Weaver HTTP responses. The storage location is
+treated as implementation detail by normal SDK flows; callers only need these
+helpers when they explicitly want to inspect the referenced bytes/content.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from pathlib import Path
+from typing import Any, Mapping
+
+
+@dataclass(slots=True)
+class PayloadRef:
+    """Reference to a large payload stored outside the HTTP response body."""
+
+    storage: str
+    format: str
+    schema: str | None = None
+    size_bytes: int | None = None
+    relative_path: str | None = None
+    path: str | None = None
+    dtype: str | None = None
+    metadata: dict[str, Any] = dataclass_field(default_factory=dict)
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "PayloadRef":
+        known = {
+            "storage",
+            "format",
+            "schema",
+            "size_bytes",
+            "relative_path",
+            "path",
+            "dtype",
+        }
+        metadata = {key: value for key, value in payload.items() if key not in known}
+        return cls(
+            storage=str(payload.get("storage", "")),
+            format=str(payload.get("format", "")),
+            schema=_optional_str(payload.get("schema")),
+            size_bytes=_optional_int(payload.get("size_bytes")),
+            relative_path=_optional_str(payload.get("relative_path")),
+            path=_optional_str(payload.get("path")),
+            dtype=_optional_str(payload.get("dtype")),
+            metadata=metadata,
+        )
+
+    def to_payload(self, *, include_private: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "storage": self.storage,
+            "format": self.format,
+        }
+        if self.schema is not None:
+            payload["schema"] = self.schema
+        if self.size_bytes is not None:
+            payload["size_bytes"] = self.size_bytes
+        if self.relative_path is not None:
+            payload["relative_path"] = self.relative_path
+        if include_private and self.path is not None:
+            payload["path"] = self.path
+        if self.dtype is not None:
+            payload["dtype"] = self.dtype
+        payload.update(self.metadata)
+        return payload
+
+
+class PayloadRefMaterializationError(RuntimeError):
+    """Raised when a payload ref cannot be materialized by this SDK process."""
+
+
+def materialize_payload_ref(
+    ref: PayloadRef | Mapping[str, Any],
+    *,
+    field: str | None = None,
+) -> Any:
+    """Load the content referenced by ``ref`` for explicit inspection.
+
+    The first implementation supports local/GPFS refs because R2 RECORD stores
+    top-k indices as ``torch.save`` files on a shared filesystem. S3 refs are
+    intentionally represented by the same schema, but should be resolved via a
+    server-backed resolver once that backend is wired in.
+    """
+
+    payload_ref = ref if isinstance(ref, PayloadRef) else PayloadRef.from_payload(ref)
+    storage = payload_ref.storage.lower()
+    if storage not in {"gpfs", "filesystem", "local"}:
+        raise PayloadRefMaterializationError(
+            f"Cannot materialize storage={payload_ref.storage!r} locally."
+        )
+
+    local_path = _resolve_local_ref_path(payload_ref)
+    if local_path is None:
+        raise PayloadRefMaterializationError("Payload ref does not include a readable path.")
+    if not local_path.exists():
+        raise PayloadRefMaterializationError(f"Payload ref path does not exist: {local_path}")
+
+    fmt = payload_ref.format.lower()
+    if fmt == "torch.save":
+        try:
+            import torch
+        except ImportError as exc:  # pragma: no cover - depends on optional torch install
+            raise PayloadRefMaterializationError(
+                "Materializing torch.save payload refs requires torch."
+            ) from exc
+        value = torch.load(local_path, map_location="cpu", weights_only=False)
+    elif fmt == "json":
+        value = json.loads(local_path.read_text(encoding="utf-8"))
+    else:
+        raise PayloadRefMaterializationError(
+            f"Unsupported payload ref format for local materialization: {payload_ref.format!r}"
+        )
+
+    if field is not None:
+        if not isinstance(value, Mapping) or field not in value:
+            raise PayloadRefMaterializationError(
+                f"Materialized payload does not contain field {field!r}."
+            )
+        return value[field]
+    return value
+
+
+def _resolve_local_ref_path(payload_ref: PayloadRef) -> Path | None:
+    """Resolve local/GPFS refs without requiring callers to handle storage paths."""
+
+    if payload_ref.path:
+        legacy_path = Path(payload_ref.path)
+        if legacy_path.exists():
+            return legacy_path
+    if payload_ref.relative_path:
+        relative = Path(payload_ref.relative_path)
+        if relative.is_absolute():
+            return relative
+        for env_key in ("WEAVER_PAYLOAD_REF_ROOT", "WEAVER_ROUTER_REPLAY_REF_ROOT"):
+            root = os.environ.get(env_key)
+            if root:
+                return Path(root) / relative
+        return relative
+    if payload_ref.path:
+        return Path(payload_ref.path)
+    return None
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)

--- a/weaver/types/router_replay.py
+++ b/weaver/types/router_replay.py
@@ -84,6 +84,7 @@ class RouterReplayMetadata:
     indices: RouterReplayIndices | Mapping[str, Any] | None = None
     fail_fast: bool = True
     action: str | None = None
+    sample_ref: str | None = None
     sample_index: int | None = None
     index_uri: str | None = None
     index_set_uri: str | None = None
@@ -97,20 +98,26 @@ class RouterReplayMetadata:
             "source": self.source,
             "fail_fast": self.fail_fast,
         }
+        if self.indices is not None:
+            raise ValueError(
+                "RouterReplayMetadata.indices is no longer SDK-visible. "
+                "Use opaque sample_ref/index_set_uri/manifest_uri refs."
+            )
         if self.sample_index is not None:
-            payload["sample_index"] = int(self.sample_index)
+            raise ValueError(
+                "RouterReplayMetadata.sample_index is no longer SDK-visible; "
+                "use sample_ref instead."
+            )
         if self.index_uri is not None:
-            payload["index_uri"] = self.index_uri
+            raise ValueError(
+                "RouterReplayMetadata.index_uri is no longer supported; use sample_ref instead."
+            )
+        if self.sample_ref is not None:
+            payload["sample_ref"] = self.sample_ref
         if self.index_set_uri is not None:
             payload["index_set_uri"] = self.index_set_uri
         if self.manifest_uri is not None:
             payload["manifest_uri"] = self.manifest_uri
-        if self.indices is not None:
-            payload["indices"] = (
-                self.indices.to_payload()
-                if isinstance(self.indices, RouterReplayIndices)
-                else dict(self.indices)
-            )
         if self.action is not None:
             payload["action"] = self.action
         return payload
@@ -119,7 +126,6 @@ class RouterReplayMetadata:
     def r2_record(
         cls,
         *,
-        sample_index: int | None = None,
         fail_fast: bool = True,
     ) -> "RouterReplayMetadata":
         """Build datum-level R2 RECORD metadata for ``forward`` recompute calls."""
@@ -130,27 +136,24 @@ class RouterReplayMetadata:
             indices=None,
             fail_fast=fail_fast,
             action="RECORD",
-            sample_index=sample_index,
         )
 
     @classmethod
     def r2_replay(
         cls,
-        indices: RouterReplayIndices | Mapping[str, Any],
         *,
-        sample_index: int | None = None,
-        index_uri: str | None = None,
-        index_set_uri: str | None = None,
-        manifest_uri: str | None = None,
+        sample_ref: str,
+        index_set_uri: str,
+        manifest_uri: str,
         fail_fast: bool = True,
     ) -> "RouterReplayMetadata":
         return cls(
             mode=ROUTER_REPLAY_MODE_R2,
             source=ROUTER_REPLAY_SOURCE_RECOMPUTE,
-            indices=indices,
+            indices=None,
             fail_fast=fail_fast,
-            sample_index=sample_index,
-            index_uri=index_uri,
+            action="REPLAY",
+            sample_ref=sample_ref,
             index_set_uri=index_set_uri,
             manifest_uri=manifest_uri,
         )
@@ -158,21 +161,19 @@ class RouterReplayMetadata:
     @classmethod
     def r3_replay(
         cls,
-        indices: RouterReplayIndices | Mapping[str, Any],
         *,
-        sample_index: int | None = None,
-        index_uri: str | None = None,
-        index_set_uri: str | None = None,
-        manifest_uri: str | None = None,
+        sample_ref: str,
+        index_set_uri: str,
+        manifest_uri: str,
         fail_fast: bool = True,
     ) -> "RouterReplayMetadata":
         return cls(
             mode=ROUTER_REPLAY_MODE_R3,
             source=ROUTER_REPLAY_SOURCE_ROLLOUT,
-            indices=indices,
+            indices=None,
             fail_fast=fail_fast,
-            sample_index=sample_index,
-            index_uri=index_uri,
+            action="REPLAY",
+            sample_ref=sample_ref,
             index_set_uri=index_set_uri,
             manifest_uri=manifest_uri,
         )
@@ -213,13 +214,19 @@ def _nested_list(value: Sequence[Any]) -> list[Any]:
     return result
 
 
-def materialize_router_replay_indices(envelope: Mapping[str, Any]) -> list[Any]:
+def materialize_router_replay_indices(
+    envelope: Mapping[str, Any],
+    *,
+    trusted: bool = False,
+) -> Any:
     """Materialize a router replay indices envelope into inspectable lists.
 
     Inline envelopes return their ``value`` directly. Sharded envelopes return
     per-sample values when ``sample_indices`` metadata is available, otherwise a
     concatenated token-level list.
     """
+    if not _trusted_router_replay_debug(trusted):
+        return _router_replay_ref_summary(envelope)
 
     value = envelope.get("value")
     if isinstance(value, list):
@@ -354,19 +361,76 @@ def router_replay_shard_uri(
     )
 
 
-def materialize_router_replay_index(uri_or_datum: Any) -> Any:
+def materialize_router_replay_index(
+    uri_or_datum: Any,
+    *,
+    trusted: bool = False,
+) -> Any:
     """Materialize router replay index content for explicit user inspection.
 
     Normal training flows should pass router replay refs opaquely. This helper is
-    for debugging: it can resolve a datum payload, a sample URI, a manifest URI,
-    a shard URI, or an inline indices envelope from a local/GPFS environment.
+    for debugging.  By default it returns only a ref summary; pass
+    ``trusted=True`` or set ``WEAVER_ROUTER_REPLAY_TRUSTED_MATERIALIZE=1`` from a
+    trainer/control-plane process to resolve manifests or shard tensors.
     """
 
+    allow_materialize = _trusted_router_replay_debug(trusted)
     if isinstance(uri_or_datum, Mapping):
+        if not allow_materialize:
+            return _router_replay_ref_summary(uri_or_datum)
         return _materialize_router_replay_mapping(uri_or_datum)
     if not isinstance(uri_or_datum, str):
         raise TypeError("Expected a weaver:// URI, datum mapping, or indices envelope.")
+    if not allow_materialize:
+        return _router_replay_uri_summary(uri_or_datum)
     return _materialize_router_replay_uri(uri_or_datum)
+
+
+def _trusted_router_replay_debug(trusted: bool) -> bool:
+    return trusted or os.environ.get("WEAVER_ROUTER_REPLAY_TRUSTED_MATERIALIZE") in (
+        "1",
+        "true",
+        "TRUE",
+        "yes",
+        "on",
+    )
+
+
+def _router_replay_ref_summary(value: Mapping[str, Any]) -> dict[str, Any]:
+    replay = value.get("router_replay")
+    if replay is None and isinstance(value.get("metadata"), Mapping):
+        replay = value["metadata"].get("router_replay")
+    if isinstance(replay, Mapping):
+        value = replay
+    return {
+        "kind": "router_replay_ref",
+        "materialized": False,
+        "mode": value.get("mode"),
+        "source": value.get("source"),
+        "action": value.get("action"),
+        "sample_ref": value.get("sample_ref"),
+        "index_set_uri": value.get("index_set_uri") or value.get("uri"),
+        "manifest_uri": value.get("manifest_uri"),
+        "has_internal_indices": isinstance(value.get("indices"), Mapping),
+        "has_internal_shards": isinstance(value.get("shards"), (list, tuple)),
+    }
+
+
+def _router_replay_uri_summary(uri: str) -> dict[str, Any]:
+    if not uri.startswith("weaver://"):
+        raise ValueError(f"Unsupported router replay URI: {uri!r}")
+    kind = "index_set"
+    if uri.endswith("/manifest.json"):
+        kind = "manifest"
+    elif "/samples/" in uri:
+        kind = "sample"
+    elif "/shards/" in uri:
+        kind = "shard"
+    return {
+        "kind": f"router_replay_{kind}_ref",
+        "materialized": False,
+        "uri": uri,
+    }
 
 
 def _materialize_router_replay_mapping(uri_or_datum: Mapping[str, Any]) -> Any:
@@ -378,22 +442,22 @@ def _materialize_router_replay_mapping(uri_or_datum: Mapping[str, Any]) -> Any:
         if result is not None:
             return result
     if uri_or_datum.get("value") is not None or uri_or_datum.get("shards") is not None:
-        return materialize_router_replay_indices(uri_or_datum)
+        return materialize_router_replay_indices(uri_or_datum, trusted=True)
     raise ValueError("Mapping does not contain router replay metadata or indices.")
 
 
 def _materialize_router_replay_payload(replay: Mapping[str, Any]) -> Any | None:
     indices = replay.get("indices")
     if isinstance(indices, Mapping) and indices.get("value") is not None:
-        return materialize_router_replay_indices(indices)
-    sample_index = replay.get("sample_index")
+        raise ValueError("Inline router_replay.indices.value payloads are no longer supported.")
+    if replay.get("sample_index") is not None or replay.get("index_uri") is not None:
+        raise ValueError("sample_index/index_uri are no longer supported; use sample_ref.")
+    sample_ref = replay.get("sample_ref")
     manifest_uri = replay.get("manifest_uri")
-    if isinstance(manifest_uri, str) and sample_index is not None:
+    if isinstance(manifest_uri, str) and isinstance(sample_ref, str):
+        _, sample = sample_ref.rsplit("/samples/", 1)
         manifest = _load_manifest_from_uri(manifest_uri)
-        return _materialize_sample_from_manifest(manifest, int(sample_index))
-    index_uri = replay.get("index_uri")
-    if isinstance(index_uri, str):
-        return _materialize_router_replay_uri(index_uri)
+        return _materialize_sample_from_manifest(manifest, int(sample.strip("/")))
     return None
 
 
@@ -457,7 +521,7 @@ def _materialize_sample_from_manifest(
         }
     )
     if sample_index in sample_order:
-        values = materialize_router_replay_indices(envelope)
+        values = materialize_router_replay_indices(envelope, trusted=True)
         if values:
             return values[sample_order.index(sample_index)]
     for shard in shards:
@@ -466,7 +530,7 @@ def _materialize_sample_from_manifest(
         sample_indices = shard.get("sample_indices")
         if not isinstance(sample_indices, list) or sample_index not in sample_indices:
             continue
-        values = materialize_router_replay_indices({"shards": [shard]})
+        values = materialize_router_replay_indices({"shards": [shard]}, trusted=True)
         sample_order = sorted({int(item) for item in sample_indices})
         if values and sample_index in sample_order:
             return values[sample_order.index(sample_index)]

--- a/weaver/types/router_replay.py
+++ b/weaver/types/router_replay.py
@@ -36,8 +36,8 @@ ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED: RouterReplayTokenAlignment = "targ
 class RouterReplayIndices:
     """Token-layer-topk router replay indices payload.
 
-    RFC-0001: This is the normalized, backend-neutral contract used by the SDK
-    and downstream trainer metadata.
+    This is the normalized, backend-neutral contract used by the SDK and
+    downstream trainer metadata.
     """
 
     value: Sequence[Sequence[Sequence[int]]]
@@ -60,7 +60,7 @@ class RouterReplayIndices:
 class RouterReplayMetadata:
     """Training-side router replay metadata envelope.
 
-    RFC-0001: Training requests carry this object at top-level metadata, not in
+    Training requests carry this object at top-level metadata, not in
     loss_fn_inputs, so the replay execution context stays separate from loss data.
     """
 
@@ -82,7 +82,7 @@ class RouterReplayMetadata:
 class RouterReplayModelConfig:
     """Model-registration router replay toggle.
 
-    RFC-0001: This mirrors supported-models.config.router_replay and keeps the
+    This mirrors supported-models.config.router_replay and keeps the
     enable/mode/shape contract explicit for clients that introspect model config.
     """
 

--- a/weaver/types/router_replay.py
+++ b/weaver/types/router_replay.py
@@ -16,7 +16,10 @@
 
 from __future__ import annotations
 
+import json
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from .payload_ref import materialize_payload_ref
@@ -32,6 +35,8 @@ ROUTER_REPLAY_SOURCE_RECOMPUTE: RouterReplaySource = "recompute"
 ROUTER_REPLAY_SOURCE_ROLLOUT: RouterReplaySource = "rollout"
 ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK: RouterReplayFormat = "token_layer_topk"
 ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED: RouterReplayTokenAlignment = "target_aligned"
+ROUTER_REPLAY_DATUM_SCHEMA = "weaver.router_replay.datum.v1"
+ROUTER_REPLAY_INDEX_SET_SCHEMA = "weaver.router_replay.index_set.v1"
 
 
 @dataclass(slots=True)
@@ -68,10 +73,10 @@ class RouterReplayIndices:
 
 @dataclass(slots=True)
 class RouterReplayMetadata:
-    """Training-side router replay metadata envelope.
+    """Datum-level router replay metadata envelope.
 
-    Training requests carry this object at top-level metadata, not in
-    loss_fn_inputs, so the replay execution context stays separate from loss data.
+    Training requests carry this object in ``Datum.metadata["router_replay"]``.
+    Batch-level router replay metadata is intentionally no longer canonical.
     """
 
     mode: RouterReplayMode
@@ -79,13 +84,27 @@ class RouterReplayMetadata:
     indices: RouterReplayIndices | Mapping[str, Any] | None = None
     fail_fast: bool = True
     action: str | None = None
+    sample_index: int | None = None
+    index_uri: str | None = None
+    index_set_uri: str | None = None
+    manifest_uri: str | None = None
+    schema: str = ROUTER_REPLAY_DATUM_SCHEMA
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {
+            "schema": self.schema,
             "mode": self.mode,
             "source": self.source,
             "fail_fast": self.fail_fast,
         }
+        if self.sample_index is not None:
+            payload["sample_index"] = int(self.sample_index)
+        if self.index_uri is not None:
+            payload["index_uri"] = self.index_uri
+        if self.index_set_uri is not None:
+            payload["index_set_uri"] = self.index_set_uri
+        if self.manifest_uri is not None:
+            payload["manifest_uri"] = self.manifest_uri
         if self.indices is not None:
             payload["indices"] = (
                 self.indices.to_payload()
@@ -97,8 +116,13 @@ class RouterReplayMetadata:
         return payload
 
     @classmethod
-    def r2_record(cls, *, fail_fast: bool = True) -> "RouterReplayMetadata":
-        """Build per-call R2 RECORD metadata for ``forward`` recompute calls."""
+    def r2_record(
+        cls,
+        *,
+        sample_index: int | None = None,
+        fail_fast: bool = True,
+    ) -> "RouterReplayMetadata":
+        """Build datum-level R2 RECORD metadata for ``forward`` recompute calls."""
 
         return cls(
             mode=ROUTER_REPLAY_MODE_R2,
@@ -106,6 +130,7 @@ class RouterReplayMetadata:
             indices=None,
             fail_fast=fail_fast,
             action="RECORD",
+            sample_index=sample_index,
         )
 
     @classmethod
@@ -113,6 +138,10 @@ class RouterReplayMetadata:
         cls,
         indices: RouterReplayIndices | Mapping[str, Any],
         *,
+        sample_index: int | None = None,
+        index_uri: str | None = None,
+        index_set_uri: str | None = None,
+        manifest_uri: str | None = None,
         fail_fast: bool = True,
     ) -> "RouterReplayMetadata":
         return cls(
@@ -120,6 +149,10 @@ class RouterReplayMetadata:
             source=ROUTER_REPLAY_SOURCE_RECOMPUTE,
             indices=indices,
             fail_fast=fail_fast,
+            sample_index=sample_index,
+            index_uri=index_uri,
+            index_set_uri=index_set_uri,
+            manifest_uri=manifest_uri,
         )
 
     @classmethod
@@ -127,6 +160,10 @@ class RouterReplayMetadata:
         cls,
         indices: RouterReplayIndices | Mapping[str, Any],
         *,
+        sample_index: int | None = None,
+        index_uri: str | None = None,
+        index_set_uri: str | None = None,
+        manifest_uri: str | None = None,
         fail_fast: bool = True,
     ) -> "RouterReplayMetadata":
         return cls(
@@ -134,6 +171,10 @@ class RouterReplayMetadata:
             source=ROUTER_REPLAY_SOURCE_ROLLOUT,
             indices=indices,
             fail_fast=fail_fast,
+            sample_index=sample_index,
+            index_uri=index_uri,
+            index_set_uri=index_set_uri,
+            manifest_uri=manifest_uri,
         )
 
 
@@ -207,7 +248,14 @@ def materialize_router_replay_indices(envelope: Mapping[str, Any]) -> list[Any]:
         if isinstance(sample_indices, list) and tokens_per_sample > 0:
             saw_sample_layout = True
             pp_rank = int(shard.get("pp_rank") or 0)
-            for offset, sample_idx in enumerate(sample_indices):
+            sample_rows = _split_shard_rows_by_sample(
+                shard_value=shard_value,
+                sample_indices=[int(item) for item in sample_indices],
+                tokens_per_sample=tokens_per_sample,
+                row_layout=str(shard.get("row_layout") or ""),
+                microbatch_sizes=shard.get("microbatch_sizes"),
+            )
+            for sample_idx, rows in sample_rows.items():
                 sample_idx = int(sample_idx)
                 sample_pp_key = (sample_idx, pp_rank)
                 if sample_pp_key in seen_sample_pp:
@@ -215,9 +263,7 @@ def materialize_router_replay_indices(envelope: Mapping[str, Any]) -> list[Any]:
                     # inspection purposes; one TP copy per PP stage is enough.
                     continue
                 seen_sample_pp.add(sample_pp_key)
-                start = offset * tokens_per_sample
-                end = start + tokens_per_sample
-                per_sample_parts.setdefault(sample_idx, {})[pp_rank] = shard_value[start:end]
+                per_sample_parts.setdefault(sample_idx, {})[pp_rank] = rows
         else:
             concatenated.extend(shard_value)
 
@@ -238,3 +284,195 @@ def materialize_router_replay_indices(envelope: Mapping[str, Any]) -> list[Any]:
             materialized.append(sample_tokens)
         return materialized
     return concatenated
+
+
+def _split_shard_rows_by_sample(
+    *,
+    shard_value: list[Any],
+    sample_indices: list[int],
+    tokens_per_sample: int,
+    row_layout: str,
+    microbatch_sizes: Any,
+) -> dict[int, list[Any]]:
+    if row_layout != "seq_major_microbatch":
+        return {
+            int(sample_idx): shard_value[
+                offset * tokens_per_sample : (offset + 1) * tokens_per_sample
+            ]
+            for offset, sample_idx in enumerate(sample_indices)
+            if (offset + 1) * tokens_per_sample <= len(shard_value)
+        }
+
+    if isinstance(microbatch_sizes, list) and microbatch_sizes:
+        mb_sizes = [int(item) for item in microbatch_sizes]
+    else:
+        mb_sizes = [len(sample_indices)]
+    if sum(mb_sizes) != len(sample_indices):
+        return {}
+
+    per_sample: dict[int, list[Any]] = {}
+    sample_offset = 0
+    row_base = 0
+    for mb_size in mb_sizes:
+        mb_samples = sample_indices[sample_offset : sample_offset + mb_size]
+        for pos, sample_idx in enumerate(mb_samples):
+            rows: list[Any] = []
+            for token_idx in range(tokens_per_sample):
+                row_idx = row_base + token_idx * mb_size + pos
+                if row_idx < len(shard_value):
+                    rows.append(shard_value[row_idx])
+            if rows:
+                per_sample[int(sample_idx)] = rows
+        sample_offset += mb_size
+        row_base += mb_size * tokens_per_sample
+    return per_sample
+
+
+def router_replay_set_uri(model_id: str, replay_set_id: str) -> str:
+    return f"weaver://{model_id}/router-replay/{replay_set_id}"
+
+
+def router_replay_manifest_uri(model_id: str, replay_set_id: str) -> str:
+    return f"{router_replay_set_uri(model_id, replay_set_id)}/manifest.json"
+
+
+def router_replay_sample_uri(model_id: str, replay_set_id: str, sample_index: int) -> str:
+    return f"{router_replay_set_uri(model_id, replay_set_id)}/samples/{int(sample_index)}"
+
+
+def router_replay_shard_uri(
+    model_id: str,
+    replay_set_id: str,
+    *,
+    dp_rank: int,
+    tp_rank: int,
+    pp_rank: int,
+) -> str:
+    return (
+        f"{router_replay_set_uri(model_id, replay_set_id)}/shards/"
+        f"dp{int(dp_rank)}-tp{int(tp_rank)}-pp{int(pp_rank)}.pt"
+    )
+
+
+def materialize_router_replay_index(uri_or_datum: Any) -> Any:
+    """Materialize router replay index content for explicit user inspection.
+
+    Normal training flows should pass router replay refs opaquely. This helper is
+    for debugging: it can resolve a datum payload, a sample URI, a manifest URI,
+    a shard URI, or an inline indices envelope from a local/GPFS environment.
+    """
+
+    if isinstance(uri_or_datum, Mapping):
+        return _materialize_router_replay_mapping(uri_or_datum)
+    if not isinstance(uri_or_datum, str):
+        raise TypeError("Expected a weaver:// URI, datum mapping, or indices envelope.")
+    return _materialize_router_replay_uri(uri_or_datum)
+
+
+def _materialize_router_replay_mapping(uri_or_datum: Mapping[str, Any]) -> Any:
+    replay = uri_or_datum.get("router_replay")
+    if replay is None and isinstance(uri_or_datum.get("metadata"), Mapping):
+        replay = uri_or_datum["metadata"].get("router_replay")
+    if isinstance(replay, Mapping):
+        result = _materialize_router_replay_payload(replay)
+        if result is not None:
+            return result
+    if uri_or_datum.get("value") is not None or uri_or_datum.get("shards") is not None:
+        return materialize_router_replay_indices(uri_or_datum)
+    raise ValueError("Mapping does not contain router replay metadata or indices.")
+
+
+def _materialize_router_replay_payload(replay: Mapping[str, Any]) -> Any | None:
+    indices = replay.get("indices")
+    if isinstance(indices, Mapping) and indices.get("value") is not None:
+        return materialize_router_replay_indices(indices)
+    sample_index = replay.get("sample_index")
+    manifest_uri = replay.get("manifest_uri")
+    if isinstance(manifest_uri, str) and sample_index is not None:
+        manifest = _load_manifest_from_uri(manifest_uri)
+        return _materialize_sample_from_manifest(manifest, int(sample_index))
+    index_uri = replay.get("index_uri")
+    if isinstance(index_uri, str):
+        return _materialize_router_replay_uri(index_uri)
+    return None
+
+
+def _materialize_router_replay_uri(uri: str) -> Any:
+    if not uri.startswith("weaver://"):
+        raise ValueError(f"Unsupported router replay URI: {uri!r}")
+    if uri.endswith("/manifest.json"):
+        return _load_manifest_from_uri(uri)
+    if "/samples/" in uri:
+        prefix, sample = uri.rsplit("/samples/", 1)
+        manifest = _load_manifest_from_uri(f"{prefix}/manifest.json")
+        return _materialize_sample_from_manifest(manifest, int(sample.strip("/")))
+    if "/shards/" in uri:
+        path = _resolve_weaver_uri_path(uri)
+        if path.suffix == ".pt":
+            return materialize_payload_ref({"storage": "gpfs", "format": "torch.save", "uri": uri})
+        return json.loads(path.read_text(encoding="utf-8"))
+    raise ValueError(f"Unsupported router replay URI kind: {uri!r}")
+
+
+def _load_manifest_from_uri(uri: str) -> Mapping[str, Any]:
+    path = _resolve_weaver_uri_path(uri)
+    if not path.exists():
+        raise FileNotFoundError(f"Router replay manifest does not exist: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_weaver_uri_path(uri: str) -> Path:
+    relative = uri.removeprefix("weaver://").lstrip("/")
+    if not relative:
+        raise ValueError("weaver:// URI must include a relative component.")
+    for env_key in ("WEAVER_PAYLOAD_REF_ROOT", "WEAVER_ROUTER_REPLAY_REF_ROOT"):
+        root = os.environ.get(env_key)
+        if root:
+            return Path(root) / relative
+    return Path(relative)
+
+
+def _materialize_sample_from_manifest(
+    manifest: Mapping[str, Any],
+    sample_index: int,
+) -> list[Any]:
+    raw_shards = manifest.get("shards", [])
+    shards = raw_shards if isinstance(raw_shards, list) else []
+    envelope = {
+        "format": manifest.get("format", ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK),
+        "token_alignment": manifest.get(
+            "token_alignment", ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED
+        ),
+        "num_layers": manifest.get("num_layers"),
+        "topk": manifest.get("topk"),
+        "transport": manifest.get("transport"),
+        "shards": shards,
+    }
+    sample_order = sorted(
+        {
+            int(sample_idx)
+            for shard in shards
+            if isinstance(shard, Mapping)
+            for sample_idx in _sample_indices_from_shard(shard)
+        }
+    )
+    if sample_index in sample_order:
+        values = materialize_router_replay_indices(envelope)
+        if values:
+            return values[sample_order.index(sample_index)]
+    for shard in shards:
+        if not isinstance(shard, Mapping):
+            continue
+        sample_indices = shard.get("sample_indices")
+        if not isinstance(sample_indices, list) or sample_index not in sample_indices:
+            continue
+        values = materialize_router_replay_indices({"shards": [shard]})
+        sample_order = sorted({int(item) for item in sample_indices})
+        if values and sample_index in sample_order:
+            return values[sample_order.index(sample_index)]
+    return []
+
+
+def _sample_indices_from_shard(shard: Mapping[str, Any]) -> list[Any]:
+    sample_indices = shard.get("sample_indices")
+    return sample_indices if isinstance(sample_indices, list) else []

--- a/weaver/types/router_replay.py
+++ b/weaver/types/router_replay.py
@@ -17,7 +17,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
+
+from .payload_ref import materialize_payload_ref
 
 RouterReplayMode = str
 RouterReplaySource = str
@@ -40,20 +42,28 @@ class RouterReplayIndices:
     downstream trainer metadata.
     """
 
-    value: Sequence[Sequence[Sequence[int]]]
     num_layers: int
     topk: int
+    value: Sequence[Sequence[Sequence[int]]] | None = None
     format: RouterReplayFormat = ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK
     token_alignment: RouterReplayTokenAlignment = ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED
+    shards: Sequence[Mapping[str, Any]] | None = None
+    transport: str | None = None
 
     def to_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "format": self.format,
-            "value": _nested_list(self.value),
             "token_alignment": self.token_alignment,
             "num_layers": self.num_layers,
             "topk": self.topk,
         }
+        if self.value is not None:
+            payload["value"] = _nested_list(self.value)
+        if self.shards is not None:
+            payload["shards"] = [dict(shard) for shard in self.shards]
+        if self.transport is not None:
+            payload["transport"] = self.transport
+        return payload
 
 
 @dataclass(slots=True)
@@ -66,16 +76,65 @@ class RouterReplayMetadata:
 
     mode: RouterReplayMode
     source: RouterReplaySource
-    indices: RouterReplayIndices
+    indices: RouterReplayIndices | Mapping[str, Any] | None = None
     fail_fast: bool = True
+    action: str | None = None
 
     def to_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "mode": self.mode,
             "source": self.source,
-            "indices": self.indices.to_payload(),
             "fail_fast": self.fail_fast,
         }
+        if self.indices is not None:
+            payload["indices"] = (
+                self.indices.to_payload()
+                if isinstance(self.indices, RouterReplayIndices)
+                else dict(self.indices)
+            )
+        if self.action is not None:
+            payload["action"] = self.action
+        return payload
+
+    @classmethod
+    def r2_record(cls, *, fail_fast: bool = True) -> "RouterReplayMetadata":
+        """Build per-call R2 RECORD metadata for ``forward`` recompute calls."""
+
+        return cls(
+            mode=ROUTER_REPLAY_MODE_R2,
+            source=ROUTER_REPLAY_SOURCE_RECOMPUTE,
+            indices=None,
+            fail_fast=fail_fast,
+            action="RECORD",
+        )
+
+    @classmethod
+    def r2_replay(
+        cls,
+        indices: RouterReplayIndices | Mapping[str, Any],
+        *,
+        fail_fast: bool = True,
+    ) -> "RouterReplayMetadata":
+        return cls(
+            mode=ROUTER_REPLAY_MODE_R2,
+            source=ROUTER_REPLAY_SOURCE_RECOMPUTE,
+            indices=indices,
+            fail_fast=fail_fast,
+        )
+
+    @classmethod
+    def r3_replay(
+        cls,
+        indices: RouterReplayIndices | Mapping[str, Any],
+        *,
+        fail_fast: bool = True,
+    ) -> "RouterReplayMetadata":
+        return cls(
+            mode=ROUTER_REPLAY_MODE_R3,
+            source=ROUTER_REPLAY_SOURCE_ROLLOUT,
+            indices=indices,
+            fail_fast=fail_fast,
+        )
 
 
 @dataclass(slots=True)
@@ -111,3 +170,71 @@ def _nested_list(value: Sequence[Any]) -> list[Any]:
         else:
             result.append(item)
     return result
+
+
+def materialize_router_replay_indices(envelope: Mapping[str, Any]) -> list[Any]:
+    """Materialize a router replay indices envelope into inspectable lists.
+
+    Inline envelopes return their ``value`` directly. Sharded envelopes return
+    per-sample values when ``sample_indices`` metadata is available, otherwise a
+    concatenated token-level list.
+    """
+
+    value = envelope.get("value")
+    if isinstance(value, list):
+        return value
+
+    shards = envelope.get("shards")
+    if not isinstance(shards, (list, tuple)):
+        return []
+
+    per_sample_parts: dict[int, dict[int, list[Any]]] = {}
+    concatenated: list[Any] = []
+    saw_sample_layout = False
+    seen_sample_pp: set[tuple[int, int]] = set()
+    for shard in shards:
+        if not isinstance(shard, Mapping):
+            continue
+        shard_value = shard.get("value")
+        if shard_value is None and isinstance(shard.get("value_ref"), Mapping):
+            shard_value = materialize_payload_ref(shard["value_ref"], field="indices")
+            if hasattr(shard_value, "tolist"):
+                shard_value = shard_value.tolist()
+        if not isinstance(shard_value, list):
+            continue
+        sample_indices = shard.get("sample_indices")
+        tokens_per_sample = int(shard.get("local_tokens_per_sample") or 0)
+        if isinstance(sample_indices, list) and tokens_per_sample > 0:
+            saw_sample_layout = True
+            pp_rank = int(shard.get("pp_rank") or 0)
+            for offset, sample_idx in enumerate(sample_indices):
+                sample_idx = int(sample_idx)
+                sample_pp_key = (sample_idx, pp_rank)
+                if sample_pp_key in seen_sample_pp:
+                    # TP shards carry duplicate user-visible token/layer rows for
+                    # inspection purposes; one TP copy per PP stage is enough.
+                    continue
+                seen_sample_pp.add(sample_pp_key)
+                start = offset * tokens_per_sample
+                end = start + tokens_per_sample
+                per_sample_parts.setdefault(sample_idx, {})[pp_rank] = shard_value[start:end]
+        else:
+            concatenated.extend(shard_value)
+
+    if saw_sample_layout:
+        materialized: list[Any] = []
+        for sample_idx in sorted(per_sample_parts):
+            pp_parts = per_sample_parts[sample_idx]
+            if not pp_parts:
+                continue
+            ordered_parts = [pp_parts[pp_rank] for pp_rank in sorted(pp_parts)]
+            sample_tokens = ordered_parts[0]
+            for extra_part in ordered_parts[1:]:
+                sample_tokens = [
+                    list(token_layers) + list(extra_part[token_idx])
+                    for token_idx, token_layers in enumerate(sample_tokens)
+                    if token_idx < len(extra_part)
+                ]
+            materialized.append(sample_tokens)
+        return materialized
+    return concatenated

--- a/weaver/types/router_replay.py
+++ b/weaver/types/router_replay.py
@@ -70,14 +70,12 @@ class RouterReplayMetadata:
     fail_fast: bool = True
 
     def to_payload(self) -> dict[str, object]:
-        payload: dict[str, object] = {
+        return {
             "mode": self.mode,
             "source": self.source,
             "indices": self.indices.to_payload(),
+            "fail_fast": self.fail_fast,
         }
-        if self.fail_fast:
-            payload["fail_fast"] = True
-        return payload
 
 
 @dataclass(slots=True)
@@ -95,15 +93,13 @@ class RouterReplayModelConfig:
     fail_fast: bool = True
 
     def to_payload(self) -> dict[str, object]:
-        payload: dict[str, object] = {"enabled": self.enabled}
+        payload: dict[str, object] = {"enabled": self.enabled, "fail_fast": self.fail_fast}
         if self.mode is not None:
             payload["mode"] = self.mode
         if self.num_layers is not None:
             payload["num_layers"] = self.num_layers
         if self.topk is not None:
             payload["topk"] = self.topk
-        if self.fail_fast:
-            payload["fail_fast"] = True
         return payload
 
 

--- a/weaver/types/router_replay.py
+++ b/weaver/types/router_replay.py
@@ -1,0 +1,117 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Router Replay contract types shared across Weaver clients."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+RouterReplayMode = str
+RouterReplaySource = str
+RouterReplayFormat = str
+RouterReplayTokenAlignment = str
+
+ROUTER_REPLAY_MODE_R2: RouterReplayMode = "R2"
+ROUTER_REPLAY_MODE_R3: RouterReplayMode = "R3"
+ROUTER_REPLAY_SOURCE_RECOMPUTE: RouterReplaySource = "recompute"
+ROUTER_REPLAY_SOURCE_ROLLOUT: RouterReplaySource = "rollout"
+ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK: RouterReplayFormat = "token_layer_topk"
+ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED: RouterReplayTokenAlignment = "target_aligned"
+
+
+@dataclass(slots=True)
+class RouterReplayIndices:
+    """Token-layer-topk router replay indices payload.
+
+    RFC-0001: This is the normalized, backend-neutral contract used by the SDK
+    and downstream trainer metadata.
+    """
+
+    value: Sequence[Sequence[Sequence[int]]]
+    num_layers: int
+    topk: int
+    format: RouterReplayFormat = ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK
+    token_alignment: RouterReplayTokenAlignment = ROUTER_REPLAY_TOKEN_ALIGNMENT_TARGET_ALIGNED
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "format": self.format,
+            "value": _nested_list(self.value),
+            "token_alignment": self.token_alignment,
+            "num_layers": self.num_layers,
+            "topk": self.topk,
+        }
+
+
+@dataclass(slots=True)
+class RouterReplayMetadata:
+    """Training-side router replay metadata envelope.
+
+    RFC-0001: Training requests carry this object at top-level metadata, not in
+    loss_fn_inputs, so the replay execution context stays separate from loss data.
+    """
+
+    mode: RouterReplayMode
+    source: RouterReplaySource
+    indices: RouterReplayIndices
+    fail_fast: bool = True
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "mode": self.mode,
+            "source": self.source,
+            "indices": self.indices.to_payload(),
+        }
+        if self.fail_fast:
+            payload["fail_fast"] = True
+        return payload
+
+
+@dataclass(slots=True)
+class RouterReplayModelConfig:
+    """Model-registration router replay toggle.
+
+    RFC-0001: This mirrors supported-models.config.router_replay and keeps the
+    enable/mode/shape contract explicit for clients that introspect model config.
+    """
+
+    enabled: bool
+    mode: RouterReplayMode | None = None
+    num_layers: int | None = None
+    topk: int | None = None
+    fail_fast: bool = True
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"enabled": self.enabled}
+        if self.mode is not None:
+            payload["mode"] = self.mode
+        if self.num_layers is not None:
+            payload["num_layers"] = self.num_layers
+        if self.topk is not None:
+            payload["topk"] = self.topk
+        if self.fail_fast:
+            payload["fail_fast"] = True
+        return payload
+
+
+def _nested_list(value: Sequence[Any]) -> list[Any]:
+    result: list[Any] = []
+    for item in value:
+        if isinstance(item, (list, tuple)):
+            result.append(_nested_list(item))
+        else:
+            result.append(item)
+    return result


### PR DESCRIPTION
## Summary

One-line summary: Add datum-level Router Replay metadata contracts with opaque payload references, training metadata passthrough, and MoE top-k index preservation in sampling responses.

Related Issue: N/A

Related design: RFC-0001 Weaver RL Router Replay training loop

## Changes

- Add Router Replay SDK contract types and exports, including `RouterReplayIndices`, `RouterReplayMetadata`, `RouterReplayModelConfig`, schema constants, URI builders, and materialization helpers.
- Move Router Replay to a datum-level contract: callers attach `Datum.metadata["router_replay"]`, while request-level `router_replay` and `metadata["router_replay"]` are rejected with clear `ValueError`s.
- Use opaque replay references for SDK-visible Router Replay metadata via `sample_ref`, `index_set_uri`, and `manifest_uri`; inline SDK-visible indices, `sample_index`, and `index_uri` are rejected in the final metadata payload.
- Add generic `PayloadRef` helpers for large payload references, with local/GPFS/filesystem materialization for JSON and `torch.save` payloads when explicit inspection is required.
- Extend `Datum` serialization to preserve optional per-datum metadata without mixing it into `loss_fn_inputs`.
- Extend `TrainingClient.forward()` and `TrainingClient.forward_backward()` to pass generic top-level request metadata while keeping Router Replay metadata per datum.
- Extend `SamplingClient.sample()` with the top-level `return_moe_topk_indices` request flag and preserve non-null `moe_topk_indices` in normalized sequence results.
- Add focused unit tests for Router Replay types, payload refs, sampling MoE top-k indices, datum metadata serialization, and training metadata request behavior.

## Change Flow

```mermaid
flowchart TD
    A["SamplingClient.sample(return_moe_topk_indices=True)"] --> B["Sampling request body"]
    B --> C["Weaver sampling service"]
    C --> D["Response sequences with optional moe_topk_indices"]
    D --> E["SamplingClient._normalize_sample_result"]
    E --> F["Caller stores or receives Router Replay top-k refs"]

    F --> G["Caller builds Datum"]
    G --> H{"Datum metadata includes router_replay?"}
    H -- "Yes" --> I["Datum.metadata['router_replay'] uses schema v1 and opaque refs"]
    H -- "No" --> J["Regular training datum"]
    I --> K["TrainingClient.forward / forward_backward"]
    J --> K
    K --> L{"Request-level Router Replay metadata?"}
    L -- "Yes" --> M["Raise ValueError and require datum.metadata"]
    L -- "No" --> N["Serialize data plus optional generic request metadata"]
    N --> O["POST forward-passes or forward-backward-passes"]
    O --> P["Trainer consumes regular data or opaque Router Replay refs"]

    I --> Q{"Debug materialization requested?"}
    Q -- "Default" --> R["Return non-materialized ref summary"]
    Q -- "trusted=True or env enabled" --> S["Resolve manifest and shards through PayloadRef helpers"]
    S --> T{"Readable local/GPFS ref?"}
    T -- "Yes" --> U["Return inspectable indices"]
    T -- "No" --> V["Raise materialization error"]
```

Flow notes:

- Sampling requests only include `return_moe_topk_indices` when explicitly requested, and normalized results preserve `moe_topk_indices` only when the service returns a non-null value.
- Training requests keep generic request metadata at the top level, but Router Replay metadata is intentionally scoped to each `Datum`.
- `RouterReplayMetadata` builds `RECORD` and `REPLAY` payloads around opaque refs so normal SDK flows do not materialize large index payloads.
- Debug helpers return ref summaries by default; trusted materialization can resolve manifests and local/GPFS shard payloads, and surfaces load failures as explicit errors.

## Correctness Tests

- [x] Unit tests added or updated
- [x] Relevant unit tests executed

Test commands:

```bash
python -m pytest tests/test_router_replay_types.py tests/test_sampling_moe_topk_indices.py tests/test_training_metadata.py
git diff --check main...HEAD
```

Test results:

- `30 passed in 13.41s`
- `git diff --check main...HEAD` completed with no output.

## Performance Tests

- [x] No performance impact
- [ ] Performance testing completed
- [ ] Performance test document provided

Performance test document:

- N/A

Performance conclusion:

- This PR changes SDK request/response serialization and typed metadata helpers only. It does not change server-side compute, database access, caching, batching, concurrency, or rendering paths. Large Router Replay payloads remain opaque by default and are materialized only through explicit trusted debug helpers.

## Risks And Rollback

Risks:

- Callers using the earlier draft request-level Router Replay API must move Router Replay data to `Datum.metadata["router_replay"]` and use opaque refs instead of inline SDK-visible indices.
- Debug materialization depends on local/GPFS-readable refs and the `WEAVER_PAYLOAD_REF_ROOT` or `WEAVER_ROUTER_REPLAY_REF_ROOT` environment when relative or `weaver://` paths need resolution.
- `return_moe_topk_indices=True` can make sampling responses larger when the service returns router top-k indices, so callers should enable it only when needed for replay workflows.

Rollback:

- Revert this PR to restore the previous SDK payload shape.
- Until the revert is deployed, callers can avoid the new paths by not passing `return_moe_topk_indices` and not attaching `Datum.metadata["router_replay"]`.