### PR TITLE
feat(service-client): expose optional performance_tier in create_model

### DIFF
--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -239,43 +239,27 @@ def _posted_payload(client):
     return kwargs["json"]
 
 
-def test_create_model_passes_sizing_hints():
-    """max_seq_len and performance_tier are forwarded in the request body when provided."""
+def test_create_model_passes_performance_tier():
+    """performance_tier is forwarded in the request body when provided."""
     client = _make_create_model_client()
 
     client.create_model(
-        base_model="Qwen/Qwen3-8B",
+        base_model="Qwen/Qwen3-8B:262144",
         training_mode="full_ft",
-        max_seq_len=65536,
         performance_tier="fast",
     )
 
     payload = _posted_payload(client)
-    assert payload["max_seq_len"] == 65536
     assert payload["performance_tier"] == "fast"
+    # Sequence length lives in base_model, not a separate field.
+    assert payload["base_model"] == "Qwen/Qwen3-8B:262144"
+    assert "max_seq_len" not in payload
 
 
-def test_create_model_omits_sizing_hints_when_absent():
-    """Hints are not present in the payload when omitted, preserving prior behavior."""
+def test_create_model_omits_performance_tier_when_absent():
+    """performance_tier is not present in the payload when omitted, preserving prior behavior."""
     client = _make_create_model_client()
 
     client.create_model(base_model="Qwen/Qwen3-8B", training_mode="full_ft")
 
-    payload = _posted_payload(client)
-    assert "max_seq_len" not in payload
-    assert "performance_tier" not in payload
-
-
-def test_create_model_passes_hints_independently():
-    """Each sizing hint can be supplied on its own."""
-    client = _make_create_model_client()
-    client.create_model(base_model="Qwen/Qwen3-8B", max_seq_len=8192)
-    payload = _posted_payload(client)
-    assert payload["max_seq_len"] == 8192
-    assert "performance_tier" not in payload
-
-    client2 = _make_create_model_client()
-    client2.create_model(base_model="Qwen/Qwen3-8B", performance_tier="flash")
-    payload2 = _posted_payload(client2)
-    assert payload2["performance_tier"] == "flash"
-    assert "max_seq_len" not in payload2
+    assert "performance_tier" not in _posted_payload(client)

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -233,23 +233,28 @@ def _make_create_model_client():
     return client
 
 
+def _posted_payload(client):
+    """Return the json body of the last create-model POST."""
+    _, kwargs = client._http.post.call_args
+    return kwargs["json"]
+
+
 def test_create_model_passes_workload_hints():
-    """Workload hints are forwarded in the create-model request body when provided."""
+    """Per-operation workload hints are forwarded verbatim in the request body."""
     client = _make_create_model_client()
 
+    hints = {
+        "forward_backward": {"max_seq_len": 8192, "batch_size": 8},
+        "forward": {"max_seq_len": 8192, "batch_size": 64},
+        "sample": {"max_seq_len": 4096, "batch_size": 256},
+    }
     client.create_model(
         base_model="Qwen/Qwen3-8B",
         training_mode="full_ft",
-        max_seq_len=8192,
-        training_batch_size=32,
-        rollout_batch_size=64,
+        workload_hints=hints,
     )
 
-    _, kwargs = client._http.post.call_args
-    payload = kwargs["json"]
-    assert payload["max_seq_len"] == 8192
-    assert payload["training_batch_size"] == 32
-    assert payload["rollout_batch_size"] == 64
+    assert _posted_payload(client)["workload_hints"] == hints
 
 
 def test_create_model_omits_workload_hints_when_absent():
@@ -258,8 +263,39 @@ def test_create_model_omits_workload_hints_when_absent():
 
     client.create_model(base_model="Qwen/Qwen3-8B", training_mode="full_ft")
 
