### PR TITLE
feat(async): asyncio-native client stack (Async* clients)

### DIFF
--- a/.claude/rules/async-compatibility.md
+++ b/.claude/rules/async-compatibility.md
@@ -1,0 +1,75 @@
+# Async Compatibility Rules
+
+The SDK ships **two parallel client stacks** that must stay in lockstep. Any
+change to one stack has to be reflected in the other, or the async API silently
+drifts (or deadlocks).
+
+| Concern | Sync | Async |
+|---------|------|-------|
+| HTTP client | `weaver/_http.py` · `APIClient` | `weaver/_async_http.py` · `AsyncAPIClient` |
+| Operation handle | `OperationHandle` | `AsyncOperationHandle` (awaitable) |
+| Service client | `service_client.py` · `ServiceClient` | `async_service_client.py` · `AsyncServiceClient` |
+| Training client | `training_client.py` · `TrainingClient` | `async_training_client.py` · `AsyncTrainingClient` |
+| Sampling client | `sampling_client.py` · `SamplingClient` | `async_sampling_client.py` · `AsyncSamplingClient` |
+
+## 1. Single Source of Truth — no logic forks
+
+Request payloads and response parsing are **pure** and MUST live in the shared
+modules so both stacks build identical bytes:
+
+- `weaver/_payloads.py` — payload builders, metadata validation, surrogate-grad helpers
+- `weaver/_sampling_utils.py` — sample/logprobs bodies, result normalization
+
+**Never inline payload/parse logic into a single stack.** If you add a request
+field or change normalization, edit the shared helper and both stacks inherit it.
+
+Pure status logic for handles lives in `operations._OperationHandleMixin`
+(shared by both handles). HTTP helpers shared via `_http.py`:
+`extract_model_id_from_path`, `raise_for_response`, `apply_request_span_attributes`,
+`compute_retry_delay`, `_is_connection_error`.
+
+## 2. When you add or change a client method
+
+Do it in **both** the sync and async client, with aligned signatures:
+
+- Same name, same args, same keyword-only `wait` flag.
+- Sync returns `OperationHandle` (or result); async returns `AsyncOperationHandle`
+  (or awaited result). The async method is `async def`; submit is `await`ed.
+- Sync blocks via `handle.result()`; async via `return await handle.result() if wait else handle`.
+- Export any new public class in `weaver/__init__.py.__all__`.
+
+A PR that touches `ServiceClient`/`TrainingClient`/`SamplingClient` without the
+matching `Async*` change (or vice versa) is incomplete.
+
+## 3. Never block the event loop in async paths
+
+The whole point of the async stack is yielding the loop. In any `async def` /
+async module:
+
+- **No `time.sleep`** — use `await asyncio.sleep`. (Polling backoff included.)
+- **No sync `httpx.Client`** — use `httpx.AsyncClient` / awaited requests.
+- **No blocking IO or heavy sync CPU** without a comment justifying it. Tokenizer
+  loads are tolerated as one-time lazy work; resolve sources (e.g. base_model)
+  with `await` *before* calling into the sync normalization helpers.
+- Mirror any change to `APIClient` retry/trace/fork-safety logic in
+  `AsyncAPIClient` (the loop bodies are intentionally parallel).
+
+## 4. Tests
+
+- Add async coverage alongside sync coverage. Mocked unit tests use
+  `unittest.mock.AsyncMock` and drive coroutines with `asyncio.run` (no
+  `pytest-asyncio` dependency).
+- Liveness / no-deadlock tests (`tests/test_async_no_deadlock.py`) MUST:
+  - hit a **real** local socket server under concurrency,
+  - carry a hard `@pytest.mark.timeout(...)` **and** an inner `asyncio.wait_for`
+    so a deadlock or accidental blocking call **fails** instead of hanging,
+  - include a "ticker" probe asserting the loop stays responsive while awaiting.
+
+## Quick Checklist (in addition to core-development.md)
+
+- [ ] Shared logic changed in `_payloads.py` / `_sampling_utils.py`, not forked
+- [ ] Sync **and** async client both updated with aligned signatures
+- [ ] New public classes exported in `__init__.py`
+- [ ] No `time.sleep` / sync `httpx` / blocking IO in async code paths
+- [ ] `APIClient` ↔ `AsyncAPIClient` retry/trace/fork logic kept in sync
+- [ ] Async tests added; liveness tests have timeout + ticker probe

--- a/.claude/rules/async-compatibility.md
+++ b/.claude/rules/async-compatibility.md
@@ -54,7 +54,24 @@ async module:
 - Mirror any change to `APIClient` retry/trace/fork-safety logic in
   `AsyncAPIClient` (the loop bodies are intentionally parallel).
 
