### PR TITLE
opd(blob): offload large training tensors off the HTTP path

### DIFF
--- a/tests/test_blob_store.py
+++ b/tests/test_blob_store.py
@@ -1,0 +1,178 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the offloaded-blob store (packing, offsets, read cache)."""
+
+import numpy as np
+import pytest
+import torch
+
+from weaver.blob_store import BlobStore
+
+
+def _store(monkeypatch, tmp_path, *, enabled=True):
+    monkeypatch.setenv("WEAVER_BLOB_OFFLOAD", "1" if enabled else "0")
+    monkeypatch.setenv("WEAVER_BLOB_ROOT", str(tmp_path))
+    return BlobStore()
+
+
+def test_offload_disabled_is_inert(monkeypatch, tmp_path):
+    store = _store(monkeypatch, tmp_path, enabled=False)
+    assert store.enabled is False
+
+
+def test_put_tensor_round_trips(monkeypatch, tmp_path):
+    store = _store(monkeypatch, tmp_path)
+    ref = store.put_tensor(
+        torch.tensor([1, 2, 3], dtype=torch.int64), model_id="m", seq_id=0, field="x"
+    )
+    assert "offset" not in ref["$blob"]  # standalone file, not a packed slice
+    out = store.get_array(ref)
+    assert out.dtype == np.int64
+    assert out.tolist() == [1, 2, 3]
+
+
+def test_pack_writes_one_file_with_offsets(monkeypatch, tmp_path):
+    store = _store(monkeypatch, tmp_path)
+    pack = store.open_pack(model_id="m", seq_id=7)
+    r_tokens = pack.put_tensor(torch.tensor([1, 2, 3, 4], dtype=torch.int64), field="d0_tokens")
+    r_target = pack.put_tensor(torch.tensor([2, 3, 4], dtype=torch.int64), field="d0_target")
+    r_weights = pack.put_tensor(torch.tensor([0.5, 0.25], dtype=torch.float32), field="d0_w")
+    pack.commit()
+
+    # All three references point at one file, distinguished by byte offset.
+    keys = {r["$blob"]["relative_path"] for r in (r_tokens, r_target, r_weights)}
+    assert len(keys) == 1
+    seq_dir = tmp_path / store.run / "m" / "seq-7"
+    assert [p.name for p in seq_dir.iterdir()] == ["pack.bin"]
+    assert r_tokens["$blob"]["offset"] == 0
+    assert r_target["$blob"]["offset"] == 4 * 8  # after four int64s
+    assert r_weights["$blob"]["offset"] == 4 * 8 + 3 * 8
+
+    # Mixed dtypes resolve back exactly from their slices.
+    assert store.get_array(r_tokens).tolist() == [1, 2, 3, 4]
+    assert store.get_array(r_target).tolist() == [2, 3, 4]
+    w = store.get_array(r_weights)
+    assert w.dtype == np.float32
+    assert np.array_equal(w, np.float32([0.5, 0.25]))
+
+
+def test_pack_read_uses_single_cached_read(monkeypatch, tmp_path):
+    store = _store(monkeypatch, tmp_path)
+    pack = store.open_pack(model_id="m", seq_id=1)
+    refs = [
+        pack.put_tensor(torch.tensor([i, i], dtype=torch.int64), field=f"d{i}") for i in range(5)
+    ]
+    pack.commit()
+
+    for i, ref in enumerate(refs):
+        assert store.get_array(ref).tolist() == [i, i]
+    # One packed file read once, then five slices served from the cache.
+    assert len(store._read_cache) == 1  # pylint: disable=protected-access
+
+
+def test_empty_pack_commit_writes_nothing(monkeypatch, tmp_path):
+    store = _store(monkeypatch, tmp_path)
+    pack = store.open_pack(model_id="m", seq_id=2)
+    pack.commit()  # must not raise or create a file
+    assert not (tmp_path / store.run / "m" / "seq-2").exists()
+
+
+def test_put_packed_round_trips_in_order(monkeypatch, tmp_path):
+    store = _store(monkeypatch, tmp_path)
+    arrays = [[-0.1, -0.2, -0.3], [-1.5, -2.5], [-9.9]]
+    ref = store.put_packed(arrays, model_id="m", field="lfo")
+    assert ref["$blob"]["splits"] == [3, 2, 1]  # order/lengths preserved
+    out = store.get_packed(ref)
+    assert len(out) == len(arrays)
+    for got, want in zip(out, arrays):
+        assert np.array_equal(got, np.float32(want))
+
+
+def test_get_packed_rejects_mismatched_splits(monkeypatch, tmp_path):
+    store = _store(monkeypatch, tmp_path)
+    ref = store.put_packed([[1.0, 2.0, 3.0], [4.0, 5.0]], model_id="m", field="f")
+    ref["$blob"]["splits"] = [3, 3]  # sums to 6, but the blob holds 5 floats
+    with pytest.raises(ValueError, match="splits sum"):
+        store.get_packed(ref)
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    ["../escape.bin", "/etc/hostname", "a/../../escape.bin", "a\\b.bin", "./x.bin", ""],
+)
+def test_get_array_rejects_path_traversal(monkeypatch, tmp_path, bad_path):
+    """A crafted $blob relative_path must not resolve outside the store root."""
+    store = _store(monkeypatch, tmp_path)
+    ref = {
+        "$blob": {
+            "storage": "filesystem",
+            "format": "raw-tensor",
+            "relative_path": bad_path,
+            "dtype": "int32",
+            "shape": [4],
+            "codec": "raw",
+            "size_bytes": 16,
+        }
+    }
+    with pytest.raises(ValueError, match="unsafe blob relative_path"):
+        store.get_array(ref)
+
+
+@pytest.mark.parametrize(
+    "wrap",
+    [
+        lambda p: {"loss_fn_outputs_packed": p},  # top level
+        lambda p: {"result": {"loss_fn_outputs_packed": p}},  # under result
+        lambda p: {  # nested per task under forward_task_results
+            "result": {"forward_task_results": {"t1": {"loss_fn_outputs_packed": p}}}
+        },
+    ],
+)
+def test_resolve_result_blobs_handles_all_shapes(monkeypatch, tmp_path, wrap):
+    """The leg-2 SDK resolver must restore loss_fn_outputs in every response
+    shape the consumer accepts (top level, under ``result``, or nested under
+    ``forward_task_results``)."""
+    import weaver.blob_store as blob_store
+    from weaver.operations import _resolve_result_blobs
+
+    monkeypatch.setenv("WEAVER_BLOB_OFFLOAD", "1")
+    monkeypatch.setenv("WEAVER_BLOB_ROOT", str(tmp_path))
+    blob_store.get_blob_store.cache_clear()
+    try:
+        store = blob_store.get_blob_store()
+        ref = store.put_packed([[-1.0, -2.0]], model_id="m", field="f")
+        packed = {
+            "ref": ref,
+            "field": "logprobs",
+            "siblings": [{"logprobs": {"dtype": "float32", "shape": [2]}}],
+            "count": 1,
+        }
+        resolved = _resolve_result_blobs(wrap(packed))
+
+        found = []
+
+        def walk(node):
+            if isinstance(node, dict):
+                if "loss_fn_outputs" in node and "loss_fn_outputs_packed" not in node:
+                    found.append(node["loss_fn_outputs"])
+                for value in node.values():
+                    walk(value)
+
+        walk(resolved)
+        assert found, "packed descriptor was not resolved"
+        data = found[0][0]["logprobs"]["data"]
+        assert np.array_equal(np.float32(data), np.float32([-1.0, -2.0]))
+    finally:
+        blob_store.get_blob_store.cache_clear()

--- a/weaver/blob_store.py
+++ b/weaver/blob_store.py
@@ -1,0 +1,486 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offload large tensor payloads off the HTTP path via a shared store.
+
+When ``WEAVER_BLOB_OFFLOAD`` is enabled, large dense tensor fields are written
+to a shared store rooted at ``WEAVER_BLOB_ROOT`` and the wire payload carries a
+small reference (``{"$blob": {...}}``) instead of the inline numbers. Both the
+producer (this SDK) and the consumer (the trainer, which imports this module)
+resolve the reference's relative ``key`` against their own ``WEAVER_BLOB_ROOT``
+— only the key crosses the wire, never an absolute path.
+
+Disabled by default: with the flag off, callers keep emitting inline payloads
+and this module is never touched, so the wire format is byte-identical.
+
+Config is read under either name: the SDK side reads ``WEAVER_BLOB_OFFLOAD`` /
+``WEAVER_BLOB_ROOT``; the auto-provisioned trainer receives the same settings
+through the orchestrator's ``WEAVER_TRAINER_*`` passthrough (which strips the
+prefix), so it reads ``TRAINER_BLOB_OFFLOAD`` / ``TRAINER_BLOB_ROOT``.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import secrets
+import threading
+import time
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+import numpy as np
+import torch
+
+from .types.payload_ref import PayloadRef
+
+logger = logging.getLogger(__name__)
+
+# Marker key identifying an offloaded-blob reference on the wire. Its value is a
+# ``PayloadRef`` (the SDK-wide large-payload envelope shared with router-replay):
+# ``{storage, format, relative_path, dtype, size_bytes}`` plus the tensor-specific
+# ``shape``/``codec``/``offset``/``splits`` carried in ``PayloadRef.metadata``.
+BLOB_KEY = "$blob"
+_CODEC = "raw"  # raw little-endian C-contiguous buffer
+_STORAGE = "filesystem"  # PayloadRef.storage (a shared POSIX mount)
+_FORMAT = "raw-tensor"  # PayloadRef.format (raw buffer, read via this store)
+
+# dtype name (shared with types.tensor) <-> numpy dtype.
+_NAME_TO_NUMPY: dict[str, np.dtype] = {
+    "int64": np.dtype("<i8"),
+    "int32": np.dtype("<i4"),
+    "float32": np.dtype("<f4"),
+    "float64": np.dtype("<f8"),
+}
+_TORCH_TO_NAME: dict[torch.dtype, str] = {
+    torch.int64: "int64",
+    torch.int32: "int32",
+    torch.float32: "float32",
+    torch.float64: "float64",
+}
+_NAME_TO_TORCH: dict[str, torch.dtype] = {n: d for d, n in _TORCH_TO_NAME.items()}
+
+
+def is_blob_ref(obj: Any) -> bool:
+    """True if ``obj`` is an offloaded-blob reference on the wire."""
+    return isinstance(obj, dict) and BLOB_KEY in obj
+
+
+def _truthy(value: Optional[str]) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _blob_env(suffix: str) -> Optional[str]:
+    """Read a blob config value under either accepted name.
+
+    The SDK process reads ``WEAVER_BLOB_<suffix>`` from its own environment.
+    The trainer receives the same config through the orchestrator's
+    ``WEAVER_TRAINER_*`` passthrough, which strips the prefix to
+    ``TRAINER_BLOB_<suffix>``. Both names resolve to the same setting so a
+    single value can be declared once on each side without renaming.
+    """
+    return os.getenv(f"WEAVER_BLOB_{suffix}") or os.getenv(f"TRAINER_BLOB_{suffix}")
+
+
+class BlobStore:
+    """Filesystem-backed store for offloaded tensors (POSIX/shared mount).
+
+    The concrete backend is a directory tree under ``WEAVER_BLOB_ROOT``; the
+    code never names it beyond that env var. Keys are relative paths of the
+    form ``<run>/<model_id>/seq-<seq_id>/<field>.bin``.
+    """
+
+    def __init__(self) -> None:
+        self._enabled = _truthy(_blob_env("OFFLOAD"))
+        root = _blob_env("ROOT")
+        self._root: Optional[Path] = Path(root) if root else None
+        # Keep the last K seq directories per model; older ones are GC'd.
+        # K must exceed the producer's max in-flight depth: ops are submitted
+        # asynchronously and the consumer parses them one at a time, so each
+        # blob must survive until its op is claimed. A too-small K would delete
+        # blobs that are still queued. 64 covers the current pipelined submission
+        # depth (one step's chunks, drained at a per-step barrier) with margin;
+        # override via WEAVER_BLOB_KEEP_LAST_K / TRAINER_BLOB_KEEP_LAST_K.
+        try:
+            self._keep_last_k = max(1, int(_blob_env("KEEP_LAST_K") or "64"))
+        except ValueError:
+            self._keep_last_k = 64
+        # unique per process/run; only the writer needs this (it ships the key).
+        self._run = f"{time.strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(3)}"
+        self._lock = threading.Lock()
+        self._pruned_seq: dict[str, int] = {}  # model_id -> last seq pruned up to
+        self._write_seq: dict[str, int] = {}  # model_id -> next auto write seq
+        # Reader-side cache of whole packed files. A packed chunk is read once
+        # and its many per-field references are sliced out of memory, instead of
+        # re-reading (or re-opening) the same file per reference.
+        self._read_cache: "OrderedDict[str, bytes]" = OrderedDict()
+        try:
+            self._read_cache_max = max(1, int(_blob_env("READ_CACHE") or "4"))
+        except ValueError:
+            self._read_cache_max = 4
+
+        if self._enabled:
+            if self._root is None:
+                logger.warning(
+                    "Blob offload requested but the store root is empty "
+                    "(set WEAVER_BLOB_ROOT, or TRAINER_BLOB_ROOT on the trainer); "
+                    "falling back to inline HTTP payloads."
+                )
+                self._enabled = False
+            else:
+                try:
+                    self._root.mkdir(parents=True, exist_ok=True)
+                except OSError as exc:
+                    logger.warning(
+                        "WEAVER_BLOB_ROOT %s not writable (%s); "
+                        "falling back to inline HTTP payloads.",
+                        self._root,
+                        exc,
+                    )
+                    self._enabled = False
+
+        if self._enabled:
+            logger.info(
+                "Blob offload ENABLED: root=%s run=%s keep_last_k=%d",
+                self._root,
+                self._run,
+                self._keep_last_k,
+            )
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def run(self) -> str:
+        return self._run
+
+    # ------------------------------------------------------------------ write
+    def put_tensor(
+        self,
+        tensor: torch.Tensor,
+        *,
+        model_id: str,
+        seq_id: int,
+        field: str,
+    ) -> dict[str, Any]:
+        """Write ``tensor`` to a blob and return its ``$blob`` reference.
+
+        The tensor is stored as a raw little-endian C-contiguous buffer; dtype
+        and shape travel in the reference so the reader can reconstruct it
+        without re-parsing JSON.
+        """
+        assert self._root is not None  # guarded by ``enabled``
+        dtype_name, shape, buf = _tensor_to_buf(tensor)
+
+        key = f"{self._run}/{model_id}/seq-{seq_id}/{_safe_field(field)}.bin"
+        self._write_atomic(self._root / key, [buf])
+        self._maybe_gc(model_id, seq_id)
+
+        return {
+            BLOB_KEY: PayloadRef(
+                storage=_STORAGE,
+                format=_FORMAT,
+                relative_path=key,
+                dtype=dtype_name,
+                size_bytes=len(buf),
+                metadata={"shape": shape, "codec": _CODEC},
+            ).to_payload()
+        }
+
+    def _write_atomic(self, dest: Path, parts: Sequence[bytes]) -> None:
+        """Write ``parts`` to ``dest`` atomically (temp file + fsync + rename)."""
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_name(f".{dest.name}.{secrets.token_hex(4)}.tmp")
+        with open(tmp, "wb") as fh:
+            for part in parts:
+                fh.write(part)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, dest)
+
+    def open_pack(self, *, model_id: str, seq_id: int) -> "PackWriter":
+        """Open a writer that packs one chunk's tensors into a single file.
+
+        Use this instead of many :meth:`put_tensor` calls when serializing a
+        batch: every per-datum field becomes one slice of one file rather than
+        its own tiny file (one create + fsync + rename each).
+        """
+        assert self._root is not None  # guarded by ``enabled``
+        return PackWriter(self, model_id=model_id, seq_id=seq_id)
+
+    # ------------------------------------------------------------------- read
+    def _safe_key_path(self, relative_path: str) -> Path:
+        """``self._root / relative_path``, refusing anything that could escape the
+        root.
+
+        ``relative_path`` arrives on the wire inside an (untrusted) training
+        payload, so a crafted ref must not let the reader resolve a file outside
+        ``WEAVER_BLOB_ROOT`` — reject absolute paths (which would replace the
+        root), ``..``/``.`` components, and backslash separators.
+        """
+        assert self._root is not None
+        parts = relative_path.split("/")
+        if (
+            not relative_path
+            or relative_path.startswith("/")
+            or "\\" in relative_path
+            or ".." in parts
+            or "." in parts
+        ):
+            raise ValueError(f"unsafe blob relative_path: {relative_path!r}")
+        return self._root / relative_path
+
+    def get_array(self, ref: dict[str, Any]) -> np.ndarray:
+        """Resolve a ``$blob`` reference to a numpy array (reader side)."""
+        if self._root is None:
+            raise RuntimeError(
+                "Got a $blob reference but the store root is not configured "
+                "(set WEAVER_BLOB_ROOT, or TRAINER_BLOB_ROOT on the trainer)."
+            )
+        pr = PayloadRef.from_payload(ref[BLOB_KEY])
+        codec = pr.metadata.get("codec", _CODEC)
+        if codec != _CODEC:
+            raise ValueError(f"Unsupported blob codec: {codec}")
+        np_dtype = _NAME_TO_NUMPY.get(pr.dtype)
+        if np_dtype is None:
+            raise TypeError(f"Unsupported blob dtype: {pr.dtype}")
+        if pr.relative_path is None:
+            raise ValueError("$blob reference is missing relative_path")
+        path = self._safe_key_path(pr.relative_path)
+        nbytes = pr.size_bytes
+        offset = pr.metadata.get("offset")
+        if offset is not None:
+            # Packed file: this reference is one slice of a shared file. Read the
+            # file once (cached) and slice, so a chunk's many references cost one
+            # read rather than one per reference.
+            if nbytes is None:
+                raise ValueError(f"Blob {pr.relative_path} has offset but no size_bytes")
+            whole = self._read_file_cached(path)
+            end = offset + nbytes
+            if end > len(whole):
+                raise ValueError(
+                    f"Blob {pr.relative_path} slice [{offset}:{end}] out of range "
+                    f"(file length {len(whole)}; partial/corrupt read)."
+                )
+            buf = whole[offset:end]
+        else:
+            buf = path.read_bytes()
+            if nbytes is not None and len(buf) != nbytes:
+                raise ValueError(
+                    f"Blob {pr.relative_path} length {len(buf)} != expected {nbytes} "
+                    "(partial/corrupt read)."
+                )
+        # .copy() so the array owns writable memory (np.frombuffer is read-only).
+        return np.frombuffer(buf, dtype=np_dtype).reshape(pr.metadata["shape"]).copy()
+
+    def _read_file_cached(self, path: Path) -> bytes:
+        """Return the full bytes of ``path``, caching whole packed files.
+
+        The I/O happens outside the lock; a concurrent double-read is harmless
+        (the content is identical), and the cache keeps the last K files so a
+        chunk's references all hit the same in-memory buffer.
+        """
+        key = str(path)
+        with self._lock:
+            cached = self._read_cache.get(key)
+            if cached is not None:
+                self._read_cache.move_to_end(key)
+                return cached
+        data = path.read_bytes()
+        with self._lock:
+            self._read_cache[key] = data
+            self._read_cache.move_to_end(key)
+            while len(self._read_cache) > self._read_cache_max:
+                self._read_cache.popitem(last=False)
+        return data
+
+    def get_tensor(self, ref: dict[str, Any]) -> torch.Tensor:
+        """Resolve a ``$blob`` reference to a torch tensor (reader side)."""
+        return torch.from_numpy(self.get_array(ref))
+
+    # ---------------------------------------------------------------- results
+    def next_write_seq(self, model_id: str) -> int:
+        """Monotonic seq for store-side (e.g. trainer result) writes.
+
+        Unlike forward/forward_backward inputs (whose seq is the operation seq
+        from the SDK), result blobs are written by the consumer side, which has
+        no operation seq — so it auto-assigns one here. The keep-last-K GC then
+        prunes old result blobs the same way.
+        """
+        with self._lock:
+            seq = self._write_seq.get(model_id, 0)
+            self._write_seq[model_id] = seq + 1
+        return seq
+
+    def put_packed(
+        self,
+        arrays: Sequence[Any],
+        *,
+        model_id: str,
+        field: str,
+    ) -> dict[str, Any]:
+        """Write a list of 1-D float sequences as one concatenated blob.
+
+        The returned ``$blob`` reference carries per-sequence lengths under
+        ``"splits"`` so :meth:`get_packed` can reconstruct the original list in
+        order. One blob per call (not per element) keeps the file/fsync count
+        low. Order is preserved exactly — the reader splits back position-for-
+        position.
+        """
+        seqs = [torch.as_tensor(a, dtype=torch.float32).reshape(-1) for a in arrays]
+        splits = [int(s.numel()) for s in seqs]
+        flat = torch.cat(seqs) if seqs else torch.zeros(0, dtype=torch.float32)
+        ref = self.put_tensor(
+            flat,
+            model_id=model_id,
+            seq_id=self.next_write_seq(model_id),
+            field=field,
+        )
+        ref[BLOB_KEY]["splits"] = splits
+        return ref
+
+    def get_packed(self, ref: dict[str, Any]) -> list[np.ndarray]:
+        """Resolve a packed ``$blob`` reference back to its list of arrays."""
+        flat = self.get_array(ref)
+        splits = ref[BLOB_KEY].get("splits")
+        if splits is None:
+            return [flat]
+        total = int(sum(splits))
+        if total != flat.size:
+            raise ValueError(
+                f"Blob {ref[BLOB_KEY].get('relative_path')} splits sum to {total} "
+                f"but the array has {flat.size} elements (corrupt/mismatched descriptor)."
+            )
+        out: list[np.ndarray] = []
+        offset = 0
+        for length in splits:
+            out.append(flat[offset : offset + length])
+            offset += length
+        return out
+
+    # --------------------------------------------------------------------- gc
+    def _maybe_gc(self, model_id: str, seq_id: int) -> None:
+        """Prune seq directories older than the last K for this model."""
+        with self._lock:
+            if self._pruned_seq.get(model_id, -1) >= seq_id:
+                return
+            self._pruned_seq[model_id] = seq_id
+        assert self._root is not None
+        model_dir = self._root / self._run / model_id
+        cutoff = seq_id - self._keep_last_k
+        if cutoff < 0:
+            return
+        try:
+            for child in model_dir.glob("seq-*"):
+                try:
+                    n = int(child.name.split("seq-", 1)[1])
+                except (IndexError, ValueError):
+                    continue
+                if n <= cutoff:
+                    _rmtree_quiet(child)
+        except OSError:
+            pass  # GC is best-effort; never fail a training step on it.
+
+
+def _tensor_to_buf(tensor: torch.Tensor) -> tuple[str, list[int], bytes]:
+    """Materialize ``tensor`` to (dtype name, shape, raw C-contiguous bytes)."""
+    dtype_name = _TORCH_TO_NAME.get(tensor.dtype)
+    if dtype_name is None:
+        raise TypeError(f"Unsupported dtype for blob offload: {tensor.dtype}")
+    arr = tensor.detach().cpu().contiguous().numpy()
+    return dtype_name, list(arr.shape), arr.tobytes(order="C")
+
+
+class PackWriter:
+    """Accumulate one chunk's tensors into a single packed blob.
+
+    A training chunk's per-datum input fields would otherwise become hundreds
+    of tiny files — one create + fsync + rename each, which dominates wall time
+    on a shared store. ``PackWriter`` buffers them and writes one file on
+    :meth:`commit`; every reference it returns carries a byte ``offset`` into
+    that file so the reader slices its tensor back out. Not thread-safe: one
+    writer serves one chunk's serialization.
+    """
+
+    def __init__(self, store: "BlobStore", *, model_id: str, seq_id: int) -> None:
+        self._store = store
+        self._model_id = model_id
+        self._seq_id = seq_id
+        self._key = f"{store.run}/{model_id}/seq-{seq_id}/pack.bin"
+        self._parts: list[bytes] = []
+        self._offset = 0
+
+    def put_tensor(self, tensor: torch.Tensor, *, field: str) -> dict[str, Any]:
+        """Append ``tensor`` to the pack and return its offset reference.
+
+        ``field`` is accepted for call-site symmetry with
+        :meth:`BlobStore.put_tensor`; the slice is identified by ``offset``.
+        """
+        del field  # offset (not a file name) identifies the slice
+        dtype_name, shape, buf = _tensor_to_buf(tensor)
+        offset = self._offset
+        self._parts.append(buf)
+        self._offset += len(buf)
+        return {
+            BLOB_KEY: PayloadRef(
+                storage=_STORAGE,
+                format=_FORMAT,
+                relative_path=self._key,
+                dtype=dtype_name,
+                size_bytes=len(buf),
+                metadata={"shape": shape, "codec": _CODEC, "offset": offset},
+            ).to_payload()
+        }
+
+    def commit(self) -> None:
+        """Flush the accumulated tensors to one file (one fsync + rename)."""
+        if not self._parts:
+            return
+        # PackWriter is a friend of BlobStore (same module); the writes below go
+        # through BlobStore's internal helpers intentionally.
+        store = self._store
+        # pylint: disable=protected-access
+        root = store._root
+        assert root is not None
+        store._write_atomic(root / self._key, self._parts)
+        self._parts = []
+        store._maybe_gc(self._model_id, self._seq_id)
+
+
+def _safe_field(field: str) -> str:
+    """Sanitize a field name into a single safe path segment."""
+    keep = [c if (c.isalnum() or c in ("-", "_", ".")) else "_" for c in field]
+    out = "".join(keep).strip("._") or "field"
+    return out
+
+
+def _rmtree_quiet(path: Path) -> None:
+    try:
+        for child in path.iterdir():
+            if child.is_dir():
+                _rmtree_quiet(child)
+            else:
+                child.unlink(missing_ok=True)
+        path.rmdir()
+    except OSError:
+        pass
+
+
+@functools.lru_cache(maxsize=1)
+def get_blob_store() -> BlobStore:
+    """Return the process-wide blob store (created lazily on first use)."""
+    return BlobStore()

--- a/weaver/operations.py
+++ b/weaver/operations.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
 from ._http import APIClient, WeaverAPIError, backoff_delays
 from ._utils import extract_id, lookup_case_insensitive
+from .blob_store import get_blob_store
 
 if TYPE_CHECKING:
     from ._async_http import AsyncAPIClient
@@ -182,7 +183,7 @@ class OperationHandle(_OperationHandleMixin):
 
     def result(self) -> Any:
         payload = self.wait()
-        return lookup_case_insensitive(payload, "response")
+        return _resolve_result_blobs(lookup_case_insensitive(payload, "response"))
 
     @classmethod
     def wait_all(cls, handles: List["OperationHandle"]) -> List[Any]:
@@ -256,7 +257,7 @@ class AsyncOperationHandle(_OperationHandleMixin):
 
     async def result(self) -> Any:
         payload = await self.wait()
-        return lookup_case_insensitive(payload, "response")
+        return _resolve_result_blobs(lookup_case_insensitive(payload, "response"))
 
     def __await__(self):
         return self.result().__await__()
@@ -275,3 +276,57 @@ def build_async_operation_handle(
     client: "AsyncAPIClient", payload: Dict[str, Any]
 ) -> AsyncOperationHandle:
     return AsyncOperationHandle.from_payload(client, payload)
+
+
+def _resolve_loss_fn_outputs_packed(container: Dict[str, Any]) -> None:
+    """Rebuild ``loss_fn_outputs`` from a leg-2 packed-blob descriptor in place.
+
+    The trainer offloads the per-datum logprobs into one ``$blob`` and sends a
+    ``loss_fn_outputs_packed`` descriptor instead of inline floats; here we read
+    the blob back and restore the exact inline shape (order preserved) so
+    callers never see the offload.
+    """
+    packed = container.get("loss_fn_outputs_packed")
+    if not isinstance(packed, dict) or "ref" not in packed:
+        return
+    arrays = get_blob_store().get_packed(packed["ref"])
+    field_name = packed.get("field", "logprobs")
+    siblings = packed.get("siblings") or []
+    outputs: List[Dict[str, Any]] = []
+    for idx, arr in enumerate(arrays):
+        out = dict(siblings[idx]) if idx < len(siblings) else {}
+        data = arr.tolist()
+        existing = out.get(field_name)
+        if isinstance(existing, dict):
+            # Tensor envelope ({dtype, shape}) was kept by the trainer; restore
+            # the exact ``{data, dtype, shape}`` shape the inline path emits.
+            envelope = dict(existing)
+            envelope["data"] = data
+            out[field_name] = envelope
+        else:
+            out[field_name] = data
+        outputs.append(out)
+    container["loss_fn_outputs"] = outputs
+    container.pop("loss_fn_outputs_packed", None)
+
+
+def _resolve_result_blobs(response: Any) -> Any:
+    """Resolve any blob-offloaded fields (leg-2) in an operation response.
+
+    Mirrors the consumer's result-shape handling: the packed descriptor may sit
+    at the top level, under ``result``, or nested per task under
+    ``forward_task_results`` (the aggregated forward shape).
+    """
+    if not isinstance(response, dict):
+        return response
+    containers: List[Dict[str, Any]] = [response]
+    inner = response.get("result")
+    if isinstance(inner, dict):
+        containers.append(inner)
+    for container in list(containers):
+        task_results = container.get("forward_task_results")
+        if isinstance(task_results, dict):
+            containers.extend(v for v in task_results.values() if isinstance(v, dict))
+    for container in containers:
+        _resolve_loss_fn_outputs_packed(container)
+    return response

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -66,7 +66,26 @@ class TrainingClient:
     def _next_seq(self) -> int:
         return self._service.next_operation_seq(self.model_id)
 
-    def _serialize_data(self, data: Sequence[Datum]) -> Sequence[Dict[str, Any]]:
+    def _serialize_data(
+        self,
+        data: Sequence[Datum],
+        *,
+        blob_ctx: Dict[str, Any] | None = None,
+    ) -> Sequence[Dict[str, Any]]:
+        if blob_ctx is not None:
+            from .blob_store import get_blob_store
+
+            store = get_blob_store()
+            if store.enabled:
+                # Pack the whole batch's offloaded tensors into one file: each
+                # datum field becomes a slice rather than its own tiny file.
+                pack = store.open_pack(model_id=blob_ctx["model_id"], seq_id=blob_ctx["seq_id"])
+                ctx = {**blob_ctx, "pack": pack}
+                payload = [datum.to_payload(blob_ctx=ctx, index=i) for i, datum in enumerate(data)]
+                pack.commit()
+                return payload
+        # Offload disabled (or no ctx): defer to the shared serializer so the
+        # sync and async stacks emit identical inline bytes.
         return serialize_data(data)
 
     def _build_metadata(
@@ -123,14 +142,21 @@ class TrainingClient:
                 Passing this argument raises ``ValueError``.
             wait: If True, blocks until the operation completes.
         """