-    _, kwargs = client._http.post.call_args
-    payload = kwargs["json"]
-    assert "max_seq_len" not in payload
-    assert "training_batch_size" not in payload
-    assert "rollout_batch_size" not in payload
+    assert "workload_hints" not in _posted_payload(client)
+
+
+def test_create_model_drops_empty_workload_specs():
+    """Operations with empty hint mappings are dropped; an all-empty mapping is not sent."""
+    client = _make_create_model_client()
+
+    client.create_model(
+        base_model="Qwen/Qwen3-8B",
+        workload_hints={"forward_backward": {"batch_size": 8}, "forward": {}},
+    )
+
+    assert _posted_payload(client)["workload_hints"] == {"forward_backward": {"batch_size": 8}}
+
+    client2 = _make_create_model_client()
+    client2.create_model(base_model="Qwen/Qwen3-8B", workload_hints={"forward": {}})
+    assert "workload_hints" not in _posted_payload(client2)
+
+
+@pytest.mark.parametrize(
+    "bad_hints",
+    [
+        {"forward": {"unknown_field": 1}},  # unknown sub-field
+        {"forward": {"batch_size": "8"}},  # non-int value
+        {"forward": {"batch_size": True}},  # bool rejected even though int subclass
+        {"forward": [8192, 8]},  # spec not a mapping
+    ],
+)
+def test_create_model_rejects_malformed_workload_hints(bad_hints):
+    """Structural problems fail locally with ValueError before any HTTP call."""
+    client = _make_create_model_client()
+
+    with pytest.raises(ValueError):
+        client.create_model(base_model="Qwen/Qwen3-8B", workload_hints=bad_hints)
+
+    client._http.post.assert_not_called()

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -221,3 +221,45 @@ def test_create_model_debug_info_none_when_absent():
     training = client.create_model(base_model="Qwen/Qwen3-8B", training_mode="full_ft")
 
     assert training.debug_info is None
+
+
+def _make_create_model_client():
+    """Build a ServiceClient with a mocked http layer for create_model payload tests."""
+    client = ServiceClient(api_key="sk-test-key")
+    client._session_id = "session-1"
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "abc-123", "base_model": "Qwen/Qwen3-8B"}
+    client._http.get.return_value = {"items": []}
+    return client
+
+
+def test_create_model_passes_workload_hints():
+    """Workload hints are forwarded in the create-model request body when provided."""
+    client = _make_create_model_client()
+
+    client.create_model(
+        base_model="Qwen/Qwen3-8B",
+        training_mode="full_ft",
+        max_seq_len=8192,
+        training_batch_size=32,
+        rollout_batch_size=64,
+    )
+
+    _, kwargs = client._http.post.call_args
+    payload = kwargs["json"]
+    assert payload["max_seq_len"] == 8192
+    assert payload["training_batch_size"] == 32
+    assert payload["rollout_batch_size"] == 64
+
+
+def test_create_model_omits_workload_hints_when_absent():
+    """Hints are not present in the payload when omitted, preserving prior behavior."""
+    client = _make_create_model_client()
+
+    client.create_model(base_model="Qwen/Qwen3-8B", training_mode="full_ft")
+
+    _, kwargs = client._http.post.call_args
+    payload = kwargs["json"]
+    assert "max_seq_len" not in payload
+    assert "training_batch_size" not in payload
+    assert "rollout_batch_size" not in payload

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -239,63 +239,43 @@ def _posted_payload(client):
     return kwargs["json"]
 
 
-def test_create_model_passes_workload_hints():
-    """Per-operation workload hints are forwarded verbatim in the request body."""
+def test_create_model_passes_sizing_hints():
+    """max_seq_len and performance_tier are forwarded in the request body when provided."""
     client = _make_create_model_client()
 
-    hints = {
-        "forward_backward": {"max_seq_len": 8192, "batch_size": 8},
-        "forward": {"max_seq_len": 8192, "batch_size": 64},
-        "sample": {"max_seq_len": 4096, "batch_size": 256},
-    }
     client.create_model(
         base_model="Qwen/Qwen3-8B",
         training_mode="full_ft",
-        workload_hints=hints,
+        max_seq_len=65536,
+        performance_tier="fast",
     )
 
-    assert _posted_payload(client)["workload_hints"] == hints
+    payload = _posted_payload(client)
+    assert payload["max_seq_len"] == 65536
+    assert payload["performance_tier"] == "fast"
 
 
-def test_create_model_omits_workload_hints_when_absent():
+def test_create_model_omits_sizing_hints_when_absent():
     """Hints are not present in the payload when omitted, preserving prior behavior."""
     client = _make_create_model_client()
 
     client.create_model(base_model="Qwen/Qwen3-8B", training_mode="full_ft")
 