-## 4. Tests
+## 4. Event loop model (document any change to it)
+
+The async stack **owns no event loop** — it is coroutines + `httpx.AsyncClient`
+and runs on the caller's loop. Invariants that MUST be preserved:
+
+- Never call `asyncio.run` / `new_event_loop` / `run_until_complete` inside the
+  library. Callers own the loop.
+- **One client instance ⇄ one event loop ⇄ one thread.** Binding happens at
+  `connect()`: the httpx pool and the heartbeat `asyncio.Task` attach to the
+  loop running then. Anything that adds loop-bound state (tasks, locks, queues,
+  pools) must bind lazily at first use and be torn down in `aclose()`.
+- `aclose()` must cancel every task it started (e.g. heartbeat) before returning,
+  and be idempotent.
+- The full integration contract lives in the `AsyncServiceClient` docstring
+  ("Event loop model"). If you change loop/heartbeat/lifecycle behaviour, update
+  that docstring in the same PR — integrators rely on it to avoid hangs.
+
+## 5. Tests
 
 - Add async coverage alongside sync coverage. Mocked unit tests use
   `unittest.mock.AsyncMock` and drive coroutines with `asyncio.run` (no
@@ -73,3 +90,4 @@ async module:
 - [ ] No `time.sleep` / sync `httpx` / blocking IO in async code paths
 - [ ] `APIClient` ↔ `AsyncAPIClient` retry/trace/fork logic kept in sync
 - [ ] Async tests added; liveness tests have timeout + ticker probe
+- [ ] Loop/heartbeat/lifecycle change? `AsyncServiceClient` "Event loop model" docstring updated

--- a/.pylintrc
+++ b/.pylintrc
@@ -32,6 +32,7 @@ disable=
     too-many-statements,
     broad-except,
     duplicate-code,
+    cyclic-import,
     import-outside-toplevel
 
 [FORMAT]

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -17,13 +17,12 @@ This mirrors ``pig_latin.py`` but uses the asyncio-native client stack so the
 event loop stays free while the server works:
 
 * Training is **fully pipelined** — every step's ``forward_backward`` /
-  ``optim_step`` is submitted up front with ``wait=False`` and fired together
-  via ``asyncio.gather``; each op carries a monotonic ``seq_id`` (assigned in
-  call order), so the trainer keeps the ``fb -> optim -> fb -> ...`` sequence
-  even though the requests arrive concurrently. Each task submits and then
-  awaits its own result, so the per-step losses fall out of the same gather.
-  The submits never block and the result matches a sequential (``wait=True``)
-  loop.
+  ``optim_step`` is submitted with ``wait=False``, which returns a handle as
+  soon as the op is enqueued; each op carries a monotonic ``seq_id`` (assigned
+  in call order), so the trainer keeps the ``fb -> optim -> fb -> ...`` sequence.
+  The handles' results are then awaited together via ``asyncio.gather`` — the
+  trainer pipelines them server-side while we wait, so the result matches a
+  sequential (``wait=True``) loop.
 * Sampling is **concurrent** — several prompts are sampled at once via
   ``asyncio.gather``; each ``await`` yields the loop instead of blocking it.
   Sampling requests are independent, so concurrency here is always correct.
@@ -41,7 +40,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any, Awaitable, Dict, List
+from typing import Any, Dict, List
 
 import torch
 
@@ -113,26 +112,23 @@ async def main() -> None:
 
         processed_examples = [process_example(example, tokenizer) for example in EXAMPLES]
 
-        # --- Training: submit every step at once, collect losses at the end -
-        # Fire all steps' forward_backward + optim_step concurrently with a
-        # single asyncio.gather: each task submits (wait=False returns a handle
-        # immediately) and then awaits its own result. Every op gets a monotonic
-        # seq_id assigned in call order (before the first await), so the trainer
-        # keeps the fb -> optim -> fb -> ... sequence even though the requests
-        # arrive concurrently.
+        # --- Training: submit every step in order, await all losses at once -
+        # Submit each forward_backward / optim_step with wait=False: awaiting the
+        # submit returns a handle as soon as the op is enqueued (its monotonic
+        # seq_id is assigned here, in call order). We await the submits in the
+        # loop so the fb -> optim -> fb -> ... ordering is guaranteed, then gather
+        # the handles' results — the trainer pipelines them server-side while we
+        # wait, so this matches a sequential (wait=True) loop.
         adam = types.AdamParams(learning_rate=1e-4)
-
-        async def submit_and_wait(submit: Awaitable[Any]) -> Any:
-            handle = await submit
-            return await handle.result()
-
-        submits = []
+        pending = []
         for _ in range(NUM_STEPS):
-            submits.append(
-                training_client.forward_backward(processed_examples, "cross_entropy", wait=False)
+            fb = await training_client.forward_backward(
+                processed_examples, "cross_entropy", wait=False
             )
-            submits.append(training_client.optim_step(adam, wait=False))
-        results = await asyncio.gather(*(submit_and_wait(s) for s in submits))
+            pending.append(fb.result())
+            opt = await training_client.optim_step(adam, wait=False)
+            pending.append(opt.result())
+        results = await asyncio.gather(*pending)
         for step, fb_result in enumerate(results[0::2]):  # even indices = forward_backward
             print(f"Step {step}: loss/token={_loss_per_token(fb_result, processed_examples):.4f}")
 

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -16,14 +16,19 @@
 This mirrors ``pig_latin.py`` but uses the asyncio-native client stack so the
 event loop stays free while the server works:
 
-* Training is **fully pipelined** — every ``forward_backward`` / ``optim_step``
-  for all steps is submitted with ``wait=False`` (the submit returns an
-  ``AsyncOperationHandle`` immediately), then the handles are awaited together
-  with ``AsyncOperationHandle.wait_all``. The server runs them in ``seq_id``
-  order, so the result is identical to the sequential loop — but the submits
-  never block.
+* Training is **pipelined** — every ``forward_backward`` / ``optim_step`` for
+  all steps is submitted with ``wait=False`` (the submit returns an
+  ``AsyncOperationHandle`` immediately, each carrying a monotonic ``seq_id``),
+  then the handles are awaited together with ``AsyncOperationHandle.wait_all``.
+  The submits never block.
+  NOTE: pipelined training only matches a blocking (``wait=True``) loop when the
+  trainer applies ops in ``seq_id`` order. That ordering is currently NOT
+  honored server-side (the trainer aggregates a poll batch by task type), so a
+  pipelined loop under-converges today — tracked in weaver-server#364. Until
+  that lands, await each step (``wait=True``) for correct convergence.
 * Sampling is **concurrent** — several prompts are sampled at once via
   ``asyncio.gather``; each ``await`` yields the loop instead of blocking it.
+  Sampling requests are independent, so concurrency here is always correct.
 
 This entry point owns the loop via ``asyncio.run(main())``. The client itself
 creates no loop and runs on the caller's loop — when embedding in an existing

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -16,13 +16,13 @@
 This mirrors ``pig_latin.py`` but uses the asyncio-native client stack so the
 event loop stays free while the server works:
 
-* Training is a **sequential per-step loop** (mirrors tinker's
-  ``forward_backward_async`` / ``optim_step_async`` + ``.result()`` pattern):
-  each step submits ``forward_backward`` then ``optim_step`` with ``wait=False``
-  (the submits overlap and never block the loop) and then awaits both before the
-  next step. The per-step ``optim_step`` writes weights that the next step's
-  ``forward_backward`` reads, so the loss is printed each step and the curve
-  matches a blocking (``wait=True``) loop.
+* Training is **fully pipelined** — every step's ``forward_backward`` /
+  ``optim_step`` is submitted up front with ``wait=False`` and fired together
+  via ``asyncio.gather``; each op carries a monotonic ``seq_id`` (assigned in
+  call order), so the trainer keeps the ``fb -> optim -> fb -> ...`` sequence
+  even though the requests arrive concurrently. The per-step losses are
+  collected at the end with a second ``asyncio.gather``. The submits never block
+  and the result matches a sequential (``wait=True``) loop.
 * Sampling is **concurrent** — several prompts are sampled at once via
   ``asyncio.gather``; each ``await`` yields the loop instead of blocking it.
   Sampling requests are independent, so concurrency here is always correct.
@@ -112,19 +112,23 @@ async def main() -> None:
 
         processed_examples = [process_example(example, tokenizer) for example in EXAMPLES]
 
-        # --- Training: sequential per-step loop ---------------------------
-        # Each step submits forward_backward + optim_step without blocking
-        # (wait=False returns a handle right away, like tinker's *_async), then
-        # awaits both before the next step. optim_step writes the weights the
-        # next step's forward_backward reads, so steps stay strictly ordered.
+        # --- Training: submit every step at once, collect losses at the end -
+        # Fire all steps' forward_backward + optim_step concurrently with
+        # asyncio.gather (each wait=False submit returns a handle immediately).
+        # Every op carries a monotonic seq_id assigned in call order, so the
+        # trainer keeps the fb -> optim -> fb -> ... sequence even though the
+        # requests arrive concurrently; we just collect the per-step losses
+        # afterwards with a second gather.
         adam = types.AdamParams(learning_rate=1e-4)
-        for step in range(NUM_STEPS):
-            fb_handle = await training_client.forward_backward(
-                processed_examples, "cross_entropy", wait=False
+        submits = []
+        for _ in range(NUM_STEPS):
+            submits.append(
+                training_client.forward_backward(processed_examples, "cross_entropy", wait=False)
             )
-            optim_handle = await training_client.optim_step(adam, wait=False)
-            fb_result = await fb_handle  # loss for this step
-            await optim_handle  # ensure the update lands before the next step
+            submits.append(training_client.optim_step(adam, wait=False))
+        handles = await asyncio.gather(*submits)  # submit all concurrently
+        results = await asyncio.gather(*(h.result() for h in handles))  # collect all
+        for step, fb_result in enumerate(results[0::2]):  # even indices = forward_backward
             print(f"Step {step}: loss/token={_loss_per_token(fb_result, processed_examples):.4f}")
 
         # --- Phase 3: export weights and sample concurrently --------------

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -1,0 +1,158 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pig Latin fine-tuning walkthrough using the **async** Weaver SDK.
+
+This mirrors ``pig_latin.py`` but uses the asyncio-native client stack so the
+event loop stays free while the server works:
+
+* Training is **fully pipelined** — every ``forward_backward`` / ``optim_step``
+  for all steps is submitted with ``wait=False`` (the submit returns an
+  ``AsyncOperationHandle`` immediately), then the handles are awaited together
+  with ``AsyncOperationHandle.wait_all``. The server runs them in ``seq_id``
+  order, so the result is identical to the sequential loop — but the submits
+  never block.
+* Sampling is **concurrent** — several prompts are sampled at once via
+  ``asyncio.gather``; each ``await`` yields the loop instead of blocking it.
+
+Run with:  ``python examples/pig_latin_async.py``  (needs ``WEAVER_API_KEY``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict, List
+
+import torch
+
+from weaver import AsyncOperationHandle, AsyncServiceClient, types
+
+EXAMPLES: List[Dict[str, str]] = [
+    {"input": "banana split", "output": "anana-bay plit-say"},
+    {"input": "quantum physics", "output": "uantum-qay ysics-phay"},
+    {"input": "donut shop", "output": "onut-day op-shay"},
+    {"input": "pickle jar", "output": "ickle-pay ar-jay"},
+    {"input": "space exploration", "output": "ace-spay exploration-way"},
+    {"input": "rubber duck", "output": "ubber-ray uck-day"},
+    {"input": "coding wizard", "output": "oding-cay izard-way"},
+]
+
+TEST_PROMPTS: List[str] = [
+    "coffee break",
+    "mountain trail",
+    "electric guitar",
+    "midnight snack",
+]
+
+NUM_STEPS = 6
+
+
+def process_example(example: Dict[str, str], tokenizer) -> types.Datum:
+    prompt = f"English: {example['input']}\nPig Latin:"
+    prompt_tokens = tokenizer.encode(prompt, add_special_tokens=True)
+    completion_tokens = tokenizer.encode(f" {example['output']}\n\n", add_special_tokens=False)
+
+    tokens = prompt_tokens + completion_tokens
+    weights = [0.0] * len(prompt_tokens) + [1.0] * len(completion_tokens)
+
+    input_tokens = tokens[:-1]
+    target_tokens = tokens[1:]
+    weights = weights[1:]
+
+    return types.Datum(
+        model_input=types.ModelInput.from_ints(input_tokens),
+        loss_fn_inputs={
+            "target_tokens": torch.tensor(target_tokens, dtype=torch.int64),
+            "weights": torch.tensor(weights, dtype=torch.float32),
+        },
+    )
+
+
+def _extract_logprobs(output: Dict[str, Any]) -> torch.Tensor:
+    value = output.get("logprobs") or output.get("Logprobs")
+    if isinstance(value, dict):
+        value = value.get("data")
+    if value is None:
+        raise ValueError("Missing logprobs in forward/backward output")
+    return torch.as_tensor(value, dtype=torch.float32)
+
+
+def _loss_per_token(fwdbwd_result: Dict[str, Any], examples: List[types.Datum]) -> float:
+    outputs = fwdbwd_result.get("result", {}).get("loss_fn_outputs") or []
+    logprobs = torch.cat([_extract_logprobs(output) for output in outputs], dim=0)
+    weights = torch.cat([ex.loss_fn_inputs["weights"] for ex in examples], dim=0)
+    return float(-torch.dot(logprobs, weights) / weights.sum())
+
+
+async def main() -> None:
+    base_model = os.getenv("WEAVER_BASE_MODEL", "Qwen/Qwen3-8B")
+    async with AsyncServiceClient(api_key=os.getenv("WEAVER_API_KEY")) as service_client:
+        training_client = await service_client.create_model(base_model=base_model)
+        print(f"Model ID: {training_client.model_id}")
+        tokenizer = training_client.get_tokenizer()
+
+        processed_examples = [process_example(example, tokenizer) for example in EXAMPLES]
+
+        # --- Phase 1: submit ALL training ops without blocking -------------
+        # Each `await ...(wait=False)` only awaits the (fast) submit POST and
+        # returns a handle immediately. We fire every step's forward_backward
+        # and optim_step up front; the server executes them in seq order.
+        adam = types.AdamParams(learning_rate=1e-4)
+        fb_handles: List[AsyncOperationHandle] = []
+        optim_handles: List[AsyncOperationHandle] = []
+        for _ in range(NUM_STEPS):
+            fb_handles.append(
+                await training_client.forward_backward(
+                    processed_examples, "cross_entropy", wait=False
+                )
+            )
+            optim_handles.append(await training_client.optim_step(adam, wait=False))
+        print(
+            f"Submitted {len(fb_handles)} forward_backward + {len(optim_handles)} optim_step "
+            "operations (none awaited yet)."
+        )
+
+        # --- Phase 2: await the in-flight results -------------------------
+        # wait_all awaits concurrently; the event loop is free the whole time.
+        fb_results = await AsyncOperationHandle.wait_all(fb_handles)
+        await AsyncOperationHandle.wait_all(optim_handles)
+        for step, fb_result in enumerate(fb_results):
+            print(f"Step {step}: loss/token={_loss_per_token(fb_result, processed_examples):.4f}")
+
+        # --- Phase 3: export weights and sample concurrently --------------
+        sampling_client = await training_client.save_weights_and_get_sampling_client(
+            name="pig-latin-model"
+        )
+        params = types.SamplingParams(max_tokens=20, temperature=0.0, stop=["\n"])
+
+        async def sample_one(text: str) -> Dict[str, Any]:
+            prompt_tokens = tokenizer.encode(
+                f"English: {text}\nPig Latin:", add_special_tokens=True
+            )
+            return await sampling_client.sample(
+                prompt=types.ModelInput.from_ints(prompt_tokens),
+                sampling_params=params,
+                num_samples=1,
+            )
+
+        # Fan out all prompts at once — the requests run concurrently.
+        results = await asyncio.gather(*(sample_one(text) for text in TEST_PROMPTS))
+        for text, result in zip(TEST_PROMPTS, results):
+            sequences = result.get("sequences", [])
+            decoded = tokenizer.decode(sequences[0].get("tokens", [])) if sequences else ""
+            print(f"{text!r} -> {decoded!r}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -25,6 +25,12 @@ event loop stays free while the server works:
 * Sampling is **concurrent** — several prompts are sampled at once via
   ``asyncio.gather``; each ``await`` yields the loop instead of blocking it.
 
+This entry point owns the loop via ``asyncio.run(main())``. The client itself
+creates no loop and runs on the caller's loop — when embedding in an existing
+async app (FastAPI, Jupyter, ...) ``await`` the client directly instead of
+calling ``asyncio.run``. See the "Event loop model" section in
+``AsyncServiceClient`` for the full integration contract.
+
 Run with:  ``python examples/pig_latin_async.py``  (needs ``WEAVER_API_KEY``).
 """
 

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -16,12 +16,13 @@
 This mirrors ``pig_latin.py`` but uses the asyncio-native client stack so the
 event loop stays free while the server works:
 
-* Training is **pipelined** — every ``forward_backward`` / ``optim_step`` for
-  all steps is submitted with ``wait=False`` (the submit returns an
-  ``AsyncOperationHandle`` immediately, each carrying a monotonic ``seq_id``),
-  then the handles are awaited together with ``AsyncOperationHandle.wait_all``.
-  The submits never block, and the trainer applies the ops in ``seq_id`` order,
-  so the loss curve matches a blocking (``wait=True``) loop.
+* Training is a **sequential per-step loop** (mirrors tinker's
+  ``forward_backward_async`` / ``optim_step_async`` + ``.result()`` pattern):
+  each step submits ``forward_backward`` then ``optim_step`` with ``wait=False``
+  (the submits overlap and never block the loop) and then awaits both before the
+  next step. The per-step ``optim_step`` writes weights that the next step's
+  ``forward_backward`` reads, so the loss is printed each step and the curve
+  matches a blocking (``wait=True``) loop.
 * Sampling is **concurrent** — several prompts are sampled at once via
   ``asyncio.gather``; each ``await`` yields the loop instead of blocking it.
   Sampling requests are independent, so concurrency here is always correct.
@@ -43,7 +44,7 @@ from typing import Any, Dict, List
 
 import torch
 
-from weaver import AsyncOperationHandle, AsyncServiceClient, types
+from weaver import AsyncServiceClient, types
 
 EXAMPLES: List[Dict[str, str]] = [
     {"input": "banana split", "output": "anana-bay plit-say"},
@@ -111,30 +112,19 @@ async def main() -> None:
 
         processed_examples = [process_example(example, tokenizer) for example in EXAMPLES]
 
-        # --- Phase 1: submit ALL training ops without blocking -------------
-        # Each `await ...(wait=False)` only awaits the (fast) submit POST and
-        # returns a handle immediately. We fire every step's forward_backward
-        # and optim_step up front; the server executes them in seq order.
+        # --- Training: sequential per-step loop ---------------------------
+        # Each step submits forward_backward + optim_step without blocking
+        # (wait=False returns a handle right away, like tinker's *_async), then
+        # awaits both before the next step. optim_step writes the weights the
+        # next step's forward_backward reads, so steps stay strictly ordered.
         adam = types.AdamParams(learning_rate=1e-4)
-        fb_handles: List[AsyncOperationHandle] = []
-        optim_handles: List[AsyncOperationHandle] = []
-        for _ in range(NUM_STEPS):
-            fb_handles.append(
-                await training_client.forward_backward(
-                    processed_examples, "cross_entropy", wait=False
-                )
+        for step in range(NUM_STEPS):
+            fb_handle = await training_client.forward_backward(
+                processed_examples, "cross_entropy", wait=False
             )
-            optim_handles.append(await training_client.optim_step(adam, wait=False))
-        print(
-            f"Submitted {len(fb_handles)} forward_backward + {len(optim_handles)} optim_step "
-            "operations (none awaited yet)."
-        )
-
-        # --- Phase 2: await the in-flight results -------------------------
-        # wait_all awaits concurrently; the event loop is free the whole time.
-        fb_results = await AsyncOperationHandle.wait_all(fb_handles)
-        await AsyncOperationHandle.wait_all(optim_handles)
-        for step, fb_result in enumerate(fb_results):
+            optim_handle = await training_client.optim_step(adam, wait=False)
+            fb_result = await fb_handle  # loss for this step
+            await optim_handle  # ensure the update lands before the next step
             print(f"Step {step}: loss/token={_loss_per_token(fb_result, processed_examples):.4f}")
 
         # --- Phase 3: export weights and sample concurrently --------------

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -20,12 +20,8 @@ event loop stays free while the server works:
   all steps is submitted with ``wait=False`` (the submit returns an
   ``AsyncOperationHandle`` immediately, each carrying a monotonic ``seq_id``),
   then the handles are awaited together with ``AsyncOperationHandle.wait_all``.
-  The submits never block.
-  NOTE: pipelined training only matches a blocking (``wait=True``) loop when the
-  trainer applies ops in ``seq_id`` order. That ordering is currently NOT
-  honored server-side (the trainer aggregates a poll batch by task type), so a
-  pipelined loop under-converges today — tracked in weaver-server#364. Until
-  that lands, await each step (``wait=True``) for correct convergence.
+  The submits never block, and the trainer applies the ops in ``seq_id`` order,
+  so the loss curve matches a blocking (``wait=True``) loop.
 * Sampling is **concurrent** — several prompts are sampled at once via
   ``asyncio.gather``; each ``await`` yields the loop instead of blocking it.
   Sampling requests are independent, so concurrency here is always correct.

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -20,9 +20,10 @@ event loop stays free while the server works:
   ``optim_step`` is submitted up front with ``wait=False`` and fired together
   via ``asyncio.gather``; each op carries a monotonic ``seq_id`` (assigned in
   call order), so the trainer keeps the ``fb -> optim -> fb -> ...`` sequence
-  even though the requests arrive concurrently. The per-step losses are
-  collected at the end with a second ``asyncio.gather``. The submits never block
-  and the result matches a sequential (``wait=True``) loop.
+  even though the requests arrive concurrently. Each task submits and then
+  awaits its own result, so the per-step losses fall out of the same gather.
+  The submits never block and the result matches a sequential (``wait=True``)
+  loop.
 * Sampling is **concurrent** — several prompts are sampled at once via
   ``asyncio.gather``; each ``await`` yields the loop instead of blocking it.
   Sampling requests are independent, so concurrency here is always correct.
@@ -40,7 +41,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any, Dict, List
+from typing import Any, Awaitable, Dict, List
 
 import torch
 
@@ -113,21 +114,25 @@ async def main() -> None:
         processed_examples = [process_example(example, tokenizer) for example in EXAMPLES]
 
         # --- Training: submit every step at once, collect losses at the end -
-        # Fire all steps' forward_backward + optim_step concurrently with
-        # asyncio.gather (each wait=False submit returns a handle immediately).
-        # Every op carries a monotonic seq_id assigned in call order, so the
-        # trainer keeps the fb -> optim -> fb -> ... sequence even though the
-        # requests arrive concurrently; we just collect the per-step losses
-        # afterwards with a second gather.
+        # Fire all steps' forward_backward + optim_step concurrently with a
+        # single asyncio.gather: each task submits (wait=False returns a handle
+        # immediately) and then awaits its own result. Every op gets a monotonic
+        # seq_id assigned in call order (before the first await), so the trainer
+        # keeps the fb -> optim -> fb -> ... sequence even though the requests
+        # arrive concurrently.
         adam = types.AdamParams(learning_rate=1e-4)
+
+        async def submit_and_wait(submit: Awaitable[Any]) -> Any:
+            handle = await submit
+            return await handle.result()
+
         submits = []
         for _ in range(NUM_STEPS):
             submits.append(
                 training_client.forward_backward(processed_examples, "cross_entropy", wait=False)
             )
             submits.append(training_client.optim_step(adam, wait=False))
-        handles = await asyncio.gather(*submits)  # submit all concurrently
-        results = await asyncio.gather(*(h.result() for h in handles))  # collect all
+        results = await asyncio.gather(*(submit_and_wait(s) for s in submits))
         for step, fb_result in enumerate(results[0::2]):  # even indices = forward_backward
             print(f"Step {step}: loss/token={_loss_per_token(fb_result, processed_examples):.4f}")
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,225 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the asyncio client stack (AsyncAPIClient + AsyncOperationHandle)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from weaver import _async_http
+from weaver._async_http import AsyncAPIClient
+from weaver.config import WeaverConfig
+from weaver.operations import AsyncOperationHandle, WeaverOperationError
+
+
+@pytest.fixture()
+def config():
+    return WeaverConfig(base_url="https://test.example.com", api_key="sk-test")
+
+
+def _ok_response(payload):
+    resp = MagicMock()
+    resp.is_success = True
+    resp.status_code = 200
+    resp.content = b'{"ok": true}'
+    resp.json.return_value = payload
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# AsyncAPIClient retry behaviour (mirrors tests/test_http_retry.py)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRetry:
+    def test_post_no_retry_on_timeout(self, config, monkeypatch):
+        monkeypatch.setattr(_async_http, "compute_retry_delay", lambda attempt: 0.0)
+
+        async def run():
+            client = AsyncAPIClient(config, max_retries=3)
+            client._client = MagicMock()
+            client._client.headers = {}
+            client._client.request = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
+            with pytest.raises(httpx.ReadTimeout):
+                await client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
+            assert client._client.request.call_count == 1
+
+        asyncio.run(run())
+
+    def test_get_retries_until_default(self, config, monkeypatch):
+        monkeypatch.setattr(_async_http, "compute_retry_delay", lambda attempt: 0.0)
+
+        async def run():
+            client = AsyncAPIClient(config, max_retries=3)
+            client._client = MagicMock()
+            client._client.headers = {}
+            client._client.request = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
+            with pytest.raises(httpx.ReadTimeout):
+                await client.get("/api/v1/models/m1")
+            assert client._client.request.call_count == 3
+
+        asyncio.run(run())
+
+    def test_connection_error_retried_with_max_retries_1(self, config, monkeypatch):
+        monkeypatch.setattr(_async_http, "compute_retry_delay", lambda attempt: 0.0)
+
+        async def run():
+            client = AsyncAPIClient(config, max_retries=3)
+            client._client = MagicMock()
+            client._client.headers = {}
+            client._client.request = AsyncMock(
+                side_effect=[OSError(9, "Bad file descriptor"), _ok_response({"id": "op-1"})]
+            )
+            result = await client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
+            assert result == {"id": "op-1"}
+            assert client._client.request.call_count == 2
+
+        asyncio.run(run())
+
+    def test_post_success_after_connection_retry_default(self, config, monkeypatch):
+        monkeypatch.setattr(_async_http, "compute_retry_delay", lambda attempt: 0.0)
+
+        async def run():
+            client = AsyncAPIClient(config, max_retries=3)
+            client._client = MagicMock()
+            client._client.headers = {}
+            client._client.request = AsyncMock(
+                side_effect=[httpx.ConnectError("refused"), _ok_response({"ok": True})]
+            )
+            result = await client.post("/api/v1/sessions", json={})
+            assert result == {"ok": True}
+            assert client._client.request.call_count == 2
+
+        asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# AsyncOperationHandle
+# ---------------------------------------------------------------------------
+
+
+class _FakeAsyncClient:
+    """Async client stub that returns a scripted sequence of operation states."""
+
+    def __init__(self, states):
+        self._states = list(states)
+        self.get_calls = 0
+
+    async def get(self, path, *, params=None):
+        self.get_calls += 1
+        # Yield to the loop like a real network call would.
+        await asyncio.sleep(0)
+        return self._states[min(self.get_calls - 1, len(self._states) - 1)]
+
+
+class TestAsyncOperationHandle:
+    def test_result_polls_until_done(self, monkeypatch):
+        monkeypatch.setenv("WEAVER_OPERATION_POLL_INTERVAL", "0.01")
+
+        async def run():
+            client = _FakeAsyncClient(
+                [
+                    {"id": "op-1", "status": "running"},
+                    {"id": "op-1", "status": "done", "response": {"value": 42}},
+                ]
+            )
+            handle = AsyncOperationHandle(
+                client=client, operation_id="op-1", _cached={"id": "op-1", "status": "running"}
+            )
+            return await handle.result(), client.get_calls
+
+        result, calls = asyncio.run(run())
+        assert result == {"value": 42}
+        assert calls >= 2
+
+    def test_await_handle_directly(self, monkeypatch):
+        monkeypatch.setenv("WEAVER_OPERATION_POLL_INTERVAL", "0.01")
+
+        async def run():
+            client = _FakeAsyncClient([{"id": "op-1", "status": "done", "response": {"value": 7}}])
+            handle = AsyncOperationHandle(
+                client=client, operation_id="op-1", _cached={"id": "op-1", "status": "running"}
+            )
+            return await handle  # __await__ shorthand for .result()
+
+        assert asyncio.run(run()) == {"value": 7}
+
+    def test_error_status_raises(self, monkeypatch):
+        monkeypatch.setenv("WEAVER_OPERATION_POLL_INTERVAL", "0.01")
+
+        async def run():
+            client = _FakeAsyncClient([{"id": "op-1", "status": "error", "error": "boom"}])
+            handle = AsyncOperationHandle(
+                client=client, operation_id="op-1", _cached={"id": "op-1", "status": "running"}
+            )
+            with pytest.raises(WeaverOperationError):
+                await handle.result()
+
+        asyncio.run(run())
+
+    def test_await_yields_event_loop_to_other_coroutines(self, monkeypatch):
+        """The core requirement: awaiting a handle must not block the loop.
+
+        While the handle is polling (asyncio.sleep between refreshes), an
+        independent coroutine must get a chance to run.
+        """
+        monkeypatch.setenv("WEAVER_OPERATION_POLL_INTERVAL", "0.01")
+
+        async def run():
+            client = _FakeAsyncClient(
+                [
+                    {"id": "op-1", "status": "running"},
+                    {"id": "op-1", "status": "running"},
+                    {"id": "op-1", "status": "done", "response": "ok"},
+                ]
+            )
+            handle = AsyncOperationHandle(
+                client=client, operation_id="op-1", _cached={"id": "op-1", "status": "running"}
+            )
+
+            ticks = 0
+
+            async def ticker():
+                nonlocal ticks
+                while True:
+                    await asyncio.sleep(0.001)
+                    ticks += 1
+
+            task = asyncio.create_task(ticker())
+            result = await handle.result()
+            task.cancel()
+            return result, ticks
+
+        result, ticks = asyncio.run(run())
+        assert result == "ok"
+        assert ticks > 0  # the ticker ran concurrently while we awaited the handle
+
+    def test_wait_all_runs_concurrently(self, monkeypatch):
+        monkeypatch.setenv("WEAVER_OPERATION_POLL_INTERVAL", "0.01")
+
+        async def run():
+            handles = [
+                AsyncOperationHandle(
+                    client=_FakeAsyncClient([{"id": f"op-{i}", "status": "done", "response": i}]),
+                    operation_id=f"op-{i}",
+                    _cached={"id": f"op-{i}", "status": "running"},
+                )
+                for i in range(3)
+            ]
+            return await AsyncOperationHandle.wait_all(handles)
+
+        assert asyncio.run(run()) == [0, 1, 2]

--- a/tests/test_async_no_deadlock.py
+++ b/tests/test_async_no_deadlock.py
@@ -1,0 +1,227 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end deadlock/liveness tests for the async client over real sockets.
+
+Unlike the mocked tests, these drive ``AsyncServiceClient`` and
+``AsyncOperationHandle`` against a real threaded HTTP server with high
+concurrency, a live heartbeat task, and clean shutdown. Every test carries a
+hard ``pytest.mark.timeout`` plus an inner ``asyncio.wait_for`` so that a
+deadlock or an accidental blocking call FAILS the test instead of hanging.
+"""
+
+import asyncio
+import json
+import re
+import threading
+from collections import defaultdict
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from weaver.async_service_client import AsyncServiceClient
+from weaver.operations import AsyncOperationHandle
+
+# Operations report "running" for this many polls, then "done".
+_POLLS_TILL_DONE = 2
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Minimal stand-in for the Weaver operations API."""
+
+    # HTTP/1.1 enables keep-alive so httpx reuses connections instead of
+    # opening a fresh socket (and server thread) per request.
+    protocol_version = "HTTP/1.1"
+
+    polls: dict = defaultdict(int)
+    op_counter = 0
+    lock = threading.Lock()
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.polls = defaultdict(int)
+        cls.op_counter = 0
+
+    def _send(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib naming
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)
+        path = self.path
+
+        if path == "/api/v1/sessions":
+            return self._send(200, {"id": "sess-1"})
+        if path.endswith("/heartbeat"):
+            return self._send(200, {})
+        if re.match(r"/api/v1/sessions/[^/]+/models$", path):
+            return self._send(200, {"id": "model-1", "base_model": "x"})
+        if path.endswith("/terminate"):
+            return self._send(200, {})
+
+        # Anything else is an operation submission.
+        with _Handler.lock:
+            _Handler.op_counter += 1
+            op_id = f"op-{_Handler.op_counter}"
+        return self._send(200, {"id": op_id, "status": "running"})
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib naming
+        match = re.match(r"/api/v1/operations/(.+)", self.path)
+        if match:
+            op_id = match.group(1)
+            with _Handler.lock:
+                _Handler.polls[op_id] += 1
+                count = _Handler.polls[op_id]
+            if count >= _POLLS_TILL_DONE:
+                return self._send(200, {"id": op_id, "status": "done", "response": {"op": op_id}})
+            return self._send(200, {"id": op_id, "status": "running"})
+        if self.path == "/api/v1/supported-models":
+            return self._send(200, {"items": []})
+        return self._send(404, {})
+
+    def log_message(self, *_args, **_kwargs) -> None:  # silence test noise
+        return
+
+
+@pytest.fixture()
+def server(monkeypatch):
+    monkeypatch.setenv("WEAVER_OPERATION_POLL_INTERVAL", "0.02")
+    _Handler.reset()
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    host, port = httpd.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2.0)
+
+
+def _svc(base_url: str, **kwargs) -> AsyncServiceClient:
+    return AsyncServiceClient(base_url=base_url, api_key="sk-test", **kwargs)
+
+
+@pytest.mark.timeout(30)
+def test_high_concurrency_no_deadlock(server):
+    """200 operations submitted and awaited concurrently must all complete."""
+
+    async def run():
+        async with _svc(server, heartbeat_interval=0.05) as svc:
+            handles = await asyncio.wait_for(
+                asyncio.gather(
+                    *[svc.enqueue_operation("/op/submit", {"i": i}) for i in range(200)]
+                ),
+                timeout=20,
+            )
+            results = await asyncio.wait_for(
+                asyncio.gather(*[h.result() for h in handles]), timeout=20
+            )
+            return results
+
+    results = asyncio.run(run())
+    assert len(results) == 200
+    assert all(r["op"].startswith("op-") for r in results)
+    assert len({r["op"] for r in results}) == 200  # no cross-talk between ops
+
+
+@pytest.mark.timeout(30)
+def test_event_loop_stays_responsive_under_load(server):
+    """A high-frequency ticker keeps advancing while 50 ops are in flight.
+
+    If any blocking call sneaks into the async path, the loop would stall and
+    the ticker would barely advance.
+    """
+
+    async def run():
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.001)
+                ticks += 1
+
+        async with _svc(server, heartbeat_interval=0.05) as svc:
+            task = asyncio.create_task(ticker())
+            handles = await asyncio.gather(
+                *[svc.enqueue_operation("/op/submit", {}) for _ in range(50)]
+            )
+            await asyncio.wait_for(asyncio.gather(*[h.result() for h in handles]), timeout=20)
+            task.cancel()
+            return ticks
+
+    ticks = asyncio.run(run())
+    assert ticks > 20  # the loop ran the ticker many times during the awaits
+
+
+@pytest.mark.timeout(30)
+def test_same_handle_awaited_concurrently(server):
+    """Awaiting the same handle from two coroutines must not deadlock."""
+
+    async def run():
+        async with _svc(server) as svc:
+            handle = await svc.enqueue_operation("/op/submit", {})
+            return await asyncio.wait_for(
+                asyncio.gather(handle.result(), handle.result()), timeout=20
+            )
+
+    a, b = asyncio.run(run())
+    assert a == b
+
+
+@pytest.mark.timeout(30)
+def test_wait_all_concurrent(server):
+    async def run():
+        async with _svc(server) as svc:
+            handles = await asyncio.gather(
+                *[svc.enqueue_operation("/op/submit", {}) for _ in range(20)]
+            )
+            return await asyncio.wait_for(AsyncOperationHandle.wait_all(handles), timeout=20)
+
+    results = asyncio.run(run())
+    assert len(results) == 20
+
+
+@pytest.mark.timeout(30)
+def test_lifecycle_create_model_and_shutdown(server):
+    """connect -> create_model -> aclose (terminate + heartbeat cancel) must not hang."""
+
+    async def run():
+        async with _svc(server, heartbeat_interval=0.05) as svc:
+            tc = await svc.create_model(base_model="x")
+            assert tc.model_id == "model-1"
+            # let the heartbeat fire a few times concurrently
+            await asyncio.sleep(0.15)
+        return True
+
+    assert asyncio.run(run()) is True
+
+
+@pytest.mark.timeout(30)
+def test_double_aclose_is_idempotent(server):
+    async def run():
+        svc = _svc(server, heartbeat_interval=0.05)
+        await svc.connect()
+        await svc.aclose()
+        await svc.aclose()  # second close must be a no-op, not a hang
+        return True
+
+    assert asyncio.run(run()) is True

--- a/weaver/__init__.py
+++ b/weaver/__init__.py
@@ -24,7 +24,19 @@ except Exception:
     __version__ = "0.3.0"
 
 from . import types  # noqa: F401
-from .operations import OperationHandle  # noqa: F401
+from .async_sampling_client import AsyncSamplingClient  # noqa: F401
+from .async_service_client import AsyncServiceClient  # noqa: F401
+from .async_training_client import AsyncTrainingClient  # noqa: F401
+from .operations import AsyncOperationHandle, OperationHandle  # noqa: F401
 from .service_client import ServiceClient  # noqa: F401
 
-__all__ = ["ServiceClient", "OperationHandle", "types", "__version__"]
+__all__ = [
+    "ServiceClient",
+    "OperationHandle",
+    "AsyncServiceClient",
+    "AsyncTrainingClient",
+    "AsyncSamplingClient",
+    "AsyncOperationHandle",
+    "types",
+    "__version__",
+]

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -1,0 +1,288 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async HTTP client for interacting with the Weaver server.
+
+This is the asyncio twin of :class:`weaver._http.APIClient`. It mirrors the
+retry, connection-error, trace-propagation and fork-safety behaviour of the
+synchronous client, but every blocking point (the network round trip and the
+backoff sleeps) is awaited so the event loop stays free for other coroutines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Mapping, MutableMapping
+
+import httpx
+from opentelemetry import baggage, context, trace
+from opentelemetry.propagate import inject
+from opentelemetry.trace import Status, StatusCode
+
+from ._http import (
+    DEFAULT_CONNECTION_LIMITS,
+    DEFAULT_CONNECTION_RETRIES,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_TIMEOUT,
+    USER_AGENT,
+    WeaverAPIError,
+    _is_connection_error,
+    apply_request_span_attributes,
+    compute_retry_delay,
+    extract_model_id_from_path,
+    raise_for_response,
+)
+from ._telemetry import get_tracer
+from .config import WeaverConfig
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncAPIClient:
+    """Thin wrapper around ``httpx.AsyncClient`` with Weaver-specific behaviour."""
+
+    def __init__(
+        self,
+        config: WeaverConfig,
+        *,
+        timeout: httpx.Timeout | float | None = None,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ):
+        self._base_url = config.base_url.rstrip("/")
+        headers: MutableMapping[str, str] = {"User-Agent": USER_AGENT}
+        if config.api_key:
+            headers["X-WEAVER-API-KEY"] = config.api_key
+        self._headers = headers
+        self._timeout = timeout or DEFAULT_TIMEOUT
+
+        self._client = self._build_client()
+        self._pid = os.getpid()
+        self._max_retries = max_retries
+
+        self._tracer = get_tracer()
+
+    def _build_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=self._timeout,
+            headers=self._headers,
+            limits=DEFAULT_CONNECTION_LIMITS,
+        )
+
+    def _ensure_fresh_client(self) -> None:
+        """Rebuild the underlying client if the process changed (post-fork).
+
+        See :meth:`weaver._http.APIClient._ensure_fresh_client` for the
+        rationale. The inherited client is dropped without ``aclose()`` because
+        its socket FDs belong to the parent process.
+        """
+        current_pid = os.getpid()
+        if current_pid == self._pid:
+            return
+        self._client = self._build_client()
+        self._pid = current_pid
+
+    async def __aenter__(self) -> "AsyncAPIClient":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        # Only close the client in the process that created it; closing a
+        # fork-inherited client would write shutdown bytes over the parent's FDs.
+        if os.getpid() == self._pid:
+            await self._client.aclose()
+
+    async def get(self, path: str, *, params: Mapping[str, Any] | None = None) -> Any:
+        return await self._request("GET", path, params=params)
+
+    async def post(self, path: str, *, json: Any = None, max_retries: int | None = None) -> Any:
+        return await self._request("POST", path, json=json, max_retries=max_retries)
+
+    async def patch(self, path: str, *, json: Any) -> Any:
+        return await self._request("PATCH", path, json=json)
+
+    async def delete(self, path: str) -> Any:
+        return await self._request("DELETE", path)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        json: Any = None,
+        max_retries: int | None = None,
+    ) -> Any:
+        model_id = extract_model_id_from_path(path)
+
+        ctx = context.get_current()
+        if model_id:
+            ctx = baggage.set_baggage("model_id", model_id, context=ctx)
+
+        with self._tracer.start_as_current_span(
+            f"weaver.{method.lower()}",
+            context=ctx,
+            kind=trace.SpanKind.CLIENT,
+        ) as span:
+            apply_request_span_attributes(span, method, path, model_id)
+            return await self._request_with_retries(
+                span, method, path, params=params, json=json, max_retries=max_retries
+            )
+
+    async def _request_with_retries(
+        self,
+        span: trace.Span,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        json: Any = None,
+        max_retries: int | None = None,
+    ) -> Any:
+        """Async mirror of :meth:`APIClient._request_with_retries`.
+
+        Connection-level errors are retried up to ``DEFAULT_CONNECTION_RETRIES``
+        regardless of *max_retries* (the request never reached the server, so it
+        is safe even for non-idempotent methods). Server-declared retryable
+        errors are retried only for idempotent methods.
+        """
+        effective_max_retries = max_retries if max_retries is not None else self._max_retries
+        last_exception: Exception | None = None
+        request_attempt = 0
+        connection_error_count = 0
+
+        while request_attempt < effective_max_retries:
+            try:
+                self._ensure_fresh_client()
+
+                headers = dict(self._client.headers or {})
+                inject(headers)  # Adds 'traceparent' header with trace context
+
+                response = await self._client.request(
+                    method, path, params=params, json=json, headers=headers
+                )
+
+                span.set_attribute("http.status_code", response.status_code)
+
+                if response.is_success:
+                    span.set_status(Status(StatusCode.OK))
+                    if response.status_code == httpx.codes.NO_CONTENT:
+                        return None
+                    if not response.content:
+                        return None
+                    return response.json()
+
+                span.set_status(Status(StatusCode.ERROR, f"HTTP {response.status_code}"))
+                raise_for_response(response)
+
+            except WeaverAPIError as e:
+                last_exception = e
+                span.record_exception(e)
+                request_attempt += 1
+                is_last_attempt = request_attempt >= effective_max_retries
+                idempotent_method = method.upper() in {"GET", "HEAD", "OPTIONS"}
+
+                if (not e.retryable) or (not idempotent_method) or is_last_attempt:
+                    span.set_status(Status(StatusCode.ERROR, "API error"))
+                    raise
+
+                logger.debug(
+                    "Retryable API error (attempt %d/%d): %s %s - [%d] %s: %s",
+                    request_attempt,
+                    effective_max_retries,
+                    method,
+                    path,
+                    e.status_code,
+                    e.code,
+                    e.message,
+                )
+                await asyncio.sleep(compute_retry_delay(request_attempt))
+
+            except Exception as e:  # pylint: disable=broad-except
+                last_exception = e
+                span.record_exception(e)
+
+                if _is_connection_error(e):
+                    connection_error_count += 1
+
+                    logger.debug(
+                        "Connection error (attempt %d/%d): %s %s - %s: %s",
+                        connection_error_count,
+                        DEFAULT_CONNECTION_RETRIES,
+                        method,
+                        path,
+                        type(e).__name__,
+                        str(e),
+                    )
+
+                    if connection_error_count >= DEFAULT_CONNECTION_RETRIES:
+                        span.set_status(
+                            Status(
+                                StatusCode.ERROR,
+                                f"Connection failed after {connection_error_count} attempts",
+                            )
+                        )
+                        logger.error(
+                            "Connection error after %d attempts: %s %s - %s",
+                            connection_error_count,
+                            method,
+                            path,
+                            str(e),
+                        )
+                        raise
+
+                    delay = compute_retry_delay(connection_error_count)
+                    logger.debug("Retrying in %.1fs...", delay)
+                    await asyncio.sleep(delay)
+                    continue
+
+                request_attempt += 1
+                is_last_attempt = request_attempt >= effective_max_retries
+
+                if is_last_attempt:
+                    span.set_status(
+                        Status(StatusCode.ERROR, f"Failed after {effective_max_retries} retries")
+                    )
+
+                logger.debug(
+                    "HTTP request failed (attempt %d/%d): %s %s - %s: %s",
+                    request_attempt,
+                    effective_max_retries,
+                    method,
+                    path,
+                    type(e).__name__,
+                    str(e),
+                )
+
+                if is_last_attempt:
+                    logger.error(
+                        "HTTP request failed after %d retries: %s %s - %s",
+                        effective_max_retries,
+                        method,
+                        path,
+                        str(e),
+                    )
+                    raise
+
+                delay = compute_retry_delay(request_attempt)
+                logger.debug("Retrying in %.1fs...", delay)
+                await asyncio.sleep(delay)
+
+        if last_exception:
+            raise last_exception
+        raise RuntimeError("Unexpected retry loop exit")

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -82,6 +82,61 @@ class WeaverAPIError(RuntimeError):
         self.retryable = retryable
 
 
+def extract_model_id_from_path(path: str) -> str | None:
+    """Extract ``model_id`` from an API path for trace/baggage propagation.
+
+    Patterns:
+    - ``/api/v1/models/{model_id}/...``
+    - ``/api/v1/models/{model_id}``
+
+    Returns:
+        model_id if found, None otherwise.
+    """
+    match = re.match(r"/api/v\d+/models/([^/]+)", path)
+    if match:
+        return match.group(1)
+    return None
+
+
+def raise_for_response(response: httpx.Response) -> None:
+    """Convert a non-success httpx response into a :class:`WeaverAPIError`."""
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {}
+    raise WeaverAPIError(
+        response.status_code,
+        code=payload.get("error", "unknown_error"),
+        message=payload.get("message", response.text),
+        retryable=bool(payload.get("retryable", False)),
+    )
+
+
+def apply_request_span_attributes(
+    span: trace.Span, method: str, path: str, model_id: str | None
+) -> None:
+    """Set the standard Weaver request attributes on *span* (shared sync/async)."""
+    span.set_attribute("http.method", method)
+    span.set_attribute("http.url", path)
+    span.set_attribute("http.user_agent", USER_AGENT)
+    if model_id:
+        span.set_attribute("model_id", model_id)
+        span.set_attribute("weaver.model_id", model_id)  # Alternative key
+
+    span_context = span.get_span_context()
+    if span_context.is_valid:
+        trace_id = format(span_context.trace_id, "032x")
+        if model_id:
+            logger.debug("API request trace_id: %s, model_id: %s", trace_id, model_id)
+        else:
+            logger.debug("API request trace_id: %s", trace_id)
+
+
+def compute_retry_delay(attempt: int) -> float:
+    """Exponential backoff delay for retry *attempt* (1-based)."""
+    return min(INITIAL_RETRY_DELAY * (2 ** (attempt - 1)), MAX_RETRY_DELAY)
+
+
 class APIClient:
     """Thin wrapper around httpx.Client with Weaver-specific behavior."""
 
@@ -208,21 +263,7 @@ class APIClient:
             )
 
     def _extract_model_id_from_path(self, path: str) -> str | None:
-        """
-        Extract model_id from API path.
-
-        Patterns:
-        - /api/v1/models/{model_id}/...
-        - /api/v1/models/{model_id}
-
-        Returns:
-            model_id if found, None otherwise
-        """
-        # Match /api/v1/models/{model_id}/... or /api/v1/models/{model_id}
-        match = re.match(r"/api/v\d+/models/([^/]+)", path)
-        if match:
-            return match.group(1)
-        return None
+        return extract_model_id_from_path(path)
 
     def _request_with_retries(
         self,
@@ -395,16 +436,7 @@ class APIClient:
         raise RuntimeError("Unexpected retry loop exit")
 
     def _raise_error(self, response: httpx.Response) -> None:
-        try:
-            payload = response.json()
-        except ValueError:
-            payload = {}
-        raise WeaverAPIError(
-            response.status_code,
-            code=payload.get("error", "unknown_error"),
-            message=payload.get("message", response.text),
-            retryable=bool(payload.get("retryable", False)),
-        )
+        raise_for_response(response)
 
 
 def backoff_delays(

--- a/weaver/_payloads.py
+++ b/weaver/_payloads.py
@@ -1,0 +1,154 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure request/response helpers shared by the sync and async clients.
+
+Keeping these IO-free and tokenizer-free means the synchronous and asyncio
+client implementations build identical payloads from a single source of truth.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Sequence
+
+from .types import Datum
+
+if TYPE_CHECKING:
+    import torch
+
+    from .types.router_replay import RouterReplayMetadata
+
+
+def build_request_metadata(
+    metadata: Mapping[str, Any] | None,
+    router_replay: "RouterReplayMetadata | Mapping[str, Any] | None",
+) -> Dict[str, Any] | None:
+    """Validate and normalize top-level request metadata.
+
+    Router replay metadata must be attached per-:class:`~weaver.types.Datum`
+    (``datum.metadata["router_replay"]``); passing it at the request level is a
+    hard error.
+    """
+    if router_replay is not None:
+        raise ValueError(
+            "router_replay= is no longer accepted at request level. "
+            "Attach router replay metadata to each Datum via "
+            "datum.metadata['router_replay']."
+        )
+    if not metadata and router_replay is None:
+        return None
+
+    payload = dict(metadata or {})
+    if "router_replay" in payload:
+        raise ValueError(
+            "metadata['router_replay'] is no longer accepted at request level. "
+            "Attach router replay metadata to each Datum via "
+            "datum.metadata['router_replay']."
+        )
+    return payload or None
+
+
+def serialize_data(data: Sequence[Datum]) -> List[Dict[str, Any]]:
+    return [datum.to_payload() for datum in data]
+
+
+def forward_payload(
+    *,
+    model_id: str,
+    seq_id: int,
+    data: Sequence[Datum],
+    loss_fn: str,
+    loss_fn_config: Mapping[str, Any] | None,
+    request_metadata: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "model_id": model_id,
+        "seq_id": seq_id,
+        "forward_input": {"loss_fn": loss_fn, "data": serialize_data(data)},
+    }
+    if loss_fn_config:
+        payload["forward_input"]["loss_fn_config"] = dict(loss_fn_config)
+    if request_metadata:
+        payload["metadata"] = request_metadata
+    return payload
+
+
+def forward_backward_payload(
+    *,
+    model_id: str,
+    seq_id: int,
+    data: Sequence[Datum],
+    loss_fn: str,
+    loss_fn_config: Mapping[str, Any] | None,
+    request_metadata: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "model_id": model_id,
+        "seq_id": seq_id,
+        "forward_backward_input": {"loss_fn": loss_fn, "data": serialize_data(data)},
+    }
+    if loss_fn_config:
+        payload["forward_backward_input"]["loss_fn_config"] = dict(loss_fn_config)
+    if request_metadata:
+        payload["metadata"] = request_metadata
+    return payload
+
+
+def parse_logprob_tensors(
+    fwd_result: Dict[str, Any], data: Sequence[Datum]
+) -> List["torch.Tensor"]:
+    """Extract per-datum logprob tensors (``requires_grad=True``) from a forward result."""
+    import torch
+
+    outputs = fwd_result.get("result", {}).get("loss_fn_outputs", [])
+    if not outputs:
+        raise ValueError("Forward pass returned no loss_fn_outputs")
+    if len(outputs) != len(data):
+        raise ValueError(f"Expected {len(data)} loss_fn_outputs, got {len(outputs)}")
+
+    logprob_tensors: List[torch.Tensor] = []
+    for output in outputs:
+        lp = output.get("logprobs") or output.get("Logprobs")
+        if isinstance(lp, dict):
+            lp = lp["data"]
+        if lp is None:
+            raise ValueError("Missing logprobs in forward/backward output")
+        logprob_tensors.append(torch.tensor(lp, dtype=torch.float32).requires_grad_(True))
+    return logprob_tensors
+
+
+def build_surrogate_data(
+    data: Sequence[Datum], logprob_tensors: Sequence["torch.Tensor"]
+) -> List[Datum]:
+    """Build surrogate :class:`~weaver.types.Datum` objects carrying gradient weights."""
+    surrogate_data: List[Datum] = []
+    for i, (datum, logprob_tensor) in enumerate(zip(data, logprob_tensors)):
+        if logprob_tensor.grad is None:
+            raise ValueError(f"logprob_tensors[{i}] has no gradient after backward")
+
+        raw_targets = datum.loss_fn_inputs.get("target_tokens")
+        if raw_targets is None:
+            resolved_targets: List[Any] = datum.model_input.to_ints()
+        elif hasattr(raw_targets, "tolist"):
+            resolved_targets = raw_targets.tolist()
+        else:
+            resolved_targets = list(raw_targets)
+
+        loss_fn_inputs: Dict[str, Any] = dict(datum.loss_fn_inputs)
+        loss_fn_inputs["target_tokens"] = resolved_targets
+        loss_fn_inputs["surrogate_weights"] = logprob_tensor.grad.detach().tolist()
+        surrogate_data.append(
+            Datum.from_raw(model_input=datum.model_input, loss_fn_inputs=loss_fn_inputs)
+        )
+    return surrogate_data

--- a/weaver/_sampling_utils.py
+++ b/weaver/_sampling_utils.py
@@ -1,0 +1,209 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sampling request/response helpers shared by the sync and async clients.
+
+Result normalization needs a tokenizer only to decode token ids or encode
+choice text, so these helpers take a ``get_tokenizer`` callable rather than
+owning one. The callable is invoked lazily, only when decoding is required.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+from transformers.tokenization_utils import PreTrainedTokenizer
+
+from ._utils import lookup_case_insensitive
+from .types import LogprobsParams, ModelInput, SamplingParams
+
+TokenizerProvider = Callable[[], PreTrainedTokenizer]
+
+
+def build_sample_body(
+    *,
+    prompt: ModelInput,
+    sampling_params: SamplingParams | None,
+    num_samples: int,
+    include_prompt_logprobs: bool,
+    topk_prompt_logprobs: int,
+    return_sampling_mask: bool,
+    return_old_logprob: bool,
+    return_moe_topk_indices: bool,
+) -> Dict[str, Any]:
+    params = sampling_params or SamplingParams()
+    body: Dict[str, Any] = {
+        "prompt": prompt.to_payload(),
+        "sampling_params": params.to_payload(),
+        "num_samples": num_samples,
+        "prompt_logprobs": include_prompt_logprobs,
+        "topk_prompt_logprobs": topk_prompt_logprobs,
+    }
+    if return_sampling_mask:
+        body["return_sampling_mask"] = True
+    if return_old_logprob:
+        body["return_old_logprob"] = True
+    if return_moe_topk_indices:
+        body["return_moe_topk_indices"] = True
+    return body
+
+
+def build_logprobs_body(
+    prompt: ModelInput, logprobs_params: LogprobsParams | None
+) -> Dict[str, Any]:
+    params = logprobs_params or LogprobsParams()
+    return {"prompt": prompt.to_payload(), **params.to_payload()}
+
+
+def sanitize_tokens(value: Any) -> List[int]:
+    if not isinstance(value, list):
+        return []
+    tokens: List[int] = []
+    for item in value:
+        try:
+            tokens.append(int(item))
+        except (TypeError, ValueError):
+            continue
+    return tokens
+
+
+def choice_text(choice: Any) -> str | None:
+    if not isinstance(choice, dict):
+        return None
+    message = choice.get("message")
+    if isinstance(message, dict):
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+    text = choice.get("text")
+    if isinstance(text, str) and text.strip():
+        return text
+    return None
+
+
+def coerce_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def result_payload(payload: Any) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    result = lookup_case_insensitive(payload, "result")
+    if isinstance(result, dict):
+        return result
+    return {}
+
+
+def coerce_prompt_logprob_list(value: Any, expected: int) -> List[float | None] | None:
+    if not isinstance(value, list):
+        return None
+    normalized: List[float | None] = []
+    for item in value:
+        if item is None:
+            normalized.append(None)
+            continue
+        normalized.append(coerce_float(item))
+    if expected > 0 and len(normalized) == expected:
+        return normalized
+    if normalized:
+        return normalized
+    return None
+
+
+def prompt_tokens(prompt: ModelInput) -> List[int]:
+    try:
+        return prompt.to_ints()
+    except ValueError:
+        tokens: List[int] = []
+        for chunk in prompt.chunks:
+            tokens.extend(int(token) for token in chunk.tokens)
+        return tokens
+
+
+def sequences_from_result(
+    result: Dict[str, Any], get_tokenizer: TokenizerProvider
+) -> List[Dict[str, Any]]:
+    existing_sequences = result.get("sequences")
+    sequences: List[Dict[str, Any]] = []
+    if isinstance(existing_sequences, list):
+        tokenizer: Optional[PreTrainedTokenizer] = None
+        for raw in existing_sequences:
+            if not isinstance(raw, dict):
+                continue
+            tokens = sanitize_tokens(raw.get("tokens"))
+            text = raw.get("text")
+            if text is None and tokens:
+                tokenizer = tokenizer or get_tokenizer()
+                text = tokenizer.decode(tokens, skip_special_tokens=False)
+            sequence: Dict[str, Any] = {
+                "tokens": tokens,
+                "text": text,
+                "stop_reason": raw.get("stop_reason"),
+            }
+            if "logprobs" in raw and isinstance(raw["logprobs"], list):
+                sequence["logprobs"] = raw["logprobs"]
+            if "old_logprobs" in raw and isinstance(raw["old_logprobs"], list):
+                sequence["old_logprobs"] = raw["old_logprobs"]
+            if "sampling_masks" in raw and raw["sampling_masks"] is not None:
+                sequence["sampling_masks"] = raw["sampling_masks"]
+            if "moe_topk_indices" in raw and raw["moe_topk_indices"] is not None:
+                sequence["moe_topk_indices"] = raw["moe_topk_indices"]
+            sequences.append(sequence)
+        return [seq for seq in sequences if seq["tokens"]]
+
+    choices = result.get("choices")
+    if not isinstance(choices, list):
+        return []
+    tokenizer = get_tokenizer()
+    for choice in choices:
+        text = choice_text(choice)
+        if text is None:
+            continue
+        tokens = tokenizer.encode(text, add_special_tokens=False)
+        stop_reason = choice.get("finish_reason") or choice.get("finishReason")
+        sequences.append({"tokens": tokens, "text": text, "stop_reason": stop_reason})
+    return sequences
+
+
+def normalize_sample_result(payload: Any, get_tokenizer: TokenizerProvider) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+    if "sequences" in payload:
+        return payload
+    result = lookup_case_insensitive(payload, "result")
+    if not isinstance(result, dict):
+        return payload
+    sequences = sequences_from_result(result, get_tokenizer)
+    normalized = dict(payload)
+    if sequences:
+        normalized["sequences"] = sequences
+    normalized["raw_result"] = result
+    usage = result.get("usage")
+    if usage:
+        normalized["usage"] = usage
+    return normalized
+
+
+def normalize_prompt_logprobs(prompt: ModelInput, payload: Any) -> List[float | None]:
+    tokens = prompt_tokens(prompt)
+    if not tokens:
+        return []
+    result = result_payload(payload)
+    prompt_values = coerce_prompt_logprob_list(result.get("prompt_logprobs"), len(tokens))
+    if prompt_values is None:
+        raise RuntimeError("trainer response missing prompt_logprobs")
+    return prompt_values

--- a/weaver/async_sampling_client.py
+++ b/weaver/async_sampling_client.py
@@ -12,26 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Sampling client for inference requests."""
+"""Asyncio-native sampling client for inference requests."""
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, overload
 
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from . import _sampling_utils as _su
 from ._utils import lookup_case_insensitive
-from .operations import OperationHandle
-from .service_client import ServiceClient
+from .async_service_client import AsyncServiceClient
+from .operations import AsyncOperationHandle
 from .types import LogprobsParams, ModelInput, SamplingParams
 
+if TYPE_CHECKING:
+    from typing import Literal
 
-class SamplingClient:
+
+class AsyncSamplingClient:
     def __init__(
         self,
         *,
-        service: ServiceClient,
+        service: AsyncServiceClient,
         sampling_session_id: str,
         base_model: str | None = None,
         model_path: str | None = None,
@@ -46,7 +49,37 @@ class SamplingClient:
         self.tokenizer_path = tokenizer_path
         self._tokenizer: PreTrainedTokenizer | None = None
 
-    def sample(
+    @overload
+    async def sample(
+        self,
+        *,
+        prompt: ModelInput,
+        sampling_params: SamplingParams | None = None,
+        num_samples: int = 1,
+        include_prompt_logprobs: bool = False,
+        topk_prompt_logprobs: int = 0,
+        return_sampling_mask: bool = False,
+        return_old_logprob: bool = False,
+        return_moe_topk_indices: bool = False,
+        wait: "Literal[True]" = True,
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    async def sample(
+        self,
+        *,
+        prompt: ModelInput,
+        sampling_params: SamplingParams | None = None,
+        num_samples: int = 1,
+        include_prompt_logprobs: bool = False,
+        topk_prompt_logprobs: int = 0,
+        return_sampling_mask: bool = False,
+        return_old_logprob: bool = False,
+        return_moe_topk_indices: bool = False,
+        wait: "Literal[False]",
+    ) -> AsyncOperationHandle: ...
+
+    async def sample(
         self,
         *,
         prompt: ModelInput,
@@ -58,7 +91,7 @@ class SamplingClient:
         return_old_logprob: bool = False,
         return_moe_topk_indices: bool = False,
         wait: bool = True,
-    ) -> OperationHandle | Dict[str, Any]:
+    ) -> AsyncOperationHandle | Dict[str, Any]:
         body = _su.build_sample_body(
             prompt=prompt,
             sampling_params=sampling_params,
@@ -69,16 +102,19 @@ class SamplingClient:
             return_old_logprob=return_old_logprob,
             return_moe_topk_indices=return_moe_topk_indices,
         )
-        handle = self._service.enqueue_operation(
+        handle = await self._service.enqueue_operation(
             f"/api/v1/sampling-sessions/{self.sampling_session_id}/samples",
             body,
         )
         if not wait:
             return handle
-        raw_result = handle.result()
+        raw_result = await handle.result()
+        # Resolve the tokenizer source up front so result normalization (which
+        # may need to decode token ids) stays synchronous.
+        await self._ensure_tokenizer_source()
         return _su.normalize_sample_result(raw_result, self._ensure_tokenizer)  # type: ignore[return-value]
 
-    def compute_logprobs(
+    async def compute_logprobs(
         self,
         *,
         prompt: ModelInput,
@@ -86,30 +122,15 @@ class SamplingClient:
     ) -> List[float | None] | Dict[str, Any]:
         """Compute log-probabilities for the given prompt.
 
-        The sampling-client contract is prompt-token-aligned: the returned list
-        has length ``len(prompt_tokens)``, and index 0 is ``None`` because the
-        first token has no previous token context to score. This differs from
-        trainer-side ``forward_logprob`` tasks, which score explicit
-        ``target_tokens`` and return one logprob per target token, with no
-        leading placeholder.
-
-        Args:
-            prompt: The model input (tokens) to compute logprobs for.
-            logprobs_params: Optional parameters (e.g. return_rollout_token_expert for MoE router replay).
-                When None, uses defaults.
-
-        Returns:
-            When logprobs_params.return_rollout_token_expert=False: List[float|None] of per-token logprobs.
-            When logprobs_params.return_rollout_token_expert=True: Dict with "logprobs" and
-                "return_rollout_token_expert_data" (None if not MoE or not available).
+        See :meth:`weaver.sampling_client.SamplingClient.compute_logprobs`.
         """
         params = logprobs_params or LogprobsParams()
         body = _su.build_logprobs_body(prompt, params)
-        handle = self._service.enqueue_operation(
+        handle = await self._service.enqueue_operation(
             f"/api/v1/sampling-sessions/{self.sampling_session_id}/logprobs",
             body,
         )
-        payload = handle.result()
+        payload = await handle.result()
         logprobs = _su.normalize_prompt_logprobs(prompt, payload)
         if not params.return_rollout_token_expert:
             return logprobs
@@ -119,34 +140,32 @@ class SamplingClient:
             "return_rollout_token_expert_data": result.get("return_rollout_token_expert_data"),
         }
 
-    def _normalize_sample_result(self, payload: Any) -> Any:
-        return _su.normalize_sample_result(payload, self._ensure_tokenizer)
-
-    def _ensure_tokenizer(self) -> PreTrainedTokenizer:
-        if self._tokenizer is not None:
-            return self._tokenizer
-        from transformers import AutoTokenizer
-
-        # Use custom tokenizer_path if provided, otherwise use base_model
-        if self.tokenizer_path:
-            model_name_or_path = self.tokenizer_path
-        else:
-            model_name_or_path = self._ensure_base_model()
-
-        self._tokenizer = AutoTokenizer.from_pretrained(
-            model_name_or_path,
-            trust_remote_code=True,
+    async def _ensure_tokenizer_source(self) -> None:
+        """Make sure a tokenizer path or base_model is known (may fetch the session)."""
+        if self.tokenizer_path or self.base_model:
+            return
+        session = await self._service.http.get(
+            f"/api/v1/sampling-sessions/{self.sampling_session_id}"
         )
-        return self._tokenizer
-
-    def _ensure_base_model(self) -> str:
-        if self.base_model:
-            return self.base_model
-        session = self._service.http.get(f"/api/v1/sampling-sessions/{self.sampling_session_id}")
         base_model = lookup_case_insensitive(session, "base_model") or lookup_case_insensitive(
             session, "base_model_name"
         )
         if not base_model:
             raise RuntimeError("sampling session is missing base_model")
         self.base_model = str(base_model)
-        return self.base_model
+
+    def _ensure_tokenizer(self) -> PreTrainedTokenizer:
+        if self._tokenizer is not None:
+            return self._tokenizer
+        from transformers import AutoTokenizer
+
+        model_name_or_path = self.tokenizer_path or self.base_model
+        if not model_name_or_path:
+            raise RuntimeError(
+                "tokenizer source unresolved; base_model or tokenizer_path is required"
+            )
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            model_name_or_path,
+            trust_remote_code=True,
+        )
+        return self._tokenizer

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -24,6 +24,36 @@ Usage::
         tc = await svc.create_model(base_model="Qwen/Qwen3-8B")
         await tc.forward_backward(data, "cross_entropy")
         await tc.optim_step(AdamParams(learning_rate=1e-4))
+
+Event loop model
+----------------
+The client **owns no event loop**. It never calls ``asyncio.run``,
+``new_event_loop`` or ``run_until_complete`` — it is just coroutines plus an
+``httpx.AsyncClient`` and runs on whatever loop is active when you ``await`` it.
+
+**One client instance is bound to one event loop and one thread.** The binding
+happens on the first call (``connect()``): the ``httpx.AsyncClient`` connection
+pool and the heartbeat ``asyncio.Task`` both attach to the loop running then.
+Do **not** share a single instance across loops or threads.
+
+Integrating without hangs:
+
+* **Inside an existing async app** (FastAPI / Starlette / aiohttp / Jupyter):
+  you already have a running loop, so ``await`` the client directly — do **not**
+  call ``asyncio.run`` (it raises "cannot be called from a running event loop").
+  Create the client once at startup, reuse it for the app's lifetime on that
+  loop, and ``await svc.aclose()`` on shutdown.
+* **From synchronous code**: wrap a whole workflow in a single
+  ``asyncio.run(main())``. If you must call repeatedly from sync code, either
+  keep one long-lived loop on a dedicated thread and submit coroutines with
+  ``asyncio.run_coroutine_threadsafe``, or build *and close* a client inside
+  each ``asyncio.run`` — do not keep one instance and call ``asyncio.run`` with
+  it repeatedly.
+* **Always close** via ``async with`` or ``await svc.aclose()`` so the heartbeat
+  task is cancelled before the loop closes (otherwise asyncio cancels it at
+  shutdown and may log a "Task was destroyed but it is pending" warning).
+* **Multiple threads**: give each thread its own loop and its own client, or
+  marshal calls onto the owning loop with ``asyncio.run_coroutine_threadsafe``.
 """
 
 from __future__ import annotations

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -1,0 +1,412 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Asyncio-native ServiceClient that manages sessions and child clients.
+
+This is the asyncio twin of :class:`weaver.service_client.ServiceClient`. Every
+network call is awaited so the event loop is free for other coroutines, and the
+session heartbeat runs as an :class:`asyncio.Task` instead of a thread.
+
+Usage::
+
+    async with AsyncServiceClient(api_key="sk-...") as svc:
+        tc = await svc.create_model(base_model="Qwen/Qwen3-8B")
+        await tc.forward_backward(data, "cross_entropy")
+        await tc.optim_step(AdamParams(learning_rate=1e-4))
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+
+from . import __version__
+from ._async_http import AsyncAPIClient
+from ._utils import extract_id, lookup_case_insensitive
+from .config import WeaverConfig
+from .operations import AsyncOperationHandle, build_async_operation_handle
+from .types import LoraConfig
+
+if TYPE_CHECKING:
+    from .async_sampling_client import AsyncSamplingClient
+    from .async_training_client import AsyncTrainingClient
+
+logger = logging.getLogger(__name__)
+
+
+# Default LoRA configuration
+DEFAULT_LORA_CONFIG = LoraConfig(rank=32)
+
+
+class AsyncServiceClient:
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        default_tags: Optional[Sequence[str]] = None,
+        session_id: Optional[str] = None,
+        heartbeat_interval: float = 30.0,
+    ) -> None:
+        """Initialize AsyncServiceClient.
+
+        Args:
+            base_url: Base URL of the Weaver server. Defaults to https://weaver-console.nex-agi.cn
+            api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
+            default_tags: Default tags for sessions
+            session_id: Optional existing session ID to reuse
+            heartbeat_interval: Interval in seconds for session heartbeat
+        """
+        self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
+        self._default_tags = list(default_tags or ["weaver-sdk"])
+        self._session_id = session_id
+        self._heartbeat_interval = heartbeat_interval
+
+        self._http: AsyncAPIClient | None = None
+        self._session: Dict[str, Any] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._closed = False
+        self._model_seq_counter = 1
+        self._sampling_seq_counter = 1
+        self._operation_seq_by_model: Dict[str, int] = {}
+        self._created_models: List[str] = []
+
+    async def __aenter__(self) -> "AsyncServiceClient":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.aclose()
+
+    @property
+    def http(self) -> AsyncAPIClient:
+        if self._http is None:
+            raise RuntimeError("AsyncServiceClient is not connected")
+        return self._http
+
+    async def connect(self) -> None:
+        if self._http is not None:
+            return
+        self._http = AsyncAPIClient(self._config)
+        if self._session_id:
+            await self._fetch_session(self._session_id)
+        else:
+            await self.ensure_session()
+        self._start_heartbeat()
+
+    async def _ensure_connected(self) -> None:
+        if self._http is None:
+            await self.connect()
+
+    async def terminate_model(
+        self,
+        model_id: str,
+        instance_types: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Terminate trainer and/or inference instances for a model."""
+        payload: Dict[str, Any] = {}
+        if instance_types is not None:
+            payload["instance_types"] = instance_types
+        return await self.http.post(
+            f"/api/v1/models/{model_id}/terminate",
+            json=payload if payload else None,
+        )
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        for model_id in self._created_models:
+            try:
+                logger.debug("Terminating model %s during cleanup", model_id)
+                await self.terminate_model(model_id)
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.debug("Failed to terminate model %s: %s", model_id, exc)
+
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except (asyncio.CancelledError, Exception):  # pragma: no cover - best effort
+                pass
+            self._heartbeat_task = None
+        if self._http is not None:
+            await self._http.aclose()
+        self._http = None
+
+    async def ensure_session(
+        self,
+        *,
+        tags: Optional[Sequence[str]] = None,
+        user_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if self._session is not None:
+            return self._session
+        payload = {
+            "tags": list(tags or self._default_tags),
+            "user_metadata": user_metadata or {},
+            "sdk_version": __version__,
+        }
+        session = await self.http.post("/api/v1/sessions", json=payload)
+        self._session_id = extract_id(session)
+        self._session = session
+        return session
+
+    async def _fetch_session(self, session_id: str) -> None:
+        session = await self.http.get(f"/api/v1/sessions/{session_id}")
+        self._session_id = extract_id(session)
+        self._session = session
+
+    def _start_heartbeat(self) -> None:
+        if self._heartbeat_task is not None or not self._session_id:
+            return
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def _heartbeat_loop(self) -> None:
+        assert self._session_id is not None
+        while True:
+            try:
+                await self.http.post(f"/api/v1/sessions/{self._session_id}/heartbeat")
+            except Exception as exc:  # pragma: no cover - best effort heartbeat
+                logger.debug("session heartbeat failed: %s", exc)
+            await asyncio.sleep(self._heartbeat_interval)
+
+    @property
+    def session_id(self) -> str:
+        if not self._session_id:
+            raise RuntimeError("Session not initialized yet")
+        return self._session_id
+
+    async def create_model(
+        self,
+        *,
+        base_model: str,
+        model_seq_id: Optional[int] = None,
+        training_mode: Optional[str] = None,
+        lora_config: Union[LoraConfig, Dict[str, Any]] = DEFAULT_LORA_CONFIG,
+        user_metadata: Optional[Dict[str, Any]] = None,
+    ) -> "AsyncTrainingClient":
+        """Create a training model with LoRA or FullFT configuration.
+
+        See :meth:`weaver.service_client.ServiceClient.create_model`. Returns an
+        :class:`AsyncTrainingClient`.
+        """
+        await self._ensure_connected()
+        model_seq_id = model_seq_id or self._next_model_seq()
+        payload: Dict[str, Any] = {
+            "model_seq_id": model_seq_id,
+            "base_model": base_model,
+        }
+        if training_mode is not None:
+            payload["training_mode"] = training_mode
+        if training_mode is None or training_mode == "lora":
+            payload["lora_config"] = (
+                lora_config.to_payload() if isinstance(lora_config, LoraConfig) else lora_config
+            )
+        if user_metadata is not None:
+            payload["user_metadata"] = user_metadata
+
+        response = await self.http.post(
+            f"/api/v1/sessions/{self.session_id}/models",
+            json=payload,
+        )
+        model_id = extract_id(response)
+        self._created_models.append(model_id)
+
+        from .async_training_client import AsyncTrainingClient  # avoid circular import
+
+        tokenizer_path = lookup_case_insensitive(response, "tokenizer_path")
+        if not tokenizer_path:
+            model_config = await self.get_supported_model_config(base_model)
+            if model_config:
+                config = model_config.get("config", {})
+                resource = config.get("resource", {})
+                tokenizer_config = resource.get("tokenizer", {})
+                tokenizer_path = tokenizer_config.get("path")
+
+        debug_info = lookup_case_insensitive(response, "debug_info")
+
+        return AsyncTrainingClient(
+            service=self,
+            model_id=model_id,
+            base_model=lookup_case_insensitive(response, "base_model") or base_model,
+            session_id=self.session_id,
+            tokenizer_path=tokenizer_path,
+            debug_info=debug_info,
+        )
+
+    def _next_model_seq(self) -> int:
+        value = self._model_seq_counter
+        self._model_seq_counter += 1
+        return value
+
+    def _next_sampling_seq(self) -> int:
+        value = self._sampling_seq_counter
+        self._sampling_seq_counter += 1
+        return value
+
+    def next_operation_seq(self, model_id: str) -> int:
+        """Return the next seq_id for a given model, shared across clients."""
+        if not model_id:
+            raise ValueError("model_id is required to generate seq_id")
+        current = self._operation_seq_by_model.get(model_id)
+        if current is None:
+            current = 1
+        self._operation_seq_by_model[model_id] = current + 1
+        return current
+
+    async def create_sampling_client(
+        self,
+        *,
+        base_model: Optional[str] = None,
+        model_path: Optional[str] = None,
+        sampling_session_seq_id: Optional[int] = None,
+        sampling_session_id: Optional[str] = None,
+        model_id: Optional[str] = None,
+        tokenizer_path: Optional[str] = None,
+    ) -> "AsyncSamplingClient":
+        from .async_sampling_client import AsyncSamplingClient  # local import to avoid cycles
+
+        await self._ensure_connected()
+        if sampling_session_id is None:
+            if model_id and not model_path:
+                raise ValueError("model_path is required when model_id is provided")
+            seq_id = sampling_session_seq_id or self._next_sampling_seq()
+            body: Dict[str, Any] = {
+                "sampling_session_seq_id": seq_id,
+                "base_model": base_model,
+                "model_path": model_path,
+            }
+            if model_id:
+                body["model_id"] = model_id
+
+            resp = await self.http.post(
+                f"/api/v1/sessions/{self.session_id}/sampling-sessions",
+                json=body,
+            )
+
+            # Handle async sync_weights response (202 Accepted):
+            # Response shape: {"sampling_session": {...}, "sync_operation": {...}}
+            sync_op_payload = (
+                lookup_case_insensitive(resp, "sync_operation") if isinstance(resp, dict) else None
+            )
+            if sync_op_payload and isinstance(sync_op_payload, dict):
+                session = lookup_case_insensitive(resp, "sampling_session") or {}
+                sync_handle = AsyncOperationHandle.from_payload(self.http, sync_op_payload)
+                logger.info(
+                    "Waiting for background weights sync (operation %s)...",
+                    sync_handle.operation_id,
+                )
+                await sync_handle.wait()
+                logger.info("Weights sync completed.")
+            else:
+                session = resp
+
+            sampling_session_id = extract_id(session)
+            if tokenizer_path is None:
+                tokenizer_path = lookup_case_insensitive(session, "tokenizer_path")
+            if tokenizer_path is None and base_model:
+                model_config = await self.get_supported_model_config(base_model)
+                if model_config:
+                    config = model_config.get("config", {})
+                    resource = config.get("resource", {})
+                    tokenizer_config = resource.get("tokenizer", {})
+                    tokenizer_path = tokenizer_config.get("path")
+        return AsyncSamplingClient(
+            service=self,
+            sampling_session_id=sampling_session_id,
+            base_model=base_model,
+            model_path=model_path,
+            model_id=model_id,
+            tokenizer_path=tokenizer_path,
+        )
+
+    async def get_sampling_client(
+        self,
+        model_path: str,
+        *,
+        base_model: Optional[str] = None,
+        model_id: Optional[str] = None,
+        sampling_session_id: Optional[str] = None,
+        tokenizer_path: Optional[str] = None,
+    ) -> "AsyncSamplingClient":
+        """Create a sampling client from an exported model path."""
+        return await self.create_sampling_client(
+            model_path=model_path,
+            base_model=base_model,
+            model_id=model_id,
+            sampling_session_id=sampling_session_id,
+            tokenizer_path=tokenizer_path,
+        )
+
+    async def enqueue_operation(self, path: str, payload: Dict[str, Any]) -> AsyncOperationHandle:
+        # max_retries=1: operations like save_state are non-idempotent POSTs —
+        # retrying after a timeout would create duplicate server-side operations.
+        response = await self.http.post(path, json=payload, max_retries=1)
+        return build_async_operation_handle(self.http, response)
+
+    async def get_supported_model_config(self, base_model: str) -> Optional[Dict[str, Any]]:
+        """Get configuration for a specific supported model."""
+        payload = await self.http.get("/api/v1/supported-models")
+        if not isinstance(payload, dict):
+            return None
+        items = payload.get("items")
+        if not isinstance(items, list):
+            return None
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            name = lookup_case_insensitive(item, "name")
+            if name and str(name) == base_model:
+                return item
+        return None
+
+    async def list_supported_models(self) -> List[str]:
+        """Return supported model names exposed by the server."""
+        payload = await self.http.get("/api/v1/supported-models")
+        if not isinstance(payload, dict):
+            return []
+        items = payload.get("items")
+        names: List[str] = []
+        if isinstance(items, list):
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                name = lookup_case_insensitive(item, "name")
+                status = lookup_case_insensitive(item, "status")
+                if status and str(status).lower() != "healthy":
+                    continue
+                if name:
+                    names.append(str(name))
+        return names
+
+    async def list_training_runs(self, *, limit: int = 25, offset: int = 0) -> Dict[str, Any]:
+        """List training runs with pagination."""
+        return await self.http.get(
+            "/api/v1/training-runs", params={"limit": limit, "offset": offset}
+        )
+
+    async def get_training_run(self, run_id: str) -> Dict[str, Any]:
+        """Get detailed information about a specific training run."""
+        return await self.http.get(f"/api/v1/training-runs/{run_id}")
+
+    async def list_models(self, *, limit: int = 25, offset: int = 0) -> Dict[str, Any]:
+        """List models with pagination."""
+        return await self.http.get("/api/v1/models", params={"limit": limit, "offset": offset})
+
+    async def get_model(self, model_id: str) -> Dict[str, Any]:
+        """Get detailed information about a specific model."""
+        return await self.http.get(f"/api/v1/models/{model_id}")

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -1,0 +1,520 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Asyncio-native training client built on top of AsyncServiceClient.
+
+Every operation is awaited. Pass ``wait=False`` to get an
+:class:`~weaver.operations.AsyncOperationHandle` back immediately and await it
+later, which lets several server-side operations overlap::
+
+    fb = await tc.forward_backward(data, "cross_entropy", wait=False)
+    opt = await tc.optim_step(params, wait=False)
+    await fb            # both already submitted; the waits overlap
+    await opt
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
+
+from ._payloads import (
+    build_request_metadata,
+    build_surrogate_data,
+    forward_backward_payload,
+    forward_payload,
+    parse_logprob_tensors,
+)
+from ._utils import UNSET, _UnsetType, lookup_case_insensitive
+from .async_service_client import AsyncServiceClient
+from .operations import AsyncOperationHandle
+from .types import AdamParams, Datum
+from .types.checkpoint import Checkpoint
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    import torch
+
+    from .async_sampling_client import AsyncSamplingClient
+    from .types.router_replay import RouterReplayMetadata
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncTrainingClient:
+    def __init__(
+        self,
+        *,
+        service: AsyncServiceClient,
+        model_id: str,
+        base_model: str,
+        session_id: str,
+        tokenizer_path: str | None = None,
+        debug_info: Dict[str, Any] | None = None,
+    ) -> None:
+        self._service = service
+        self.model_id = model_id
+        self.base_model = base_model
+        self.session_id = session_id
+        self.tokenizer_path = tokenizer_path
+        self.debug_info = debug_info
+        self._tokenizer: Any = None
+
+    def _next_seq(self) -> int:
+        return self._service.next_operation_seq(self.model_id)
+
+    @overload
+    async def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
+        wait: "Literal[True]" = True,
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    async def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
+        wait: "Literal[False]",
+    ) -> AsyncOperationHandle: ...
+
+    async def forward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
+        wait: bool = True,
+    ) -> AsyncOperationHandle | Dict[str, Any]:
+        """Compute a forward pass without accumulating gradients.
+
+        Args:
+            data: Sequence of training data.
+            loss_fn: Name of the loss function to use.
+            loss_fn_config: Optional loss function configuration.
+            metadata: Optional top-level request metadata. Router replay metadata
+                must be attached to each Datum as ``datum.metadata["router_replay"]``.
+            router_replay: Deprecated request-level Router Replay envelope; passing
+                it raises ``ValueError``.
+            wait: If True (default), awaits completion and returns the result dict;
+                if False, returns an ``AsyncOperationHandle`` immediately.
+        """
+        payload = forward_payload(
+            model_id=self.model_id,
+            seq_id=self._next_seq(),
+            data=data,
+            loss_fn=loss_fn,
+            loss_fn_config=loss_fn_config,
+            request_metadata=build_request_metadata(metadata, router_replay),
+        )
+        handle = await self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/forward-passes",
+            {"payload": payload},
+        )
+        return await handle.result() if wait else handle
+
+    @overload
+    async def forward_backward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        *,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
+        wait: "Literal[True]" = True,
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    async def forward_backward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        *,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
+        wait: "Literal[False]",
+    ) -> AsyncOperationHandle: ...
+
+    async def forward_backward(
+        self,
+        data: Sequence[Datum],
+        loss_fn: str,
+        *,
+        loss_fn_config: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        router_replay: "RouterReplayMetadata | Mapping[str, Any] | None" = None,
+        wait: bool = True,
+    ) -> AsyncOperationHandle | Dict[str, Any]:
+        """Compute a forward and backward pass, accumulating gradients.
+
+        Args:
+            data: Sequence of training data.
+            loss_fn: Name of the loss function to use.
+            loss_fn_config: Optional loss function configuration.
+            metadata: Optional top-level request metadata. Router replay metadata
+                must be attached to each Datum as ``datum.metadata["router_replay"]``.
+            router_replay: Deprecated request-level Router Replay envelope; passing
+                it raises ``ValueError``.
+            wait: If True (default), awaits completion and returns the result dict;
+                if False, returns an ``AsyncOperationHandle`` immediately.
+        """
+        payload = forward_backward_payload(
+            model_id=self.model_id,
+            seq_id=self._next_seq(),
+            data=data,
+            loss_fn=loss_fn,
+            loss_fn_config=loss_fn_config,
+            request_metadata=build_request_metadata(metadata, router_replay),
+        )
+        handle = await self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/forward-backward-passes",
+            {"payload": payload},
+        )
+        return await handle.result() if wait else handle
+
+    async def forward_backward_custom(
+        self,
+        data: Sequence[Datum],
+        loss_fn: Callable[
+            [Sequence[Datum], List["torch.Tensor"]], Tuple["torch.Tensor", Dict[str, Any]]
+        ],
+        *,
+        loss_fn_config: Mapping[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        """Run a custom loss function with surrogate-based gradient propagation.
+
+        Orchestrates two sequential server calls: a forward pass to obtain
+        per-token logprobs, then a surrogate backward pass that applies the
+        user-computed gradients. See
+        :meth:`weaver.training_client.TrainingClient.forward_backward_custom`.
+        """
+        # Step A: forward pass to get logprobs
+        fwd_result = await self.forward(
+            data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True
+        )
+
+        # Step B: parse logprobs from response
+        logprob_tensors = parse_logprob_tensors(fwd_result, data)
+
+        # Step C: run user's loss function
+        try:
+            loss, metrics = loss_fn(data, logprob_tensors)
+        except Exception as exc:
+            raise RuntimeError(f"User loss_fn failed: {exc}") from exc
+
+        if loss.dim() != 0:
+            raise ValueError(f"loss_fn must return a scalar loss, got shape {loss.shape}")
+
+        # Step D: backprop through user graph into logprob tensors
+        loss.backward()
+
+        # Step E: build surrogate Datum objects from the propagated gradients
+        surrogate_data = build_surrogate_data(data, logprob_tensors)
+
+        # Step F: surrogate backward pass
+        await self.forward_backward(
+            surrogate_data, "surrogate", loss_fn_config=loss_fn_config, wait=True
+        )
+
+        # Step G: return loss and metrics
+        return {"loss": loss.detach(), "metrics": metrics}
+
+    @overload
+    async def optim_step(
+        self, params: AdamParams, *, wait: "Literal[True]" = True
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    async def optim_step(
+        self, params: AdamParams, *, wait: "Literal[False]"
+    ) -> AsyncOperationHandle: ...
+
+    async def optim_step(
+        self, params: AdamParams, *, wait: bool = True
+    ) -> AsyncOperationHandle | Dict[str, Any]:
+        payload = {
+            "model_id": self.model_id,
+            "seq_id": self._next_seq(),
+            "adam_params": params.to_payload(),
+        }
+        handle = await self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/optimizer-steps",
+            {"payload": payload},
+        )
+        return await handle.result() if wait else handle
+
+    @overload
+    async def save_weights_for_sampler(
+        self,
+        *,
+        name: str | None = None,
+        ttl_seconds: int | None = 86400,
+        wait: "Literal[True]" = True,
+    ) -> str: ...
+
+    @overload
+    async def save_weights_for_sampler(
+        self, *, name: str | None = None, ttl_seconds: int | None = 86400, wait: "Literal[False]"
+    ) -> AsyncOperationHandle: ...
+
+    async def save_weights_for_sampler(
+        self,
+        *,
+        name: str | None = None,
+        ttl_seconds: int | None = 86400,
+        wait: bool = True,
+    ) -> str | AsyncOperationHandle:
+        """Export model weights for sampling.
+
+        See :meth:`weaver.training_client.TrainingClient.save_weights_for_sampler`.
+        Returns the model path (str) when *wait* is True, else an
+        ``AsyncOperationHandle``.
+        """
+        body: Dict[str, Any] = {"seq_id": self._next_seq()}
+        if name:
+            body["path"] = name
+        if ttl_seconds is not None:
+            body["ttl_seconds"] = ttl_seconds
+        handle = await self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/export-sampler",
+            body,
+        )
+        if not wait:
+            return handle
+        result = await handle.result()
+        model_path = lookup_case_insensitive(result or {}, "model_path") or lookup_case_insensitive(
+            result or {}, "path"
+        )
+        if not model_path:
+            raise RuntimeError("Export response missing model path")
+        return str(model_path)
+
+    @overload
+    async def save_weights_and_get_sampling_client(
+        self,
+        *,
+        name: str | None = None,
+        ttl_seconds: int | None = 86400,
+        wait: "Literal[True]" = True,
+    ) -> "AsyncSamplingClient": ...
+
+    @overload
+    async def save_weights_and_get_sampling_client(
+        self, *, name: str | None = None, ttl_seconds: int | None = 86400, wait: "Literal[False]"
+    ) -> AsyncOperationHandle: ...
+
+    async def save_weights_and_get_sampling_client(
+        self,
+        *,
+        name: str | None = None,
+        ttl_seconds: int | None = 86400,
+        wait: bool = True,
+    ) -> "AsyncSamplingClient | AsyncOperationHandle":
+        """Export model weights and create an async sampling client.
+
+        See :meth:`weaver.training_client.TrainingClient.save_weights_and_get_sampling_client`.
+        """
+        body: Dict[str, Any] = {"seq_id": self._next_seq()}
+        if name:
+            body["path"] = name
+        if ttl_seconds is not None:
+            body["ttl_seconds"] = ttl_seconds
+        handle = await self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/export-sampler",
+            body,
+        )
+        if not wait:
+            return handle
+        result = await handle.result()
+        sampling_session_id = lookup_case_insensitive(result or {}, "sampling_session_id")
+        model_path = lookup_case_insensitive(result or {}, "model_path") or lookup_case_insensitive(
+            result or {}, "path"
+        )
+        if sampling_session_id:
+            return await self._service.get_sampling_client(
+                model_path=model_path or "",
+                base_model=self.base_model,
+                model_id=self.model_id,
+                sampling_session_id=sampling_session_id,
+                tokenizer_path=self.tokenizer_path,
+            )
+        if model_path:
+            return await self._service.get_sampling_client(
+                model_path=str(model_path),
+                base_model=self.base_model,
+                model_id=self.model_id,
+                tokenizer_path=self.tokenizer_path,
+            )
+        raise RuntimeError("Export response missing sampling session id or model path")
+
+    @property
+    def tokenizer(self):  # type: ignore[misc]
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer
+
+            model_name_or_path = self.tokenizer_path if self.tokenizer_path else self.base_model
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                model_name_or_path, trust_remote_code=True
+            )
+        return self._tokenizer
+
+    def get_tokenizer(self):  # Backwards compatible accessor
+        return self.tokenizer
+
+    # ------------------------------------------------------------------
+    # Checkpoint management
+    # ------------------------------------------------------------------
+
+    @overload
+    async def save_state(
+        self,
+        *,
+        name: str | None = None,
+        checkpoint_type: str = "weight",
+        ttl_seconds: int | None | _UnsetType = ...,
+        wait: "Literal[True]" = True,
+    ) -> Checkpoint: ...
+
+    @overload
+    async def save_state(
+        self,
+        *,
+        name: str | None = None,
+        checkpoint_type: str = "weight",
+        ttl_seconds: int | None | _UnsetType = ...,
+        wait: "Literal[False]",
+    ) -> AsyncOperationHandle: ...
+
+    async def save_state(
+        self,
+        *,
+        name: str | None = None,
+        checkpoint_type: str = "weight",
+        ttl_seconds: int | None | _UnsetType = UNSET,
+        wait: bool = True,
+    ) -> Checkpoint | AsyncOperationHandle:
+        """Save the current model weights as a checkpoint.
+
+        See :meth:`weaver.training_client.TrainingClient.save_state`. Returns a
+        :class:`~weaver.types.Checkpoint` when *wait* is True, else an
+        ``AsyncOperationHandle``.
+        """
+        body: Dict[str, Any] = {"type": checkpoint_type}
+        if name is not None:
+            body["name"] = name
+        if not isinstance(ttl_seconds, _UnsetType):
+            body["ttl_seconds"] = ttl_seconds
+        handle = await self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/checkpoints",
+            body,
+        )
+        if not wait:
+            return handle
+        result = await handle.result()
+        return Checkpoint.from_payload(result if isinstance(result, dict) else {})
+
+    @overload
+    async def load_state(
+        self, path: str | Checkpoint, *, wait: "Literal[True]" = True
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    async def load_state(
+        self, path: str | Checkpoint, *, wait: "Literal[False]"
+    ) -> AsyncOperationHandle: ...
+
+    async def load_state(
+        self,
+        path: str | Checkpoint,
+        *,
+        wait: bool = True,
+    ) -> AsyncOperationHandle | Dict[str, Any]:
+        """Restore model weights from a checkpoint (optimizer state is **not** restored)."""
+        return await self._load_checkpoint(path, include_optimizer=False, wait=wait)
+
+    @overload
+    async def load_state_with_optimizer(
+        self, path: str | Checkpoint, *, wait: "Literal[True]" = True
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    async def load_state_with_optimizer(
+        self, path: str | Checkpoint, *, wait: "Literal[False]"
+    ) -> AsyncOperationHandle: ...
+
+    async def load_state_with_optimizer(
+        self,
+        path: str | Checkpoint,
+        *,
+        wait: bool = True,
+    ) -> AsyncOperationHandle | Dict[str, Any]:
+        """Restore model weights **and** optimizer state from a checkpoint."""
+        return await self._load_checkpoint(path, include_optimizer=True, wait=wait)
+
+    async def _load_checkpoint(
+        self,
+        path: str | Checkpoint,
+        *,
+        include_optimizer: bool,
+        wait: bool,
+    ) -> AsyncOperationHandle | Dict[str, Any]:
+        checkpoint_path = path.path if isinstance(path, Checkpoint) else path
+        body: Dict[str, Any] = {
+            "path": checkpoint_path,
+            "include_optimizer": include_optimizer,
+        }
+        handle = await self._service.enqueue_operation(
+            f"/api/v1/models/{self.model_id}/load",
+            body,
+        )
+        return await handle.result() if wait else handle
+
+    async def list_checkpoints(self) -> list[Checkpoint]:
+        """List all checkpoints for this model."""
+        response = await self._service.http.get(
+            f"/api/v1/models/{self.model_id}/checkpoints",
+        )
+        items = (response or {}).get("items", []) if isinstance(response, dict) else []
+        return [Checkpoint.from_payload(item) for item in items if isinstance(item, dict)]
+
+    async def set_checkpoint_ttl(
+        self,
+        path: str | Checkpoint,
+        ttl_seconds: int | None,
+    ) -> Dict[str, Any]:
+        """Set or cancel the TTL (time-to-live) for a checkpoint."""
+        checkpoint_path = path.path if isinstance(path, Checkpoint) else path
+        body: Dict[str, Any] = {"path": checkpoint_path, "ttl_seconds": ttl_seconds}
+        return await self._service.http.patch(
+            f"/api/v1/models/{self.model_id}/checkpoints/ttl",
+            json=body,
+        )
+
+    async def terminate(self, instance_types: list[str] | None = None) -> Dict[str, Any]:
+        """Terminate trainer and/or inference instances for this model."""
+        return await self._service.terminate_model(self.model_id, instance_types)

--- a/weaver/operations.py
+++ b/weaver/operations.py
@@ -16,14 +16,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
 from ._http import APIClient, WeaverAPIError, backoff_delays
 from ._utils import extract_id, lookup_case_insensitive
+
+if TYPE_CHECKING:
+    from ._async_http import AsyncAPIClient
 
 logger = logging.getLogger(__name__)
 
@@ -100,16 +104,11 @@ class WeaverOperationError(RuntimeError):
         self.payload = payload
 
 
-@dataclass
-class OperationHandle:
-    client: APIClient
+class _OperationHandleMixin:
+    """Pure (IO-free) status accessors shared by sync and async handles."""
+
     operation_id: str
     _cached: Dict[str, Any]
-
-    @classmethod
-    def from_payload(cls, client: APIClient, payload: Dict[str, Any]) -> "OperationHandle":
-        op_id = extract_id(payload)
-        return cls(client=client, operation_id=str(op_id), _cached=payload)
 
     @property
     def status(self) -> Optional[str]:
@@ -128,6 +127,22 @@ class OperationHandle:
     def done(self) -> bool:
         status = self.status
         return status in {"done", "error"}
+
+    def _raise_if_failed(self) -> None:
+        if self.status == "error":
+            raise WeaverOperationError(self._cached)
+
+
+@dataclass
+class OperationHandle(_OperationHandleMixin):
+    client: APIClient
+    operation_id: str
+    _cached: Dict[str, Any]
+
+    @classmethod
+    def from_payload(cls, client: APIClient, payload: Dict[str, Any]) -> "OperationHandle":
+        op_id = extract_id(payload)
+        return cls(client=client, operation_id=str(op_id), _cached=payload)
 
     def refresh(self) -> Dict[str, Any]:
         path = f"/api/v1/operations/{self.operation_id}"
@@ -162,8 +177,7 @@ class OperationHandle:
                 break
         if not self.done():
             raise WeaverAPIError(504, "timeout", "Operation polling timed out", True)
-        if self.status == "error":
-            raise WeaverOperationError(self._cached)
+        self._raise_if_failed()
         return self._cached
 
     def result(self) -> Any:
@@ -183,5 +197,81 @@ class OperationHandle:
         return [h.result() for h in handles]
 
 
+@dataclass
+class AsyncOperationHandle(_OperationHandleMixin):
+    """Asyncio twin of :class:`OperationHandle`.
+
+    Polling uses ``asyncio.sleep`` so awaiting a handle yields the event loop
+    to other coroutines while the server works. The handle is also directly
+    awaitable: ``result = await handle`` is shorthand for ``await
+    handle.result()``.
+    """
+
+    client: "AsyncAPIClient"
+    operation_id: str
+    _cached: Dict[str, Any]
+
+    @classmethod
+    def from_payload(
+        cls, client: "AsyncAPIClient", payload: Dict[str, Any]
+    ) -> "AsyncOperationHandle":
+        op_id = extract_id(payload)
+        return cls(client=client, operation_id=str(op_id), _cached=payload)
+
+    async def refresh(self) -> Dict[str, Any]:
+        path = f"/api/v1/operations/{self.operation_id}"
+        self._cached = await self.client.get(path)
+        return self._cached
+
+    async def wait(self) -> Dict[str, Any]:
+        transient_error_count = 0
+        max_transient_errors = _operation_poll_transient_retries()
+        if self.done():
+            return self._cached
+        for delay in _operation_poll_delays():
+            await asyncio.sleep(delay)
+            try:
+                await self.refresh()
+            except WeaverAPIError as exc:
+                if (
+                    transient_error_count < max_transient_errors
+                    and _is_transient_operation_poll_error(exc)
+                ):
+                    transient_error_count += 1
+                    logger.warning(
+                        "Transient error while polling operation %s; retrying (%d/%d): %s",
+                        self.operation_id,
+                        transient_error_count,
+                        max_transient_errors,
+                        exc,
+                    )
+                    continue
+                raise
+            if self.done():
+                break
+        if not self.done():
+            raise WeaverAPIError(504, "timeout", "Operation polling timed out", True)
+        self._raise_if_failed()
+        return self._cached
+
+    async def result(self) -> Any:
+        payload = await self.wait()
+        return lookup_case_insensitive(payload, "response")
+
+    def __await__(self):
+        return self.result().__await__()
+
+    @classmethod
+    async def wait_all(cls, handles: List["AsyncOperationHandle"]) -> List[Any]:
+        """Concurrently wait for all handles and return results in input order."""
+        return await asyncio.gather(*(handle.result() for handle in handles))
+
+
 def build_operation_handle(client: APIClient, payload: Dict[str, Any]) -> OperationHandle:
     return OperationHandle.from_payload(client, payload)
+
+
+def build_async_operation_handle(
+    client: "AsyncAPIClient", payload: Dict[str, Any]
+) -> AsyncOperationHandle:
+    return AsyncOperationHandle.from_payload(client, payload)

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -20,6 +20,14 @@ import logging
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
+from ._payloads import (
+    build_request_metadata,
+    build_surrogate_data,
+    forward_backward_payload,
+    forward_payload,
+    parse_logprob_tensors,
+    serialize_data,
+)
 from ._utils import UNSET, _UnsetType, lookup_case_insensitive
 from .operations import OperationHandle
 from .service_client import ServiceClient
@@ -59,30 +67,14 @@ class TrainingClient:
         return self._service.next_operation_seq(self.model_id)
 
     def _serialize_data(self, data: Sequence[Datum]) -> Sequence[Dict[str, Any]]:
-        return [datum.to_payload() for datum in data]
+        return serialize_data(data)
 
     def _build_metadata(
         self,
         metadata: Mapping[str, Any] | None,
         router_replay: "RouterReplayMetadata | Mapping[str, Any] | None",
     ) -> Dict[str, Any] | None:
-        if router_replay is not None:
-            raise ValueError(
-                "router_replay= is no longer accepted at request level. "
-                "Attach router replay metadata to each Datum via "
-                "datum.metadata['router_replay']."
-            )
-        if not metadata and router_replay is None:
-            return None
-
-        payload = dict(metadata or {})
-        if "router_replay" in payload:
-            raise ValueError(
-                "metadata['router_replay'] is no longer accepted at request level. "
-                "Attach router replay metadata to each Datum via "
-                "datum.metadata['router_replay']."
-            )
-        return payload or None
+        return build_request_metadata(metadata, router_replay)
 
     @overload
     def forward(
@@ -131,19 +123,14 @@ class TrainingClient:
                 Passing this argument raises ``ValueError``.
             wait: If True, blocks until the operation completes.
         """
-        payload: Dict[str, Any] = {
-            "model_id": self.model_id,
-            "seq_id": self._next_seq(),
-            "forward_input": {
-                "loss_fn": loss_fn,
-                "data": self._serialize_data(data),
-            },
-        }
-        if loss_fn_config:
-            payload["forward_input"]["loss_fn_config"] = dict(loss_fn_config)
-        request_metadata = self._build_metadata(metadata, router_replay)
-        if request_metadata:
-            payload["metadata"] = request_metadata
+        payload = forward_payload(
+            model_id=self.model_id,
+            seq_id=self._next_seq(),
+            data=data,
+            loss_fn=loss_fn,
+            loss_fn_config=loss_fn_config,
+            request_metadata=build_request_metadata(metadata, router_replay),
+        )
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/forward-passes",
             {"payload": payload},
@@ -197,19 +184,14 @@ class TrainingClient:
                 Passing this argument raises ``ValueError``.
             wait: If True, blocks until the operation completes.
         """
-        payload: Dict[str, Any] = {
-            "model_id": self.model_id,
-            "seq_id": self._next_seq(),
-            "forward_backward_input": {
-                "loss_fn": loss_fn,
-                "data": self._serialize_data(data),
-            },
-        }
-        if loss_fn_config:
-            payload["forward_backward_input"]["loss_fn_config"] = dict(loss_fn_config)
-        request_metadata = self._build_metadata(metadata, router_replay)
-        if request_metadata:
-            payload["metadata"] = request_metadata
+        payload = forward_backward_payload(
+            model_id=self.model_id,
+            seq_id=self._next_seq(),
+            data=data,
+            loss_fn=loss_fn,
+            loss_fn_config=loss_fn_config,
+            request_metadata=build_request_metadata(metadata, router_replay),
+        )
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/forward-backward-passes",
             {"payload": payload},
@@ -241,27 +223,11 @@ class TrainingClient:
             data: Sequence of training data.
             loss_fn: ``(data, logprob_tensors) -> (loss, metrics)``
         """
-        import torch
-
         # Step A: forward pass to get logprobs
         fwd_result = self.forward(data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True)
 
         # Step B: parse logprobs from response
-        outputs = fwd_result.get("result", {}).get("loss_fn_outputs", [])
-        if not outputs:
-            raise ValueError("Forward pass returned no loss_fn_outputs")
-        if len(outputs) != len(data):
-            raise ValueError(f"Expected {len(data)} loss_fn_outputs, got {len(outputs)}")
-
-        logprob_tensors: List[torch.Tensor] = []
-        for output in outputs:
-            lp = output.get("logprobs") or output.get("Logprobs")
-            if isinstance(lp, dict):
-                lp = lp["data"]
-            if lp is None:
-                raise ValueError("Missing logprobs in forward/backward output")
-            t = torch.tensor(lp, dtype=torch.float32).requires_grad_(True)
-            logprob_tensors.append(t)
+        logprob_tensors = parse_logprob_tensors(fwd_result, data)
 
         # Step C: run user's loss function
         try:
@@ -275,31 +241,8 @@ class TrainingClient:
         # Step D: backprop through user graph into logprob tensors
         loss.backward()
 
-        for i, t in enumerate(logprob_tensors):
-            if t.grad is None:
-                raise ValueError(f"logprob_tensors[{i}] has no gradient after backward")
-
-        # Step E: build surrogate Datum objects
-        surrogate_data: List[Datum] = []
-        for datum, logprob_tensor in zip(data, logprob_tensors):
-            raw_targets = datum.loss_fn_inputs.get("target_tokens")
-            if raw_targets is None:
-                resolved_targets: List[Any] = datum.model_input.to_ints()
-            elif hasattr(raw_targets, "tolist"):
-                resolved_targets = raw_targets.tolist()
-            else:
-                resolved_targets = list(raw_targets)
-
-            grad = logprob_tensor.grad
-            assert grad is not None  # validated above
-            loss_fn_inputs: Dict[str, Any] = dict(datum.loss_fn_inputs)
-            loss_fn_inputs["target_tokens"] = resolved_targets
-            loss_fn_inputs["surrogate_weights"] = grad.detach().tolist()
-            surrogate_datum = Datum.from_raw(
-                model_input=datum.model_input,
-                loss_fn_inputs=loss_fn_inputs,
-            )
-            surrogate_data.append(surrogate_datum)
+        # Step E: build surrogate Datum objects from the propagated gradients
+        surrogate_data = build_surrogate_data(data, logprob_tensors)
 
         # Step F: surrogate backward pass
         self.forward_backward(surrogate_data, "surrogate", loss_fn_config=loss_fn_config, wait=True)


### PR DESCRIPTION
## Summary

Adds a fully **asyncio-native** client stack mirroring the sync clients, so callers can `await` training/sampling operations with the event loop **yielding to other coroutines** (aligns with tinker's async API — requested in nex-taas-feedback#183).

The existing `wait=False` + `OperationHandle` model only pipelined in-flight ops; it still blocked the thread (sync `httpx.Client` + `time.sleep` polling). This PR makes the wait truly cooperative.

```python
async with AsyncServiceClient(api_key="sk-...") as svc:
    tc = await svc.create_model(base_model="Qwen/Qwen3-30B-A3B-bridge-lora-cp8")
    fb = await tc.forward_backward(data, "cross_entropy", wait=False)  # submit, don't block
    await tc.optim_step(params, wait=False)
    await fb                                                           # await yields the loop
    sc = await tc.save_weights_and_get_sampling_client()
    out = await sc.sample(prompt=p, sampling_params=sp)
```

## What's included

- **`AsyncAPIClient`** (`_async_http.py`) — `httpx.AsyncClient`; mirrors `APIClient` retry / trace / connection-error / fork-safety logic with `await asyncio.sleep` backoff.
- **`AsyncOperationHandle`** — awaitable (`__await__`), async `wait_all`; shares pure status logic with `OperationHandle` via a mixin.
- **`AsyncServiceClient` / `AsyncTrainingClient` / `AsyncSamplingClient`** — full surface, `@overload` on `wait`-methods for sync-parity typing. Heartbeat runs as an `asyncio.Task`.
- **Single source of truth** — payload building & response normalization extracted into `_payloads.py` / `_sampling_utils.py`; the **sync** clients were refactored to use them too (no logic fork).
- **Example** `examples/pig_latin_async.py` — pipelined `forward_backward` + concurrent `asyncio.gather` sampling.
- **Rule** `.claude/rules/async-compatibility.md` — enforces sync/async parity for future changes.
- `.pylintrc`: disable `cyclic-import` (pre-existing benign `_http` ↔ package cycle via `from . import __version__`, already tolerated by `make lint`).

## Event loop model (documented)

The client **owns no loop** (never calls `asyncio.run`); one instance is bound to one loop + one thread (httpx pool + heartbeat Task bind at `connect()`). The `AsyncServiceClient` docstring spells out integration for FastAPI/Jupyter (await directly, never `asyncio.run`), sync code, threads, and always closing — so embedding it elsewhere doesn't hang.

## Verification

- **161 tests pass**, mypy + black + pylint clean (pre-commit gate green).
- **Liveness / no-deadlock**: real-socket tests with hard `pytest.mark.timeout` + inner `asyncio.wait_for` (a deadlock fails instead of hanging); 200 ops concurrent complete.
- **Yields CPU — measured**: a ticker probe shows the real impl lets another coroutine run **449×** during an await vs **0×** for a blocking version; the negative control proves the probe catches a blocking regression.
- **Live e2e**: `pig_latin_async` ran end-to-end against the service (`Qwen/Qwen3-30B-A3B-bridge-lora-cp8`) — loss 1.06 → 0.33, concurrent sampling returned results.

## Notes

- Backward compatible: existing sync API unchanged.
- Not yet exercised under large-scale RL load (covered by mock-server concurrency tests + one live single-process run).