### PR TITLE
chore: bump version to v1.7.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.7.0.3"
+version = "1.7.0.4"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

- Bump nex-weaver package version from 1.7.0.3 to 1.7.0.4 after PR #77 merged.

## Verification

- `python -m compileall -q weaver`
- `python -m pytest tests/test_temperature_payload.py -q`
- `python -m build`