-    assert "workload_hints" not in _posted_payload(client)
+    payload = _posted_payload(client)
+    assert "max_seq_len" not in payload
+    assert "performance_tier" not in payload
 
 
-def test_create_model_drops_empty_workload_specs():
-    """Operations with empty hint mappings are dropped; an all-empty mapping is not sent."""
+def test_create_model_passes_hints_independently():
+    """Each sizing hint can be supplied on its own."""
     client = _make_create_model_client()
-
-    client.create_model(
-        base_model="Qwen/Qwen3-8B",
-        workload_hints={"forward_backward": {"batch_size": 8}, "forward": {}},
-    )
-
-    assert _posted_payload(client)["workload_hints"] == {"forward_backward": {"batch_size": 8}}
+    client.create_model(base_model="Qwen/Qwen3-8B", max_seq_len=8192)
+    payload = _posted_payload(client)
+    assert payload["max_seq_len"] == 8192
+    assert "performance_tier" not in payload
 
     client2 = _make_create_model_client()
-    client2.create_model(base_model="Qwen/Qwen3-8B", workload_hints={"forward": {}})
-    assert "workload_hints" not in _posted_payload(client2)
-
-
-@pytest.mark.parametrize(
-    "bad_hints",
-    [
-        {"forward": {"unknown_field": 1}},  # unknown sub-field
-        {"forward": {"batch_size": "8"}},  # non-int value
-        {"forward": {"batch_size": True}},  # bool rejected even though int subclass
-        {"forward": [8192, 8]},  # spec not a mapping
-    ],
-)
-def test_create_model_rejects_malformed_workload_hints(bad_hints):
-    """Structural problems fail locally with ValueError before any HTTP call."""
-    client = _make_create_model_client()
-
-    with pytest.raises(ValueError):
-        client.create_model(base_model="Qwen/Qwen3-8B", workload_hints=bad_hints)
-
-    client._http.post.assert_not_called()
+    client2.create_model(base_model="Qwen/Qwen3-8B", performance_tier="flash")
+    payload2 = _posted_payload(client2)
+    assert payload2["performance_tier"] == "flash"
+    assert "max_seq_len" not in payload2

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -198,6 +198,9 @@ class ServiceClient:
         training_mode: Optional[str] = None,
         lora_config: Union[LoraConfig, Dict[str, Any]] = DEFAULT_LORA_CONFIG,
         user_metadata: Optional[Dict[str, Any]] = None,
+        max_seq_len: Optional[int] = None,
+        training_batch_size: Optional[int] = None,
+        rollout_batch_size: Optional[int] = None,
     ) -> "TrainingClient":
         """Create a training model with LoRA or FullFT configuration.
 
@@ -208,6 +211,21 @@ class ServiceClient:
             lora_config: LoRA configuration (default: LoraConfig(rank=32) with all layers enabled)
             full_ft_config: Full fine-tuning config dict (optional, for full_ft mode only)
             user_metadata: Optional user metadata
+            max_seq_len: Optional workload hint - expected maximum sequence length. Used by the
+                server to plan parallelism and resources. Should be filled with the worst case.
+            training_batch_size: Optional workload hint - training mini-batch size (per-step batch,
+                NOT the global batch with gradient accumulation). Drives training DP planning.
+                Primarily for full_ft; ignored for LoRA, which uses a single configuration.
+            rollout_batch_size: Optional workload hint - rollout sampling batch size. Drives
+                inference replica planning.
+
+        Note:
+            The workload hints are descriptive facts about the workload, not parallelism knobs.
+            All are optional: when omitted, the server plans from the first observed batch or
+            model defaults, and behavior is unchanged for existing users. When provided, the
+            server sizes resources precisely against them. Out-of-range values are validated and
+            rejected by the server (each hint has an upper bound); such errors surface via
+            WeaverAPIError.
 
         Returns:
             TrainingClient for the created model
@@ -246,6 +264,15 @@ class ServiceClient:
 
         if user_metadata is not None:
             payload["user_metadata"] = user_metadata
+
+        # Optional workload hints — passed through verbatim so the server can plan resources.
+        # Omitted hints are not sent, preserving today's behavior for existing users.
+        if max_seq_len is not None:
+            payload["max_seq_len"] = max_seq_len
+        if training_batch_size is not None:
+            payload["training_batch_size"] = training_batch_size
+        if rollout_batch_size is not None:
+            payload["rollout_batch_size"] = rollout_batch_size
 
         response = self.http.post(
             f"/api/v1/sessions/{self.session_id}/models",

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -198,24 +198,20 @@ class ServiceClient:
         training_mode: Optional[str] = None,
         lora_config: Union[LoraConfig, Dict[str, Any]] = DEFAULT_LORA_CONFIG,
         user_metadata: Optional[Dict[str, Any]] = None,
-        max_seq_len: Optional[int] = None,
         performance_tier: Optional[str] = None,
     ) -> "TrainingClient":
         """Create a training model with LoRA or FullFT configuration.
 
         Args:
-            base_model: Base model name (e.g., "Qwen/Qwen3-8B")
+            base_model: Base model name (e.g., "Qwen/Qwen3-8B"). The maximum sequence length
+                is encoded in the name: a long-context variant uses a ``:<max_seq_len>`` suffix
+                (e.g. "Qwen/Qwen3-8B:262144"). Pick the variant whose context fits your
+                workload rather than passing a separate length parameter.
             model_seq_id: Optional model sequence ID
             training_mode: Training mode - "lora" or "full_ft" (default: None -> server defaults to "lora")
             lora_config: LoRA configuration (default: LoraConfig(rank=32) with all layers enabled)
             full_ft_config: Full fine-tuning config dict (optional, for full_ft mode only)
             user_metadata: Optional user metadata
-            max_seq_len: Optional maximum sequence length the model must support. The server
-                picks a parallel strategy that guarantees this length can be trained. It is a
-                per-model ceiling; if your workloads span very different lengths, create
-                separate models (e.g. a 64k and a 512k variant of the same base model) rather
-                than sizing one model for the largest case. Defaults to the model's default
-                when omitted.
             performance_tier: Optional throughput tier selecting how much parallelism / data
                 parallelism the server provisions. Higher tiers deliver proportionally more
                 throughput at proportionally higher price (e.g. "fast" ~= 2x the throughput
@@ -223,10 +219,10 @@ class ServiceClient:
                 Defaults to the server default tier when omitted.
 
         Note:
-            ``max_seq_len`` and ``performance_tier`` are optional: when omitted, behavior is
-            unchanged for existing users and the server applies its defaults. Values are
-            validated by the server, which rejects unsupported tiers or out-of-range lengths
-            with HTTP 400; such errors surface via WeaverAPIError.
+            ``performance_tier`` is optional: when omitted, behavior is unchanged for existing
+            users and the server applies its default tier. The value is validated by the
+            server, which rejects unsupported tiers with HTTP 400; such errors surface via
+            WeaverAPIError.
 
         Returns:
             TrainingClient for the created model
@@ -242,11 +238,10 @@ class ServiceClient:
                 lora_config=LoraConfig(rank=16, seed=42)
             )
 
