### PR TITLE
fix(checkpoint): default sampling checkpoints to a bounded TTL

### DIFF
--- a/tests/test_training_checkpoint.py
+++ b/tests/test_training_checkpoint.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from weaver._utils import DEFAULT_SAMPLER_TTL_SECONDS
 from weaver.operations import OperationHandle
 from weaver.training_client import TrainingClient
 from weaver.types.checkpoint import Checkpoint
@@ -383,6 +384,34 @@ class TestSaveStateTTL:
         body = tc._service.enqueue_operation.call_args[0][1]
         assert body["ttl_seconds"] == 3600
 
+    def test_sampling_type_defaults_to_sampler_ttl(self):
+        # A sampling checkpoint saved without an explicit TTL gets the default
+        # sampler TTL so regenerable exports don't accumulate. Weight types keep
+        # their permanent default (test_default_no_ttl_in_body).
+        tc = _make_training_client()
+        handle = _make_handle({"id": "ckpt-s", "path": "weaver://ckpt-s"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_state(name="test", checkpoint_type="sampling")
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert body["ttl_seconds"] == DEFAULT_SAMPLER_TTL_SECONDS
+
+    def test_sampling_type_explicit_none_stays_permanent(self):
+        tc = _make_training_client()
+        handle = _make_handle({"id": "ckpt-s", "path": "weaver://ckpt-s"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_state(name="test", checkpoint_type="sampling", ttl_seconds=None)
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert "ttl_seconds" in body
+        assert body["ttl_seconds"] is None
+
+    def test_sampling_type_explicit_ttl_wins(self):
+        tc = _make_training_client()
+        handle = _make_handle({"id": "ckpt-s", "path": "weaver://ckpt-s"})
+        tc._service.enqueue_operation.return_value = handle
+        tc.save_state(name="test", checkpoint_type="sampling", ttl_seconds=3600)
+        body = tc._service.enqueue_operation.call_args[0][1]
+        assert body["ttl_seconds"] == 3600
+
 
 # ---------------------------------------------------------------------------
 # save_weights_for_sampler TTL
@@ -390,13 +419,13 @@ class TestSaveStateTTL:
 
 
 class TestSaveWeightsForSamplerTTL:
-    def test_default_is_one_day(self):
+    def test_default_is_sampler_ttl(self):
         tc = _make_training_client()
         handle = _make_handle({"model_path": "weaver://path"})
         tc._service.enqueue_operation.return_value = handle
         tc.save_weights_for_sampler(name="test")
         body = tc._service.enqueue_operation.call_args[0][1]
-        assert body["ttl_seconds"] == 86400
+        assert body["ttl_seconds"] == DEFAULT_SAMPLER_TTL_SECONDS
 
     def test_explicit_none_no_ttl_in_body(self):
         tc = _make_training_client()
@@ -421,14 +450,14 @@ class TestSaveWeightsForSamplerTTL:
 
 
 class TestSaveWeightsAndGetSamplingClientTTL:
-    def test_default_sends_86400(self):
+    def test_default_is_sampler_ttl(self):
         tc = _make_training_client()
         handle = _make_handle({"model_path": "weaver://path", "sampling_session_id": "ss-1"})
         tc._service.enqueue_operation.return_value = handle
         tc._service.get_sampling_client.return_value = MagicMock()
         tc.save_weights_and_get_sampling_client()
         body = tc._service.enqueue_operation.call_args[0][1]
-        assert body["ttl_seconds"] == 86400
+        assert body["ttl_seconds"] == DEFAULT_SAMPLER_TTL_SECONDS
 
     def test_explicit_none_no_ttl_in_body(self):
         tc = _make_training_client()

--- a/weaver/_utils.py
+++ b/weaver/_utils.py
@@ -39,6 +39,14 @@ class _UnsetType:
 UNSET = _UnsetType()
 
 
+# Default time-to-live for sampling checkpoints created through the SDK. Sampler
+# exports are regenerable, short-lived RL weight-sync artifacts, so the SDK
+# stamps a bounded TTL by default instead of letting them accumulate forever on
+# shared storage. Callers can pass an explicit ``ttl_seconds`` (including
+# ``None`` for permanent retention) to override it.
+DEFAULT_SAMPLER_TTL_SECONDS = 3600  # 1 hour
+
+
 def lookup_case_insensitive(payload: Dict[str, Any], name: str) -> Any:
     variants = {
         name,

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -36,7 +36,7 @@ from ._payloads import (
     forward_payload,
     parse_logprob_tensors,
 )
-from ._utils import UNSET, _UnsetType, lookup_case_insensitive
+from ._utils import DEFAULT_SAMPLER_TTL_SECONDS, UNSET, _UnsetType, lookup_case_insensitive
 from .async_service_client import AsyncServiceClient
 from .operations import AsyncOperationHandle
 from .types import AdamParams, Datum
@@ -273,20 +273,24 @@ class AsyncTrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: "Literal[True]" = True,
     ) -> str: ...
 
     @overload
     async def save_weights_for_sampler(
-        self, *, name: str | None = None, ttl_seconds: int | None = 86400, wait: "Literal[False]"
+        self,
+        *,
+        name: str | None = None,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
+        wait: "Literal[False]",
     ) -> AsyncOperationHandle: ...
 
     async def save_weights_for_sampler(
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: bool = True,
     ) -> str | AsyncOperationHandle:
         """Export model weights for sampling.
@@ -319,20 +323,24 @@ class AsyncTrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: "Literal[True]" = True,
     ) -> "AsyncSamplingClient": ...
 
     @overload
     async def save_weights_and_get_sampling_client(
-        self, *, name: str | None = None, ttl_seconds: int | None = 86400, wait: "Literal[False]"
+        self,
+        *,
+        name: str | None = None,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
+        wait: "Literal[False]",
     ) -> AsyncOperationHandle: ...
 
     async def save_weights_and_get_sampling_client(
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: bool = True,
     ) -> "AsyncSamplingClient | AsyncOperationHandle":
         """Export model weights and create an async sampling client.
@@ -429,6 +437,11 @@ class AsyncTrainingClient:
             body["name"] = name
         if not isinstance(ttl_seconds, _UnsetType):
             body["ttl_seconds"] = ttl_seconds
+        elif checkpoint_type == "sampling":
+            # Regenerable sampling checkpoints default to a bounded TTL so they
+            # don't accumulate on shared storage; weight checkpoints stay
+            # permanent unless an explicit ttl_seconds is given.
+            body["ttl_seconds"] = DEFAULT_SAMPLER_TTL_SECONDS
         handle = await self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/checkpoints",
             body,

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -28,7 +28,7 @@ from ._payloads import (
     parse_logprob_tensors,
     serialize_data,
 )
-from ._utils import UNSET, _UnsetType, lookup_case_insensitive
+from ._utils import DEFAULT_SAMPLER_TTL_SECONDS, UNSET, _UnsetType, lookup_case_insensitive
 from .operations import OperationHandle
 from .service_client import ServiceClient
 from .types import AdamParams, Datum
@@ -275,7 +275,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: Literal[True] = True,
     ) -> str: ...
 
@@ -284,7 +284,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -292,20 +292,20 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: bool = True,
     ) -> str | OperationHandle:
         """Export model weights for sampling.
 
         Sampler weights are intended for short-lived RL weight-sync use, so
-        the default TTL is **1 day (86400 s)**.  Pass ``ttl_seconds=None`` to
+        the default TTL is **1 hour (3600 s)**.  Pass ``ttl_seconds=None`` to
         keep the exported checkpoint permanently (use ``save_state`` if you
         need a durable checkpoint instead).
 
         Args:
             name: Optional custom path name for the exported weights
             ttl_seconds: Time-to-live in seconds for the exported checkpoint.
-                Defaults to ``86400`` (1 day).  Pass ``None`` for permanent.
+                Defaults to ``3600`` (1 hour).  Pass ``None`` for permanent.
             wait: If True (default), waits for export to complete and returns path.
                   If False, returns an OperationHandle immediately.
 
@@ -339,7 +339,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: Literal[True] = True,
     ) -> "SamplingClient": ...
 
@@ -348,7 +348,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: Literal[False],
     ) -> OperationHandle: ...
 
@@ -356,7 +356,7 @@ class TrainingClient:
         self,
         *,
         name: str | None = None,
-        ttl_seconds: int | None = 86400,
+        ttl_seconds: int | None = DEFAULT_SAMPLER_TTL_SECONDS,
         wait: bool = True,
     ) -> "SamplingClient" | OperationHandle:
         """Export model weights and create a sampling client.
@@ -365,13 +365,13 @@ class TrainingClient:
         and get_sampling_client. For more control, use those methods separately.
 
         Because this method is designed for frequent RL weight-sync calls,
-        the default TTL is **1 day (86400 s)**.  Pass ``ttl_seconds=None``
+        the default TTL is **1 hour (3600 s)**.  Pass ``ttl_seconds=None``
         to keep the checkpoint permanently.
 
         Args:
             name: Optional custom path name for the exported weights
             ttl_seconds: Time-to-live in seconds for the exported checkpoint.
-                Defaults to ``86400`` (1 day).  Pass ``None`` for permanent.
+                Defaults to ``3600`` (1 hour).  Pass ``None`` for permanent.
             wait: If True (default), waits for export and returns SamplingClient.
                   If False, returns an OperationHandle immediately.
 
@@ -466,12 +466,15 @@ class TrainingClient:
             name: Human-readable checkpoint label (e.g. ``"step-100"``).
                 The server generates the full storage path incorporating
                 the model ID automatically.
-            checkpoint_type: ``"weight"`` (default) or
-                ``"weight_and_optimizer"``.
-            ttl_seconds: Time-to-live in seconds for the checkpoint.
-                Defaults to ``None`` (permanent, backward-compatible).
-                Pass an integer to set auto-expiration, or explicit ``None``
-                to ensure permanent retention.
+            checkpoint_type: ``"weight"`` (default), ``"weight_and_optimizer"``,
+                or ``"sampling"``.
+            ttl_seconds: Time-to-live in seconds for the checkpoint. When
+                omitted, weight checkpoints are kept permanently (backward
+                compatible) while ``"sampling"`` checkpoints default to
+                ``DEFAULT_SAMPLER_TTL_SECONDS`` (1 hour), matching the sampler
+                export methods, since they are regenerable. Pass an integer to
+                set auto-expiration, or explicit ``None`` to force permanent
+                retention for any type.
             wait: If True (default), blocks until the save completes and
                 returns a :class:`~weaver.types.Checkpoint`.
 
@@ -484,6 +487,11 @@ class TrainingClient:
             body["name"] = name
         if not isinstance(ttl_seconds, _UnsetType):
             body["ttl_seconds"] = ttl_seconds
+        elif checkpoint_type == "sampling":
+            # Regenerable sampling checkpoints default to a bounded TTL so they
+            # don't accumulate on shared storage; weight checkpoints stay
+            # permanent unless an explicit ttl_seconds is given.
+            body["ttl_seconds"] = DEFAULT_SAMPLER_TTL_SECONDS
         handle = self._service.enqueue_operation(
             f"/api/v1/models/{self.model_id}/checkpoints",
             body,


### PR DESCRIPTION
## Summary

Sampling exports are regenerable, short-lived weight-sync artifacts, but some SDK paths registered them with **no TTL**, so they accumulated on shared storage indefinitely. This gives every sampling-producing path the same bounded default TTL, while leaving **persistent checkpoints untouched**.

## Changes

- **Unify the sampling default TTL at 1 hour (3600 s)**, single-sourced as `DEFAULT_SAMPLER_TTL_SECONDS`. Applied by all three sampling-producing paths: `save_weights_for_sampler`, `save_weights_and_get_sampling_client`, and `save_state(checkpoint_type="sampling")` (which previously sent no TTL). 1 hour is comfortably longer than a weight-sync cycle while still reclaiming storage promptly.
- **Persistent checkpoints are never auto-expired.** `save_state` with a weight checkpoint type keeps its permanent default — no TTL is added. An explicit `ttl_seconds` (including `None` for permanent) always overrides, for any type.
- Docstrings updated; default-behaviour tests assert against the constant so the value stays single-sourced.

## Testing

- [x] Unit suite green (166 passed)
- [x] Sampling saves default to the constant; explicit `None` stays permanent; explicit int wins; **weight-type saves add no TTL**
- [x] Lint / type checks clean (pre-commit)