-        payload = forward_payload(
-            model_id=self.model_id,
-            seq_id=self._next_seq(),
-            data=data,
-            loss_fn=loss_fn,
-            loss_fn_config=loss_fn_config,
-            request_metadata=build_request_metadata(metadata, router_replay),
-        )
+        seq_id = self._next_seq()
+        blob_ctx = {"model_id": self.model_id, "seq_id": seq_id}
+        payload: Dict[str, Any] = {
+            "model_id": self.model_id,
+            "seq_id": seq_id,
+            "forward_input": {
+                "loss_fn": loss_fn,
+                "data": self._serialize_data(data, blob_ctx=blob_ctx),
+            },
+        }
+        if loss_fn_config:
+            payload["forward_input"]["loss_fn_config"] = dict(loss_fn_config)
+        request_metadata = self._build_metadata(metadata, router_replay)
+        if request_metadata:
+            payload["metadata"] = request_metadata
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/forward-passes",
             {"payload": payload},
@@ -184,14 +210,21 @@ class TrainingClient:
                 Passing this argument raises ``ValueError``.
             wait: If True, blocks until the operation completes.
         """
-        payload = forward_backward_payload(
-            model_id=self.model_id,
-            seq_id=self._next_seq(),
-            data=data,
-            loss_fn=loss_fn,
-            loss_fn_config=loss_fn_config,
-            request_metadata=build_request_metadata(metadata, router_replay),
-        )
+        seq_id = self._next_seq()
+        blob_ctx = {"model_id": self.model_id, "seq_id": seq_id}
+        payload: Dict[str, Any] = {
+            "model_id": self.model_id,
+            "seq_id": seq_id,
+            "forward_backward_input": {
+                "loss_fn": loss_fn,
+                "data": self._serialize_data(data, blob_ctx=blob_ctx),
+            },
+        }
+        if loss_fn_config:
+            payload["forward_backward_input"]["loss_fn_config"] = dict(loss_fn_config)
+        request_metadata = self._build_metadata(metadata, router_replay)
+        if request_metadata:
+            payload["metadata"] = request_metadata
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/forward-backward-passes",
             {"payload": payload},

--- a/weaver/types/datum.py
+++ b/weaver/types/datum.py
@@ -47,21 +47,58 @@ class Datum:
                 normalized[key] = torch.as_tensor(value)
         self.loss_fn_inputs = normalized
 
-    def to_payload(self) -> dict[str, object]:
-        return {
-            "model_input": self.model_input.to_payload(),
-            "loss_fn_inputs": {
-                name: (
-                    values.to_dict()
-                    if isinstance(values, TensorData)
-                    else (
-                        tensor_payload(values).to_dict()
-                        if isinstance(values, torch.Tensor)
-                        else values
+    def to_payload(
+        self,
+        *,
+        blob_ctx: dict[str, Any] | None = None,
+        index: int = 0,
+    ) -> dict[str, object]:
+        """Serialize to a wire payload.
+
+        Args:
+            blob_ctx: When blob offload is enabled, ``{"model_id", "seq_id"}``
+                used to name offloaded blobs. ``None`` (default) keeps the
+                inline form, byte-identical to before.
+            index: Position of this datum within its batch, for unique keys.
+        """
+        store = None
+        if blob_ctx is not None:
+            from ..blob_store import get_blob_store
+
+            store = get_blob_store()
+        offload = store is not None and store.enabled
+
+        model_input_payload = (
+            self.model_input.to_payload(blob_ctx=blob_ctx, field_prefix=f"d{index}")
+            if offload
+            else self.model_input.to_payload()
+        )
+
+        pack = blob_ctx.get("pack") if blob_ctx is not None else None
+        loss_fn_inputs_payload: dict[str, object] = {}
+        for name, values in self.loss_fn_inputs.items():
+            if offload and isinstance(values, (torch.Tensor, TensorData)):
+                tensor = values if isinstance(values, torch.Tensor) else values.to_tensor()
+                assert store is not None and blob_ctx is not None
+                if pack is not None:
+                    loss_fn_inputs_payload[name] = pack.put_tensor(tensor, field=f"d{index}_{name}")
+                else:
+                    loss_fn_inputs_payload[name] = store.put_tensor(
+                        tensor,
+                        model_id=blob_ctx["model_id"],
+                        seq_id=blob_ctx["seq_id"],
+                        field=f"d{index}_{name}",
                     )
-                )
-                for name, values in self.loss_fn_inputs.items()
-            },
+            elif isinstance(values, TensorData):
+                loss_fn_inputs_payload[name] = values.to_dict()
+            elif isinstance(values, torch.Tensor):
+                loss_fn_inputs_payload[name] = tensor_payload(values).to_dict()
+            else:
+                loss_fn_inputs_payload[name] = values
+
+        return {
+            "model_input": model_input_payload,
+            "loss_fn_inputs": loss_fn_inputs_payload,
             **({"metadata": dict(self.metadata)} if self.metadata else {}),
         }
 
@@ -90,6 +127,14 @@ class Datum:
 def _is_jagged_sequence(value: Any) -> bool:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
         return False
+    # Fast path: loss inputs are homogeneous, so a sequence whose first element
+    # is a scalar is a flat (non-jagged) array. Decide in O(1) instead of
+    # scanning every element — the full scan dominated client-side datum
+    # building for dense per-token arrays (advantages, logprobs, loss_mask).
+    if value:
+        first = value[0]
+        if not (isinstance(first, Sequence) and not isinstance(first, (str, bytes, bytearray))):
+            return False
     nested_lengths: list[int] = []
     saw_nested = False
     for item in value:

--- a/weaver/types/model_input.py
+++ b/weaver/types/model_input.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable, List, Sequence
+from typing import Any, Iterable, List, Sequence
 
 
 @dataclass(slots=True)
@@ -50,5 +50,39 @@ class ModelInput:
             return
         self.chunks[chunk_index].tokens.extend(tokens)
 
-    def to_payload(self) -> dict[str, object]:
+    def to_payload(
+        self,
+        *,
+        blob_ctx: dict[str, Any] | None = None,
+        field_prefix: str = "",
+    ) -> dict[str, object]:
+        """Serialize to a wire payload.
+
+        With ``blob_ctx`` and offload enabled, each chunk's ``tokens`` list is
+        written to a blob and replaced with a ``$blob`` reference; otherwise the
+        inline form is preserved (byte-identical to before).
+        """
+        if blob_ctx is not None:
+            import torch  # local: keep the type module torch-light when inline
+
+            from ..blob_store import get_blob_store
+
+            store = get_blob_store()
+            if store.enabled:
+                pack = blob_ctx.get("pack")
+                chunks: list[dict[str, object]] = []
+                for chunk_index, chunk in enumerate(self.chunks):
+                    tensor = torch.as_tensor(chunk.tokens, dtype=torch.int64)
+                    field_name = f"{field_prefix}_tokens_{chunk_index}"
+                    if pack is not None:
+                        ref = pack.put_tensor(tensor, field=field_name)
+                    else:
+                        ref = store.put_tensor(
+                            tensor,
+                            model_id=blob_ctx["model_id"],
+                            seq_id=blob_ctx["seq_id"],
+                            field=field_name,
+                        )
+                    chunks.append({"type": chunk.type, "tokens": ref})
+                return {"chunks": chunks}
         return {"chunks": [chunk.to_dict() for chunk in self.chunks]}

--- a/weaver/types/payload_ref.py
+++ b/weaver/types/payload_ref.py
@@ -108,6 +108,17 @@ def materialize_payload_ref(
     """
 
     payload_ref = ref if isinstance(ref, PayloadRef) else PayloadRef.from_payload(ref)