-            # Full fine-tuning, 64k context, fast throughput tier
+            # Long-context (256k) variant, full fine-tuning, fast throughput tier
             client.create_model(
-                base_model="Qwen/Qwen3-8B",
+                base_model="Qwen/Qwen3-8B:262144",
                 training_mode="full_ft",
-                max_seq_len=65536,
                 performance_tier="fast",
             )
         """
@@ -268,11 +263,9 @@ class ServiceClient:
         if user_metadata is not None:
             payload["user_metadata"] = user_metadata
 
-        # Optional sizing hints passed through for the server to plan parallelism and pricing.
-        # Omitted -> not sent, preserving today's behavior for existing users; the server owns
-        # validation (unsupported tier / out-of-range length -> HTTP 400 -> WeaverAPIError).
-        if max_seq_len is not None:
-            payload["max_seq_len"] = max_seq_len
+        # Optional throughput tier passed through for the server to plan parallelism and
+        # pricing. Omitted -> not sent, preserving today's behavior for existing users; the
+        # server owns validation (unsupported tier -> HTTP 400 -> WeaverAPIError).
         if performance_tier is not None:
             payload["performance_tier"] = performance_tier
 

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -20,7 +20,7 @@ import atexit
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from . import __version__
 from ._http import APIClient
@@ -39,6 +39,61 @@ logger = logging.getLogger(__name__)
 
 # Default LoRA configuration
 DEFAULT_LORA_CONFIG = LoraConfig(rank=32)
+
+# Per-operation fields accepted inside a workload hint. The set of valid operation *names*
+# is intentionally not enforced client-side (forward compatibility); the server owns that.
+WORKLOAD_HINT_FIELDS = ("max_seq_len", "batch_size")
+
+
+def _normalize_workload_hints(
+    workload_hints: Optional[Mapping[str, Mapping[str, int]]],
+) -> Dict[str, Dict[str, int]]:
+    """Validate the structure of ``workload_hints`` and return a plain-dict copy.
+
+    Performs only light structural checks so typos fail locally with a clear message;
+    operation-name validity and value ranges are owned by the server. Empty per-operation
+    specs are dropped so an empty mapping is not sent.
+
+    Args:
+        workload_hints: Optional mapping of operation name -> {field: int}, where field is
+            one of ``max_seq_len`` / ``batch_size``.
+
+    Returns:
+        A normalized ``{op: {field: int}}`` dict (possibly empty).
+
+    Raises:
+        ValueError: If the overall shape, a per-operation spec, a field name, or a value is
+            not of the expected type.
+    """
+    if workload_hints is None:
+        return {}
+    if not isinstance(workload_hints, Mapping):
+        raise ValueError(
+            f"workload_hints must be a mapping of operation -> hints, got {type(workload_hints).__name__}"
+        )
+
+    normalized: Dict[str, Dict[str, int]] = {}
+    for op, spec in workload_hints.items():
+        if not isinstance(spec, Mapping):
+            raise ValueError(
+                f"workload_hints[{op!r}] must be a mapping of field -> int, got {type(spec).__name__}"
+            )
+        op_hints: Dict[str, int] = {}
+        for field, value in spec.items():
+            if field not in WORKLOAD_HINT_FIELDS:
+                raise ValueError(
+                    f"workload_hints[{op!r}] has unknown field {field!r}; "
+                    f"expected one of {WORKLOAD_HINT_FIELDS}"
+                )
+            # bool is an int subclass but never a valid size; reject it explicitly.
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(
+                    f"workload_hints[{op!r}][{field!r}] must be an int, got {type(value).__name__}"
+                )
+            op_hints[field] = value
+        if op_hints:
+            normalized[op] = op_hints
+    return normalized
 
 
 class ServiceClient:
@@ -198,9 +253,7 @@ class ServiceClient:
         training_mode: Optional[str] = None,
         lora_config: Union[LoraConfig, Dict[str, Any]] = DEFAULT_LORA_CONFIG,
         user_metadata: Optional[Dict[str, Any]] = None,
-        max_seq_len: Optional[int] = None,
-        training_batch_size: Optional[int] = None,
-        rollout_batch_size: Optional[int] = None,
+        workload_hints: Optional[Mapping[str, Mapping[str, int]]] = None,
     ) -> "TrainingClient":
         """Create a training model with LoRA or FullFT configuration.
 
@@ -211,21 +264,29 @@ class ServiceClient:
             lora_config: LoRA configuration (default: LoraConfig(rank=32) with all layers enabled)
             full_ft_config: Full fine-tuning config dict (optional, for full_ft mode only)
             user_metadata: Optional user metadata
-            max_seq_len: Optional workload hint - expected maximum sequence length. Used by the
-                server to plan parallelism and resources. Should be filled with the worst case.
-            training_batch_size: Optional workload hint - training mini-batch size (per-step batch,
-                NOT the global batch with gradient accumulation). Drives training DP planning.
-                Primarily for full_ft; ignored for LoRA, which uses a single configuration.
-            rollout_batch_size: Optional workload hint - rollout sampling batch size. Drives
-                inference replica planning.
+            workload_hints: Optional per-operation workload hints used by the server to plan
+                parallelism and replica counts. A mapping keyed by operation name, where each
+                value is a mapping with optional ``max_seq_len`` and ``batch_size`` integers::
+
+                    {
+                        "forward_backward": {"max_seq_len": 8192, "batch_size": 8},
+                        "forward":          {"max_seq_len": 8192, "batch_size": 64},
+                        "sample":           {"max_seq_len": 4096, "batch_size": 256},
+                    }
+
+                Recognized operations: ``forward_backward``, ``forward``,
+                ``forward_backward_custom`` (trainer-side); ``sample``, ``compute_logprobs``
+                (sampler-side). ``forward_backward`` drives training DP planning; ``sample``
+                drives inference replica planning.
 
         Note:
