### PR TITLE
fix: preserve loss mask for custom surrogate data

### DIFF
--- a/tests/test_temperature_payload.py
+++ b/tests/test_temperature_payload.py
@@ -80,9 +80,15 @@ def test_forward_backward_custom_uses_forward_and_reuses_loss_fn_config() -> Non
     client = _make_training_client()
     datum = Datum.from_raw(
         model_input=ModelInput.from_ints([1, 2]),
-        loss_fn_inputs={"target_tokens": [2]},
+        loss_fn_inputs={
+            "target_tokens": [2],
+            "loss_mask": [1],
+            "sampling_mask": [[2]],
+            "surrogate_weights": [99.0],
+        },
     )
     calls: list[dict[str, Any]] = []
+    surrogate_data: list[Datum] = []
 
     def fake_forward(
         self: TrainingClient,
@@ -106,6 +112,7 @@ def test_forward_backward_custom_uses_forward_and_reuses_loss_fn_config() -> Non
         wait: bool = True,
     ) -> dict[str, Any]:
         calls.append({"loss_fn": loss_fn, "loss_fn_config": loss_fn_config})
+        surrogate_data.extend(data)
         return {"result": {}}
 
     client.forward = MethodType(fake_forward, client)
@@ -120,6 +127,15 @@ def test_forward_backward_custom_uses_forward_and_reuses_loss_fn_config() -> Non
         {"loss_fn": "forward_logprob", "loss_fn_config": {"temperature": 0.7}},
         {"loss_fn": "surrogate", "loss_fn_config": {"temperature": 0.7}},
     ]
+    assert len(surrogate_data) == 1
+    assert torch.equal(surrogate_data[0].loss_fn_inputs["target_tokens"], torch.tensor([2]))
+    assert torch.equal(surrogate_data[0].loss_fn_inputs["loss_mask"], torch.tensor([1]))
+    assert torch.equal(surrogate_data[0].loss_fn_inputs["sampling_mask"], torch.tensor([[2]]))
+    assert torch.equal(
+        surrogate_data[0].loss_fn_inputs["surrogate_weights"],
+        torch.tensor([1.0]),
+    )
+    assert torch.equal(datum.loss_fn_inputs["surrogate_weights"], torch.tensor([99.0]))
 
 
 def test_logprobs_params_sends_loss_fn_config() -> None:

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -225,12 +225,12 @@ class TrainingClient:
 
             grad = logprob_tensor.grad
             assert grad is not None  # validated above
+            loss_fn_inputs: Dict[str, Any] = dict(datum.loss_fn_inputs)
+            loss_fn_inputs["target_tokens"] = resolved_targets
+            loss_fn_inputs["surrogate_weights"] = grad.detach().tolist()
             surrogate_datum = Datum.from_raw(
                 model_input=datum.model_input,
-                loss_fn_inputs={
-                    "target_tokens": resolved_targets,
-                    "surrogate_weights": grad.detach().tolist(),
-                },
+                loss_fn_inputs=loss_fn_inputs,
             )
             surrogate_data.append(surrogate_datum)
 


### PR DESCRIPTION
## Problem

The custom-loss path computes gradients with respect to logprobs locally, then sends a surrogate loss request to the trainer. During that conversion, the surrogate datum was rebuilt from a narrow allowlist of fields, which dropped alignment metadata from the original datum.

Dropping `loss_mask` meant the trainer-side surrogate loss did not necessarily operate on the same token set that the custom loss used when constructing `surrogate_weights`. For PPO/GRPO, this is a correctness issue because prompt tokens, padding, or otherwise masked positions must not affect the loss or its normalization. A narrow allowlist also risks dropping future target-aligned metadata needed by the surrogate path.

## Fix

- Build surrogate datums by copying the original datum's `loss_fn_inputs` and then overriding surrogate-specific fields.
- Preserve existing alignment metadata such as `loss_mask` and `sampling_mask` without mutating the caller's original datum.
- Add coverage that verifies preserved fields, overwritten stale `surrogate_weights`, and non-mutation of the source datum.

## Verification

- `python -m pytest tests/test_temperature_payload.py -q`
- `python -m compileall -q weaver/training_client.py tests/test_temperature_payload.py`
- Pre-commit hooks during amend: black, isort, license check, pylint, mypy