+    if payload_ref.format.lower() == "raw-tensor":
+        # Raw tensor buffers are owned by the blob store (the hot-path offload);
+        # delegate so generic inspection resolves the same bytes the trainer/SDK
+        # consume (against WEAVER_BLOB_ROOT / TRAINER_BLOB_ROOT).
+        from ..blob_store import BLOB_KEY, get_blob_store
+
+        if field is not None:
+            raise PayloadRefMaterializationError(
+                "field= is not supported for raw-tensor payload refs."
+            )
+        return get_blob_store().get_array({BLOB_KEY: payload_ref.to_payload()})
     storage = payload_ref.storage.lower()
     if storage not in {"gpfs", "filesystem", "local"}:
         raise PayloadRefMaterializationError(


### PR DESCRIPTION
## What
Optional **HTTP blob offload** for large training tensors. With `WEAVER_BLOB_OFFLOAD=1` the SDK writes large `model_input` / `loss_fn_inputs` tensors to a shared filesystem store (`WEAVER_BLOB_ROOT`) and ships a small reference on the wire instead of the inline numbers; the trainer resolves it against the same store. Leg-2 packed results coming back are resolved transparently before the caller sees them.

## Ref envelope = `PayloadRef` (shared with router-replay #76)
The `$blob` value is a **`PayloadRef`** (`storage`/`format`/`relative_path`/`dtype`/`size_bytes`, with tensor `shape`/`codec`/`offset`/`splits` in `metadata`) — one large-payload envelope across the SDK. `materialize_payload_ref` handles the `raw-tensor` format for generic inspection.

## One switch, safe by default
- **Off by default** → byte-identical inline payloads; the store module is never touched.
- `OFFLOAD` gates it; `ROOT` is the shared store path; `KEEP_LAST_K`(64)/`READ_CACHE`(4) default.
- Per-process `<run>` namespacing + run-scoped GC → a shared ROOT is safe across processes/users.
- **Path safety:** the reader rejects a `relative_path` that would escape `WEAVER_BLOB_ROOT` (absolute / `..` / backslash), so an untrusted payload cannot read arbitrary files.

## Scope
SDK side of a 3-repo change (weaver-server `$blob` validation + weaver-trainer resolution). Tests: `tests/test_blob_store.py` (round-trip, packing, traversal rejection); existing datum/types/metadata tests pass.