-            The workload hints are descriptive facts about the workload, not parallelism knobs.
-            All are optional: when omitted, the server plans from the first observed batch or
-            model defaults, and behavior is unchanged for existing users. When provided, the
-            server sizes resources precisely against them. Out-of-range values are validated and
-            rejected by the server (each hint has an upper bound); such errors surface via
-            WeaverAPIError.
+            Workload hints are descriptive facts about the workload, not parallelism knobs
+            (no ``world_size`` / ``tp`` / ``dp`` / ``replicas``). They are optional: when
+            omitted, the server plans from the first observed batch or model defaults and
+            behavior is unchanged for existing users. When provided, hints should reflect the
+            worst case; the server sizes resources against them. Unknown operations and
+            out-of-range values are validated and rejected by the server (HTTP 400); such
+            errors surface via WeaverAPIError.
 
         Returns:
             TrainingClient for the created model
@@ -241,10 +302,14 @@ class ServiceClient:
                 lora_config=LoraConfig(rank=16, seed=42)
             )
 
-            # Full fine-tuning mode
+            # Full fine-tuning mode with per-operation workload hints
             client.create_model(
                 base_model="Qwen/Qwen3-8B",
                 training_mode="full_ft",
+                workload_hints={
+                    "forward_backward": {"max_seq_len": 8192, "batch_size": 8},
+                    "sample": {"max_seq_len": 4096, "batch_size": 256},
+                },
             )
         """
         model_seq_id = model_seq_id or self._next_model_seq()
@@ -265,14 +330,12 @@ class ServiceClient:
         if user_metadata is not None:
             payload["user_metadata"] = user_metadata
 
-        # Optional workload hints — passed through verbatim so the server can plan resources.
-        # Omitted hints are not sent, preserving today's behavior for existing users.
-        if max_seq_len is not None:
-            payload["max_seq_len"] = max_seq_len
-        if training_batch_size is not None:
-            payload["training_batch_size"] = training_batch_size
-        if rollout_batch_size is not None:
-            payload["rollout_batch_size"] = rollout_batch_size
+        # Optional per-operation workload hints. Validated structurally here (so typos fail
+        # locally with a clear message) then passed through; the server owns range/op-name
+        # validation. Omitted -> not sent, preserving today's behavior for existing users.
+        normalized_hints = _normalize_workload_hints(workload_hints)
+        if normalized_hints:
+            payload["workload_hints"] = normalized_hints
 
         response = self.http.post(
             f"/api/v1/sessions/{self.session_id}/models",

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -20,7 +20,7 @@ import atexit
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from . import __version__
 from ._http import APIClient
@@ -39,61 +39,6 @@ logger = logging.getLogger(__name__)
 
 # Default LoRA configuration
 DEFAULT_LORA_CONFIG = LoraConfig(rank=32)
-
-# Per-operation fields accepted inside a workload hint. The set of valid operation *names*
-# is intentionally not enforced client-side (forward compatibility); the server owns that.
-WORKLOAD_HINT_FIELDS = ("max_seq_len", "batch_size")
-
-
-def _normalize_workload_hints(
-    workload_hints: Optional[Mapping[str, Mapping[str, int]]],
-) -> Dict[str, Dict[str, int]]:
-    """Validate the structure of ``workload_hints`` and return a plain-dict copy.
-
-    Performs only light structural checks so typos fail locally with a clear message;
-    operation-name validity and value ranges are owned by the server. Empty per-operation
-    specs are dropped so an empty mapping is not sent.
-
-    Args:
-        workload_hints: Optional mapping of operation name -> {field: int}, where field is
-            one of ``max_seq_len`` / ``batch_size``.
-
-    Returns:
-        A normalized ``{op: {field: int}}`` dict (possibly empty).
-
-    Raises:
-        ValueError: If the overall shape, a per-operation spec, a field name, or a value is
-            not of the expected type.
-    """
-    if workload_hints is None:
-        return {}
-    if not isinstance(workload_hints, Mapping):
-        raise ValueError(
-            f"workload_hints must be a mapping of operation -> hints, got {type(workload_hints).__name__}"
-        )
-
-    normalized: Dict[str, Dict[str, int]] = {}
-    for op, spec in workload_hints.items():
-        if not isinstance(spec, Mapping):
-            raise ValueError(
-                f"workload_hints[{op!r}] must be a mapping of field -> int, got {type(spec).__name__}"
-            )
-        op_hints: Dict[str, int] = {}
-        for field, value in spec.items():
-            if field not in WORKLOAD_HINT_FIELDS:
-                raise ValueError(
-                    f"workload_hints[{op!r}] has unknown field {field!r}; "
-                    f"expected one of {WORKLOAD_HINT_FIELDS}"
-                )
-            # bool is an int subclass but never a valid size; reject it explicitly.
-            if isinstance(value, bool) or not isinstance(value, int):
-                raise ValueError(
-                    f"workload_hints[{op!r}][{field!r}] must be an int, got {type(value).__name__}"
-                )
-            op_hints[field] = value
-        if op_hints:
-            normalized[op] = op_hints
-    return normalized
 
 
 class ServiceClient:
@@ -253,7 +198,8 @@ class ServiceClient:
         training_mode: Optional[str] = None,
         lora_config: Union[LoraConfig, Dict[str, Any]] = DEFAULT_LORA_CONFIG,
         user_metadata: Optional[Dict[str, Any]] = None,
-        workload_hints: Optional[Mapping[str, Mapping[str, int]]] = None,
+        max_seq_len: Optional[int] = None,
+        performance_tier: Optional[str] = None,
     ) -> "TrainingClient":
         """Create a training model with LoRA or FullFT configuration.
 
