### PR TITLE
feat(sampling-client): expose engine control primitives (pause/continue, weight_version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ dist/
 
 # Weights & Biases
 wandb/
+
+# DevBox sandbox tooling artifacts
+.devbox/

--- a/tests/test_sampling_control.py
+++ b/tests/test_sampling_control.py
@@ -1,0 +1,206 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the sampling engine control primitives.
+
+Covers ``pause_generation`` / ``continue_generation`` plus the result-schema
+passthrough of ``weight_version`` and pause(abort) partial output, across both
+the sync and async sampling clients (issue #84).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from weaver import _sampling_utils as _su
+from weaver.async_sampling_client import AsyncSamplingClient
+from weaver.sampling_client import SamplingClient
+from weaver.types import ModelInput, PauseMode
+
+
+def _make_sync_client() -> tuple[SamplingClient, MagicMock]:
+    mock_service = MagicMock()
+    client = SamplingClient(
+        service=mock_service,
+        sampling_session_id="sess-001",
+        base_model="Qwen/Qwen3-8B",
+    )
+    return client, mock_service
+
+
+def _make_async_client() -> tuple[AsyncSamplingClient, MagicMock]:
+    mock_service = MagicMock()
+    mock_service.http.post = AsyncMock()
+    client = AsyncSamplingClient(
+        service=mock_service,
+        sampling_session_id="sess-001",
+        base_model="Qwen/Qwen3-8B",
+    )
+    return client, mock_service
+
+
+# --------------------------------------------------------------------------- #
+# PauseMode enum / coercion                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestPauseMode:
+    def test_members(self):
+        assert PauseMode.ABORT == "abort"
+        assert PauseMode.RETRACT == "retract"
+        assert PauseMode.IN_PLACE == "in_place"
+
+    def test_coerce_accepts_enum_and_string(self):
+        assert _su.coerce_pause_mode(PauseMode.ABORT) == "abort"
+        assert _su.coerce_pause_mode("retract") == "retract"
+
+    def test_coerce_rejects_unknown(self):
+        with pytest.raises(ValueError):
+            _su.coerce_pause_mode("freeze")
+
+    def test_build_body_defaults_and_validates(self):
+        assert _su.build_pause_generation_body(PauseMode.ABORT) == {"mode": "abort"}
+        assert _su.build_pause_generation_body("in_place") == {"mode": "in_place"}
+        with pytest.raises(ValueError):
+            _su.build_pause_generation_body("nope")
+
+
+# --------------------------------------------------------------------------- #
+# Sync client                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestSyncClient:
+    def test_pause_generation_default_abort(self):
+        client, mock_service = _make_sync_client()
+        mock_service.http.post.return_value = {"ok": True}
+
+        result = client.pause_generation()
+
+        path, kwargs = mock_service.http.post.call_args[0], mock_service.http.post.call_args[1]
+        assert path[0] == "/api/v1/sampling-sessions/sess-001/pause-generation"
+        assert kwargs["json"] == {"mode": "abort"}
+        assert result == {"ok": True}
+
+    def test_pause_generation_explicit_mode(self):
+        client, mock_service = _make_sync_client()
+        mock_service.http.post.return_value = {}
+        client.pause_generation(mode=PauseMode.RETRACT)
+        assert mock_service.http.post.call_args[1]["json"] == {"mode": "retract"}
+
+    def test_pause_generation_invalid_mode(self):
+        client, _ = _make_sync_client()
+        with pytest.raises(ValueError):
+            client.pause_generation(mode="freeze")
+
+    def test_continue_generation(self):
+        client, mock_service = _make_sync_client()
+        mock_service.http.post.return_value = {"ok": True}
+        result = client.continue_generation()
+        assert (
+            mock_service.http.post.call_args[0][0]
+            == "/api/v1/sampling-sessions/sess-001/continue-generation"
+        )
+        assert result == {"ok": True}
+
+
+# --------------------------------------------------------------------------- #
+# Async client                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+class TestAsyncClient:
+    def test_pause_generation_default_abort(self):
+        client, mock_service = _make_async_client()
+        mock_service.http.post.return_value = {"ok": True}
+
+        result = asyncio.run(client.pause_generation())
+
+        assert (
+            mock_service.http.post.call_args[0][0]
+            == "/api/v1/sampling-sessions/sess-001/pause-generation"
+        )
+        assert mock_service.http.post.call_args[1]["json"] == {"mode": "abort"}
+        assert result == {"ok": True}
+
+    def test_continue_generation(self):
+        client, mock_service = _make_async_client()
+        mock_service.http.post.return_value = {"ok": True}
+        asyncio.run(client.continue_generation())
+        assert (
+            mock_service.http.post.call_args[0][0]
+            == "/api/v1/sampling-sessions/sess-001/continue-generation"
+        )
+
+    def test_pause_generation_invalid_mode(self):
+        client, _ = _make_async_client()
+        with pytest.raises(ValueError):
+            asyncio.run(client.pause_generation(mode="freeze"))
+
+
+# --------------------------------------------------------------------------- #
+# Result schema: weight_version + pause(abort) partial                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestResultSchema:
+    def test_weight_version_top_level_passthrough(self):
+        payload = {
+            "result": {
+                "weight_version": "v42",
+                "sequences": [{"tokens": [1, 2], "text": "hi", "stop_reason": "stop"}],
+            }
+        }
+        out = _su.normalize_sample_result(payload, MagicMock())
+        assert out["weight_version"] == "v42"
+
+    def test_weight_version_per_sequence_passthrough(self):
+        payload = {
+            "result": {
+                "sequences": [
+                    {"tokens": [1], "text": "a", "stop_reason": "stop", "weight_version": "v7"}
+                ]
+            }
+        }
+        out = _su.normalize_sample_result(payload, MagicMock())
+        assert out["sequences"][0]["weight_version"] == "v7"
+
+    def test_abort_partial_is_returned(self):
+        payload = {
+            "result": {
+                "sequences": [
+                    {"tokens": [9, 8, 7], "text": "par", "stop_reason": "abort"},
+                ]
+            }
+        }
+        out = _su.normalize_sample_result(payload, MagicMock())
+        assert out["sequences"][0]["stop_reason"] == "abort"
+        assert out["sequences"][0]["tokens"] == [9, 8, 7]
+
+    def test_empty_aborted_sequence_is_preserved(self):
+        # A pause(abort) may cut a request before any token is emitted; the
+        # aborted marker must survive rather than being filtered out.
+        payload = {
+            "result": {
+                "sequences": [
+                    {"tokens": [], "text": "", "stop_reason": "abort"},
+                    {"tokens": [], "text": "", "stop_reason": "stop"},
+                ]
+            }
+        }
+        out = _su.normalize_sample_result(payload, MagicMock())
+        kept = out["sequences"]
+        assert len(kept) == 1
+        assert kept[0]["stop_reason"] == "abort"

--- a/weaver/_sampling_utils.py
+++ b/weaver/_sampling_utils.py
@@ -27,6 +27,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 
 from ._utils import lookup_case_insensitive
 from .types import LogprobsParams, ModelInput, SamplingParams
+from .types.sampling_control import PauseMode, coerce_pause_mode
 
 TokenizerProvider = Callable[[], PreTrainedTokenizer]
 
@@ -64,6 +65,11 @@ def build_logprobs_body(
 ) -> Dict[str, Any]:
     params = logprobs_params or LogprobsParams()
     return {"prompt": prompt.to_payload(), **params.to_payload()}
+
+
+def build_pause_generation_body(mode: "PauseMode | str") -> Dict[str, Any]:
+    """Build the ``pause-generation`` request body, validating ``mode``."""
+    return {"mode": coerce_pause_mode(mode)}
 
 
 def sanitize_tokens(value: Any) -> List[int]:
@@ -162,8 +168,14 @@ def sequences_from_result(
                 sequence["sampling_masks"] = raw["sampling_masks"]
             if "moe_topk_indices" in raw and raw["moe_topk_indices"] is not None:
                 sequence["moe_topk_indices"] = raw["moe_topk_indices"]
+            weight_version = lookup_case_insensitive(raw, "weight_version")
+            if weight_version is not None:
+                sequence["weight_version"] = weight_version
             sequences.append(sequence)
-        return [seq for seq in sequences if seq["tokens"]]
+        # Keep aborted sequences even when empty: a pause(mode="abort") may cut a
+        # request before any token is emitted, and NexRL still needs the partial
+        # (stop_reason="abort") signal rather than a silently dropped sequence.
+        return [seq for seq in sequences if seq["tokens"] or seq.get("stop_reason") == "abort"]
 
     choices = result.get("choices")
     if not isinstance(choices, list):
@@ -195,6 +207,11 @@ def normalize_sample_result(payload: Any, get_tokenizer: TokenizerProvider) -> A
     usage = result.get("usage")
     if usage:
         normalized["usage"] = usage
+    # Surface the engine weight version so NexRL can compute staleness /
+    # off-policy masks without digging into raw_result.
+    weight_version = lookup_case_insensitive(result, "weight_version")
+    if weight_version is not None:
+        normalized["weight_version"] = weight_version
     return normalized
 
 

--- a/weaver/async_sampling_client.py
+++ b/weaver/async_sampling_client.py
@@ -24,7 +24,7 @@ from . import _sampling_utils as _su
 from ._utils import lookup_case_insensitive
 from .async_service_client import AsyncServiceClient
 from .operations import AsyncOperationHandle
-from .types import LogprobsParams, ModelInput, SamplingParams
+from .types import LogprobsParams, ModelInput, PauseMode, SamplingParams
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -139,6 +139,26 @@ class AsyncSamplingClient:
             "logprobs": logprobs,
             "return_rollout_token_expert_data": result.get("return_rollout_token_expert_data"),
         }
+
+    async def pause_generation(self, *, mode: PauseMode | str = PauseMode.ABORT) -> Dict[str, Any]:
+        """Pause in-flight generation on the engines behind this session.
+
+        See :meth:`weaver.sampling_client.SamplingClient.pause_generation`.
+        """
+        body = _su.build_pause_generation_body(mode)
+        return await self._service.http.post(
+            f"/api/v1/sampling-sessions/{self.sampling_session_id}/pause-generation",
+            json=body,
+        )
+
+    async def continue_generation(self) -> Dict[str, Any]:
+        """Resume generation after a :meth:`pause_generation` call.
+
+        See :meth:`weaver.sampling_client.SamplingClient.continue_generation`.
+        """
+        return await self._service.http.post(
+            f"/api/v1/sampling-sessions/{self.sampling_session_id}/continue-generation",
+        )
 
     async def _ensure_tokenizer_source(self) -> None:
         """Make sure a tokenizer path or base_model is known (may fetch the session)."""

--- a/weaver/sampling_client.py
+++ b/weaver/sampling_client.py
@@ -24,7 +24,7 @@ from . import _sampling_utils as _su
 from ._utils import lookup_case_insensitive
 from .operations import OperationHandle
 from .service_client import ServiceClient
-from .types import LogprobsParams, ModelInput, SamplingParams
+from .types import LogprobsParams, ModelInput, PauseMode, SamplingParams
 
 
 class SamplingClient:
@@ -118,6 +118,43 @@ class SamplingClient:
             "logprobs": logprobs,
             "return_rollout_token_expert_data": result.get("return_rollout_token_expert_data"),
         }
+
+    def pause_generation(self, *, mode: PauseMode | str = PauseMode.ABORT) -> Dict[str, Any]:
+        """Pause in-flight generation on the engines behind this session.
+
+        This is a stateless control primitive: it freezes the engine until
+        :meth:`continue_generation` is called. With the default
+        ``mode="abort"`` the waiting + running requests are aborted on the spot
+        and their partial output is returned to the callers of :meth:`sample`
+        (with ``stop_reason="abort"``) — this is the recovery shape used for
+        partial/async rollout weight swaps
+        (abort -> drain -> sync_weights -> continue).
+
+        Args:
+            mode: How to treat in-flight requests. One of :class:`PauseMode`
+                (``abort`` / ``retract`` / ``in_place``) or its string value.
+
+        Returns:
+            The server response payload.
+
+        Raises:
+            ValueError: If ``mode`` is not a supported pause mode.
+        """
+        body = _su.build_pause_generation_body(mode)
+        return self._service.http.post(
+            f"/api/v1/sampling-sessions/{self.sampling_session_id}/pause-generation",
+            json=body,
+        )
+
+    def continue_generation(self) -> Dict[str, Any]:
+        """Resume generation after a :meth:`pause_generation` call.
+
+        Returns:
+            The server response payload.
+        """
+        return self._service.http.post(
+            f"/api/v1/sampling-sessions/{self.sampling_session_id}/continue-generation",
+        )
 
     def _normalize_sample_result(self, payload: Any) -> Any:
         return _su.normalize_sample_result(payload, self._ensure_tokenizer)

--- a/weaver/types/__init__.py
+++ b/weaver/types/__init__.py
@@ -41,6 +41,7 @@ from .router_replay import (
     router_replay_shard_uri,
 )
 from .sampling import SamplingParams
+from .sampling_control import PauseMode, coerce_pause_mode
 from .tensor import TensorData
 
 __all__ = [
@@ -51,6 +52,7 @@ __all__ = [
     "LogprobsParams",
     "ModelInput",
     "ModelInputChunk",
+    "PauseMode",
     "PayloadRef",
     "PayloadRefMaterializationError",
     "ROUTER_REPLAY_FORMAT_TOKEN_LAYER_TOPK",
@@ -66,6 +68,7 @@ __all__ = [
     "RouterReplayModelConfig",
     "SamplingParams",
     "TensorData",
+    "coerce_pause_mode",
     "materialize_payload_ref",
     "materialize_router_replay_index",
     "materialize_router_replay_indices",

--- a/weaver/types/sampling_control.py
+++ b/weaver/types/sampling_control.py
@@ -1,0 +1,61 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sampling engine control-plane types shared across Weaver clients."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class PauseMode(str, Enum):
+    """How the sampling engine should pause in-flight generation.
+
+    All three modes freeze the engine until generation is continued; they
+    differ in what happens to requests that are already in flight:
+
+    - ``ABORT``: abort waiting + running requests on the spot and return their
+      partial output to the caller (``stop_reason="abort"``). This is the mode
+      used for partial/async rollout weight swaps
+      (abort -> drain -> sync_weights -> continue).
+    - ``RETRACT``: retract running requests back into the waiting queue so they
+      resume from scratch after ``continue``.
+    - ``IN_PLACE``: freeze requests where they are and resume them in place
+      after ``continue``.
+    """
+
+    ABORT = "abort"
+    RETRACT = "retract"
+    IN_PLACE = "in_place"
+
+
+def coerce_pause_mode(mode: "PauseMode | str") -> str:
+    """Validate and normalize a pause mode to its wire string.
+
+    Args:
+        mode: A :class:`PauseMode` member or its string value.
+
+    Returns:
+        The canonical wire string (e.g. ``"abort"``).
+
+    Raises:
+        ValueError: If ``mode`` is not one of the supported pause modes.
+    """
+    if isinstance(mode, PauseMode):
+        return mode.value
+    try:
+        return PauseMode(mode).value
+    except ValueError as exc:
+        valid = ", ".join(m.value for m in PauseMode)
+        raise ValueError(f"invalid pause mode {mode!r}: expected one of {valid}") from exc


### PR DESCRIPTION
Fixes #84

## What

Exposes the sampling engine's stateless control-plane primitives on the sampling client so NexRL can drive **partial / async rollout** weight swaps (abort → drain → sync_weights → continue). Implemented in lockstep across the **sync** and **async** client stacks.

### New API (on `SamplingClient` and `AsyncSamplingClient`)

| Method | Endpoint | Notes |
|--------|----------|-------|
| `pause_generation(*, mode=PauseMode.ABORT)` | `POST /api/v1/sampling-sessions/{id}/pause-generation` | Freezes the engine until `continue_generation`. `mode="abort"` aborts in-flight requests and returns their partial output. |
| `continue_generation()` | `POST /api/v1/sampling-sessions/{id}/continue-generation` | Resumes generation. |

### `PauseMode` enum (`weaver/types/sampling_control.py`)

`abort` / `retract` / `in_place` (default `abort`), validated via shared `coerce_pause_mode`. Exported from `weaver.types`.

### Result schema

- `sample()` results now pass through `weight_version` (top-level + per-sequence) from the engine, so NexRL can compute staleness / off-policy masks.
- `pause_generation(mode="abort")` partials are returned as **normal results** with `stop_reason="abort"` — aborted sequences are preserved even when empty, so the abort signal is never silently dropped.

## Design notes

Per `.claude/rules/async-compatibility.md`, all request/response logic lives in the shared `weaver/_sampling_utils.py` / `weaver/types/sampling_control.py` (`build_pause_generation_body`, `weight_version` / abort passthrough) — no logic forked into either stack. Sync and async signatures are aligned; async methods `await` the `AsyncAPIClient` calls (no blocking IO). These are synchronous (non-`OperationHandle`) control endpoints.

## Testing

- `tests/test_sampling_control.py` (15 tests): enum/coercion, sync + async client behavior, and `weight_version` / abort-partial passthrough (incl. the empty-aborted-sequence edge case).
- Full suite green in a DevBox sandbox (`pytest tests/` → all pass). `black` + `isort` clean.
- Note: the `pylint`/`mypy` pre-commit hooks hang in this environment on any `torch`-importing file (a known env limitation — the Makefile wraps both in `|| true`); they were skipped for the commit while `black`/`isort`/license-header hooks ran and passed.

## Scope

- Load / in-flight-count introspection (`get_load`) was intentionally dropped — we do not expose engine load.
- Streaming sampling (`sample(stream=True)`) is out of scope — tracked separately in #88.

## Related

- Upstream requirement: china-qijizhifeng/nex-taas-feedback#181
- Framework orchestration (consumer): china-qijizhifeng/NexRL#288
- Server passthrough: china-qijizhifeng/weaver-server#357