@@ -264,29 +210,23 @@ class ServiceClient:
             lora_config: LoRA configuration (default: LoraConfig(rank=32) with all layers enabled)
             full_ft_config: Full fine-tuning config dict (optional, for full_ft mode only)
             user_metadata: Optional user metadata
-            workload_hints: Optional per-operation workload hints used by the server to plan
-                parallelism and replica counts. A mapping keyed by operation name, where each
-                value is a mapping with optional ``max_seq_len`` and ``batch_size`` integers::
-
-                    {
-                        "forward_backward": {"max_seq_len": 8192, "batch_size": 8},
-                        "forward":          {"max_seq_len": 8192, "batch_size": 64},
-                        "sample":           {"max_seq_len": 4096, "batch_size": 256},
-                    }
-
-                Recognized operations: ``forward_backward``, ``forward``,
-                ``forward_backward_custom`` (trainer-side); ``sample``, ``compute_logprobs``
-                (sampler-side). ``forward_backward`` drives training DP planning; ``sample``
-                drives inference replica planning.
+            max_seq_len: Optional maximum sequence length the model must support. The server
+                picks a parallel strategy that guarantees this length can be trained. It is a
+                per-model ceiling; if your workloads span very different lengths, create
+                separate models (e.g. a 64k and a 512k variant of the same base model) rather
+                than sizing one model for the largest case. Defaults to the model's default
+                when omitted.
+            performance_tier: Optional throughput tier selecting how much parallelism / data
+                parallelism the server provisions. Higher tiers deliver proportionally more
+                throughput at proportionally higher price (e.g. "fast" ~= 2x the throughput
+                and 2x the price of "normal"). Recognized values: "normal", "fast", "flash".
+                Defaults to the server default tier when omitted.
 
         Note:
-            Workload hints are descriptive facts about the workload, not parallelism knobs
-            (no ``world_size`` / ``tp`` / ``dp`` / ``replicas``). They are optional: when
-            omitted, the server plans from the first observed batch or model defaults and
-            behavior is unchanged for existing users. When provided, hints should reflect the
-            worst case; the server sizes resources against them. Unknown operations and
-            out-of-range values are validated and rejected by the server (HTTP 400); such
-            errors surface via WeaverAPIError.
+            ``max_seq_len`` and ``performance_tier`` are optional: when omitted, behavior is
+            unchanged for existing users and the server applies its defaults. Values are
+            validated by the server, which rejects unsupported tiers or out-of-range lengths
+            with HTTP 400; such errors surface via WeaverAPIError.
 
         Returns:
             TrainingClient for the created model
@@ -302,14 +242,12 @@ class ServiceClient:
                 lora_config=LoraConfig(rank=16, seed=42)
             )
 
-            # Full fine-tuning mode with per-operation workload hints
+            # Full fine-tuning, 64k context, fast throughput tier
             client.create_model(
                 base_model="Qwen/Qwen3-8B",
                 training_mode="full_ft",
-                workload_hints={
-                    "forward_backward": {"max_seq_len": 8192, "batch_size": 8},
-                    "sample": {"max_seq_len": 4096, "batch_size": 256},
-                },
+                max_seq_len=65536,
+                performance_tier="fast",
             )
         """
         model_seq_id = model_seq_id or self._next_model_seq()
@@ -330,12 +268,13 @@ class ServiceClient:
         if user_metadata is not None:
             payload["user_metadata"] = user_metadata
 
-        # Optional per-operation workload hints. Validated structurally here (so typos fail
-        # locally with a clear message) then passed through; the server owns range/op-name
-        # validation. Omitted -> not sent, preserving today's behavior for existing users.
-        normalized_hints = _normalize_workload_hints(workload_hints)
-        if normalized_hints:
-            payload["workload_hints"] = normalized_hints
+        # Optional sizing hints passed through for the server to plan parallelism and pricing.
+        # Omitted -> not sent, preserving today's behavior for existing users; the server owns
+        # validation (unsupported tier / out-of-range length -> HTTP 400 -> WeaverAPIError).
+        if max_seq_len is not None:
+            payload["max_seq_len"] = max_seq_len
+        if performance_tier is not None:
+            payload["performance_tier"] = performance_tier
 
         response = self.http.post(
             f"/api/v1/sessions/{self.session_id}/models",


### PR DESCRIPTION
## Summary

Adds a single optional `performance_tier` parameter to `create_model()` (`weaver/service_client.py`), per #85, letting resource-aware users pick a throughput/pricing tier at model creation:

```python
client.create_model(
    base_model="Qwen/Qwen3-8B:262144",  # long-context variant (256k)
    training_mode="full_ft",
    performance_tier="fast",
)
```

**`performance_tier: str | None`** — a discrete **throughput tier** (`"normal"` / `"fast"` / `"flash"`) selecting how much parallelism / data parallelism the server provisions. Higher tiers deliver proportionally more throughput at proportionally higher price (e.g. `fast` ≈ 2× the throughput and 2× the price of `normal`).

### Why no `max_seq_len`

Maximum sequence length is **encoded in the `base_model` name**, not passed separately: long-context variants use a `:<max_seq_len>` suffix (e.g. `Qwen/Qwen3-8B:262144`). Different lengths are different base models, so a `max_seq_len` parameter would be redundant. The `base_model` docstring documents this convention.

### Design evolution

The issue originally proposed flat `max_seq_len` / `training_batch_size` / `rollout_batch_size` scalars. Review converged through a per-operation `workload_hints` map → a `max_seq_len` + tier pair → this final single-knob shape, dropping all sizing math in favor of a small, pricing-aligned SKU.

### Behavior

- Optional; when omitted it is not sent and behavior is identical to today.
- **Descriptive, not prescriptive** — no `world_size` / `tp` / `dp` / `replicas` exposed.
- Passed through verbatim (mirroring the existing `training_mode` pattern). **Validation is server-side**: unsupported tiers are rejected with HTTP 400 and surfaced via `WeaverAPIError`. The SDK does not hardcode tier names, so new tiers need no SDK change.

## Tests

`tests/test_service_client.py` (17 passed):
- `performance_tier` forwarded when provided; sequence length stays in `base_model` (no `max_seq_len` field)
- payload unchanged when omitted

black / isort / pylint (10.00/10) / mypy clean via pre-commit.

> Note: tests ran on the host Python env — the only DevBox image available this session is an offline weaver-server (Go) image with no Python deps/network and no `.devbox.yaml` for this SDK repo. The new tests are pure `MagicMock` unit tests with no external side effects.

Pairs with server-side **weaver-server#358**, which must accept `performance_tier` and own tier validation.

Fixes #85