### PR TITLE
feat(training): add binary tensor transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ the server keeps its stable personal-organization/default-project fallback.
 
 ### Training tensor transport
 
-`WEAVER_TENSOR_TRANSPORT` accepts `default` or `http-binary`. HTTP packs can set
-`WEAVER_TENSOR_COMPRESSION=zstd`.
+`WEAVER_TENSOR_TRANSPORT` accepts `default` (inline JSON) or `http-binary`.
+HTTP packs use Zstandard compression by default; set
+`WEAVER_TENSOR_COMPRESSION=raw` to disable compression.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Configuration can be provided via keyword arguments or environment variables:
 Canonical IDs take precedence. When no organization or project is configured,
 the server keeps its stable personal-organization/default-project fallback.
 
+### Training tensor transport
+
+`WEAVER_TENSOR_TRANSPORT` accepts `default` or `http-binary`. HTTP packs can set
+`WEAVER_TENSOR_COMPRESSION=zstd`.
+
 ## Quickstart
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "torch>=2.3,<3",
   "transformers",
   "typing-extensions>=4.8,<5",
+  "zstandard>=0.23,<1",
   "click>=8.1,<9",
   "rich>=13.0",
   # OpenTelemetry for distributed tracing (lightweight, no exporters)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,8 @@ def test_config_defaults():
     config = WeaverConfig()
     assert config.base_url == "https://weaver-console.nex-agi.cn"
     assert config.api_key is None
+    assert config.tensor_transport == "default"
+    assert config.tensor_compression == "raw"
 
 
 def test_config_from_kwargs():
@@ -42,23 +44,58 @@ def test_config_from_env(monkeypatch):
     """Test config loading from environment variables."""
     monkeypatch.setenv("WEAVER_BASE_URL", "https://env.example.com")
     monkeypatch.setenv("WEAVER_API_KEY", "sk-env-key")
+    monkeypatch.setenv("WEAVER_TENSOR_TRANSPORT", "http-binary")
+    monkeypatch.setenv("WEAVER_TENSOR_COMPRESSION", "zstd")
 
     config = WeaverConfig.from_env()
     assert config.base_url == "https://env.example.com"
     assert config.api_key == "sk-env-key"
+    assert config.tensor_transport == "http-binary"
+    assert config.tensor_compression == "zstd"
 
 
 def test_config_kwargs_override_env(monkeypatch):
     """Test that kwargs override environment variables."""
     monkeypatch.setenv("WEAVER_BASE_URL", "https://env.example.com")
     monkeypatch.setenv("WEAVER_API_KEY", "sk-env-key")
+    monkeypatch.setenv("WEAVER_TENSOR_TRANSPORT", "http-binary")
+    monkeypatch.setenv("WEAVER_TENSOR_COMPRESSION", "zstd")
 
     config = WeaverConfig.from_env(
         base_url="https://override.example.com",
         api_key="sk-override-key",
+        tensor_transport="default",
+        tensor_compression="raw",
     )
     assert config.base_url == "https://override.example.com"
     assert config.api_key == "sk-override-key"
+    assert config.tensor_transport == "default"
+    assert config.tensor_compression == "raw"
+
+
+def test_config_rejects_unknown_tensor_transport(monkeypatch):
+    monkeypatch.setenv("WEAVER_TENSOR_TRANSPORT", "magic")
+
+    with pytest.raises(ValueError, match="Unsupported tensor transport"):
+        WeaverConfig.from_env()
+
+    with pytest.raises(ValueError, match="Unsupported tensor transport"):
+        WeaverConfig(tensor_transport="magic")  # type: ignore[arg-type]
+
+
+def test_config_rejects_unknown_tensor_compression(monkeypatch):
+    monkeypatch.setenv("WEAVER_TENSOR_COMPRESSION", "magic")
+
+    with pytest.raises(ValueError, match="Unsupported tensor compression"):
+        WeaverConfig.from_env()
+
+    with pytest.raises(ValueError, match="Unsupported tensor compression"):
+        WeaverConfig(tensor_compression="magic")  # type: ignore[arg-type]
+
+
+def test_config_rejects_compression_without_http_transport():
+    with pytest.raises(ValueError, match="requires tensor_transport"):
+        WeaverConfig(tensor_compression="zstd")
 
 
 def test_require_auth_with_credentials():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ def test_config_defaults():
     assert config.base_url == "https://weaver-console.nex-agi.cn"
     assert config.api_key is None
     assert config.tensor_transport == "default"
-    assert config.tensor_compression == "raw"
+    assert config.tensor_compression == "zstd"
 
 
 def test_config_from_kwargs():
@@ -93,9 +93,10 @@ def test_config_rejects_unknown_tensor_compression(monkeypatch):
         WeaverConfig(tensor_compression="magic")  # type: ignore[arg-type]
 
 
-def test_config_rejects_compression_without_http_transport():
-    with pytest.raises(ValueError, match="requires tensor_transport"):
-        WeaverConfig(tensor_compression="zstd")
+def test_http_binary_defaults_to_zstd():
+    config = WeaverConfig(tensor_transport="http-binary")
+
+    assert config.tensor_compression == "zstd"
 
 
 def test_require_auth_with_credentials():

--- a/tests/test_temperature_payload.py
+++ b/tests/test_temperature_payload.py
@@ -27,6 +27,8 @@ from weaver.types import Datum, LogprobsParams, ModelInput
 def _make_training_client() -> TrainingClient:
     service = MagicMock()
     service.next_operation_seq.return_value = 1
+    service.tensor_transport = "default"
+    service.tensor_compression = "raw"
     return TrainingClient(
         service=service,
         model_id="model-123",
@@ -97,10 +99,12 @@ def test_forward_backward_custom_uses_forward_and_reuses_loss_fn_config() -> Non
         *,
         loss_fn_config: dict[str, float] | None = None,
         wait: bool = True,
-    ) -> dict[str, Any]:
+    ) -> Any:
         calls.append({"loss_fn": loss_fn, "loss_fn_config": loss_fn_config})
         if loss_fn == "forward_logprob":
-            return {"result": {"loss_fn_outputs": [{"logprobs": [1.0]}]}}
+            handle = MagicMock()
+            handle.result.return_value = {"result": {"loss_fn_outputs": [{"logprobs": [1.0]}]}}
+            return handle
         return {"result": {}}
 
     def fake_forward_backward(

--- a/tests/test_tensor_transport.py
+++ b/tests/test_tensor_transport.py
@@ -457,6 +457,96 @@ def test_async_operation_result_transparently_materializes_and_caches_pack(codec
     asyncio.run(exercise())
 
 
+def test_operation_refresh_replaces_inline_result_without_stale_cache():
+    class RefreshClient:
+        def get(self, path):
+            assert path == "/api/v1/operations/op-1"
+            return {"status": "done", "response": {"value": 2}}
+
+    handle = OperationHandle(
+        client=RefreshClient(),
+        operation_id="op-1",
+        _cached={"status": "done", "response": {"value": 1}},
+    )
+
+    assert handle.result() == {"value": 1}
+    assert handle.refresh()["response"] == {"value": 2}
+    assert handle.response == {"value": 2}
+    assert handle.result() == {"value": 2}
+
+
+def test_async_operation_refresh_replaces_inline_result_without_stale_cache():
+    async def exercise() -> None:
+        class RefreshClient:
+            async def get(self, path):
+                assert path == "/api/v1/operations/op-1"
+                return {"status": "done", "response": {"value": 2}}
+
+        handle = AsyncOperationHandle(
+            client=RefreshClient(),
+            operation_id="op-1",
+            _cached={"status": "done", "response": {"value": 1}},
+        )
+
+        assert await handle.result() == {"value": 1}
+        assert (await handle.refresh())["response"] == {"value": 2}
+        assert handle.response == {"value": 2}
+        assert await handle.result() == {"value": 2}
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("codec", ["raw", "zstd"])
+def test_operation_refresh_materializes_binary_transition(codec):
+    values = np.asarray([-0.2, -0.4], dtype="<f4")
+    result = _http_logprob_result(values, codec=codec)
+
+    class RefreshClient(_SyncTensorPackClient):
+        def get(self, path):
+            assert path == "/api/v1/operations/op-1"
+            return {"status": "done", "response": result}
+
+    client = RefreshClient(values.tobytes(), codec)
+    handle = OperationHandle(
+        client=client,
+        operation_id="op-1",
+        _cached={"status": "processing"},
+    )
+
+    expected = _inline_logprob_result(values)
+    assert handle.refresh()["response"] == expected
+    assert handle.response == expected
+    assert handle.result() == expected
+    assert client.calls == 1
+
+
+@pytest.mark.parametrize("codec", ["raw", "zstd"])
+def test_async_operation_refresh_materializes_binary_transition(codec):
+    async def exercise() -> None:
+        values = np.asarray([-0.2, -0.4], dtype="<f4")
+        result = _http_logprob_result(values, codec=codec)
+
+        class RefreshClient(_AsyncTensorPackClient):
+            async def get(self, path):
+                assert path == "/api/v1/operations/op-1"
+                return {"status": "done", "response": result}
+
+        client = RefreshClient(values.tobytes(), codec)
+        handle = AsyncOperationHandle(
+            client=client,
+            operation_id="op-1",
+            _cached={"status": "processing"},
+        )
+
+        expected = _inline_logprob_result(values)
+        assert (await handle.refresh())["response"] == expected
+        assert handle.response == expected
+        assert await handle.result() == expected
+        assert client.calls == 1
+
+    asyncio.run(exercise())
+
+
 def test_operation_wait_all_materializes_binary_results():
     values = np.asarray([-0.2, -0.4], dtype="<f4")
     clients = [_SyncTensorPackClient(values.tobytes(), "raw") for _ in range(2)]

--- a/tests/test_tensor_transport.py
+++ b/tests/test_tensor_transport.py
@@ -39,13 +39,16 @@ from weaver._payloads import (
 )
 from weaver.async_training_client import AsyncTrainingClient, _build_training_payload
 from weaver.config import WeaverConfig
+from weaver.operations import AsyncOperationHandle, OperationHandle
 from weaver.tensor_transport import (
     TENSOR_KEY,
     MultipartLayout,
     PreparedOperationBody,
     TensorPack,
     decompress_zstd_tensor_pack,
+    materialize_http_tensor,
     result_tensor_pack_metadata,
+    result_uses_http_tensor_pack,
 )
 from weaver.training_client import TrainingClient
 from weaver.types import Datum, ModelInput
@@ -309,6 +312,22 @@ def test_parse_logprobs_materializes_http_tensor_pack():
     assert tensors[0].requires_grad
 
 
+def test_materialize_http_tensor_checks_pack_bounds_before_allocating():
+    ref = {
+        TENSOR_KEY: {
+            "format": "raw-tensor",
+            "codec": "raw",
+            "dtype": "float32",
+            "shape": [1_000_000_000],
+            "offset": 0,
+            "size_bytes": 4_000_000_000,
+        }
+    }
+
+    with pytest.raises(ValueError, match="slice exceeds the tensor pack"):
+        materialize_http_tensor(ref, io.BytesIO(b"tiny"))
+
+
 def test_downloaded_tensor_pack_metadata_is_strict():
     payload = {"tensor_pack": {"size_bytes": 4, "sha256": "0" * 64}}
 
@@ -335,6 +354,64 @@ def test_zstd_result_metadata_and_exact_decompression():
 
     assert metadata.codec == "zstd"
     assert destination.read() == decoded
+
+
+def test_zstd_decompression_accepts_bounded_concatenated_frames():
+    compressor = zstandard.ZstdCompressor()
+    wire = compressor.compress(b"abc") + compressor.compress(b"def")
+    destination = io.BytesIO()
+
+    decompress_zstd_tensor_pack(io.BytesIO(wire), destination, 6)
+
+    assert destination.read() == b"abcdef"
+
+
+def test_operation_results_bind_binary_pack_without_changing_inline_results():
+    values = np.asarray([-0.2, -0.4], dtype="<f4")
+    binary = _http_logprob_result(values)
+    inline = {"result": {"loss_fn_outputs": [{"logprobs": {"data": [-0.2]}}]}}
+
+    binary_handle = OperationHandle(
+        client=SimpleNamespace(),
+        operation_id="op-1",
+        _cached={"status": "done", "response": binary},
+    )
+    inline_handle = OperationHandle(
+        client=SimpleNamespace(),
+        operation_id="op-2",
+        _cached={"status": "done", "response": inline},
+    )
+
+    bound = binary_handle.result()
+    assert bound["tensor_pack"]["operation_id"] == "op-1"
+    assert "operation_id" not in binary["tensor_pack"]
+    assert inline_handle.result() is inline
+
+
+def test_result_tensor_pack_detection_does_not_scan_inline_outputs():
+    class NoTraversal(dict):
+        def values(self):
+            raise AssertionError("inline output was traversed")
+
+    assert not result_uses_http_tensor_pack(NoTraversal(result={"values": [1, 2, 3]}))
+    assert result_uses_http_tensor_pack({"tensor_pack": {"size_bytes": 1}})
+
+
+def test_async_operation_result_binds_binary_pack():
+    async def exercise() -> None:
+        values = np.asarray([-0.2, -0.4], dtype="<f4")
+        result = _http_logprob_result(values)
+        handle = AsyncOperationHandle(
+            client=SimpleNamespace(),
+            operation_id="op-1",
+            _cached={"status": "done", "response": result},
+        )
+
+        bound = await handle.result()
+
+        assert bound["tensor_pack"]["operation_id"] == "op-1"
+
+    asyncio.run(exercise())
 
 
 @pytest.mark.parametrize(
@@ -568,6 +645,73 @@ def _http_logprob_result(values: np.ndarray) -> dict:
     }
 
 
+def _nested_http_tensor_result() -> tuple[dict, bytes]:
+    values = np.asarray([0.25, 0.5], dtype="<f4")
+    result = _http_logprob_result(values)
+    reference = result["result"]["loss_fn_outputs"][0].pop("logprobs")
+    result["result"]["loss_fn_outputs"][0]["custom"] = {"nested": [reference, reference]}
+    result["tensor_pack"]["operation_id"] = "op-1"
+    return result, values.tobytes()
+
+
+def _write_test_tensor_pack(pack, operation_id, destination, **metadata):
+    assert operation_id == "op-1"
+    assert metadata == {
+        "size_bytes": len(pack),
+        "sha256": hashlib.sha256(pack).hexdigest(),
+        "codec": "raw",
+        "decoded_size_bytes": len(pack),
+    }
+    destination.write(pack)
+    destination.seek(0)
+
+
+def test_sync_client_materializes_every_nested_result_tensor():
+    result, pack = _nested_http_tensor_result()
+    download_client = SimpleNamespace(
+        download_tensor_pack=lambda operation_id, destination, **metadata: (
+            _write_test_tensor_pack(pack, operation_id, destination, **metadata)
+        )
+    )
+    client = TrainingClient(
+        service=SimpleNamespace(http=download_client),
+        model_id="model-1",
+        base_model="base",
+        session_id="session-1",
+    )
+
+    materialized = client.materialize_result_tensors(result)
+
+    output = materialized["result"]["loss_fn_outputs"][0]
+    expected = torch.tensor([0.25, 0.5], dtype=torch.float32)
+    assert all(torch.equal(tensor, expected) for tensor in output["custom"]["nested"])
+    assert TENSOR_KEY in result["result"]["loss_fn_outputs"][0]["custom"]["nested"][0]
+
+
+def test_async_client_materializes_every_nested_result_tensor():
+    async def exercise() -> None:
+        result, pack = _nested_http_tensor_result()
+
+        class DownloadClient:
+            async def download_tensor_pack(self, operation_id, destination, **metadata):
+                _write_test_tensor_pack(pack, operation_id, destination, **metadata)
+
+        client = AsyncTrainingClient(
+            service=SimpleNamespace(http=DownloadClient()),
+            model_id="model-1",
+            base_model="base",
+            session_id="session-1",
+        )
+
+        materialized = await client.materialize_result_tensors(result)
+
+        output = materialized["result"]["loss_fn_outputs"][0]
+        expected = torch.tensor([0.25, 0.5], dtype=torch.float32)
+        assert all(torch.equal(tensor, expected) for tensor in output["custom"]["nested"])
+
+    asyncio.run(exercise())
+
+
 def test_sync_custom_loss_downloads_one_operation_pack():
     values = np.asarray([-0.2, -0.4, -0.6], dtype="<f4")
     result = _http_logprob_result(values)
@@ -595,13 +739,13 @@ def test_sync_custom_loss_downloads_one_operation_pack():
             destination.seek(0)
 
     download_client = DownloadClient()
-    handle = SimpleNamespace(
-        operation_id="op-1",
+    handle = OperationHandle(
         client=download_client,
-        result=lambda: result,
+        operation_id="op-1",
+        _cached={"status": "done", "response": result},
     )
     client = TrainingClient(
-        service=SimpleNamespace(),
+        service=SimpleNamespace(http=download_client),
         model_id="model-1",
         base_model="base",
         session_id="session-1",
@@ -654,23 +798,21 @@ def test_async_custom_loss_downloads_one_operation_pack():
 
         download_client = DownloadClient()
 
-        class Handle:
-            operation_id = "op-1"
-            client = download_client
-
-            async def result(self):
-                return result
-
         client = AsyncTrainingClient(
-            service=SimpleNamespace(),
+            service=SimpleNamespace(http=download_client),
             model_id="model-1",
             base_model="base",
             session_id="session-1",
         )
+        handle = AsyncOperationHandle(
+            client=download_client,
+            operation_id="op-1",
+            _cached={"status": "done", "response": result},
+        )
 
         async def fake_forward(self, *args, **kwargs):
             assert kwargs["wait"] is False
-            return Handle()
+            return handle
 
         async def fake_forward_backward(self, *args, **kwargs):
             return {}

--- a/tests/test_tensor_transport.py
+++ b/tests/test_tensor_transport.py
@@ -100,9 +100,28 @@ def test_default_transport_remains_inline():
     datum = payload["forward_backward_input"]["data"][0]
 
     assert payload["tensor_transport"] == "default"
+    assert "tensor_compression" not in payload
     assert datum["model_input"]["chunks"][0]["tokens"] == [11, 12, 13]
     assert datum["loss_fn_inputs"]["target_tokens"]["data"] == [12, 13, 14]
     assert datum["loss_fn_inputs"]["weights"]["data"] == [0.0, 1.0, 1.0]
+
+
+def test_http_binary_defaults_to_zstd():
+    prepared = prepare_forward_backward_operation(
+        model_id="model-1",
+        seq_id=7,
+        data=[_datum()],
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+        request_metadata=None,
+        tensor_transport="http-binary",
+    )
+    try:
+        assert prepared.body["payload"]["tensor_compression"] == "zstd"
+        assert prepared.tensor_pack is not None
+        assert prepared.tensor_pack.codec == "zstd"
+    finally:
+        prepared.close()
 
 
 def test_http_binary_normalizes_dense_input_dtypes():

--- a/tests/test_tensor_transport.py
+++ b/tests/test_tensor_transport.py
@@ -235,6 +235,13 @@ def test_http_binary_is_cross_entropy_only():
     ]
 
 
+def test_http_binary_rejects_protocol_limit_before_upload(monkeypatch):
+    monkeypatch.setattr("weaver.tensor_transport._MAX_TENSOR_PACK_BYTES", 1)
+
+    with pytest.raises(ValueError, match="decoded_size_bytes.*exceeds maximum"):
+        _prepare(transport="http-binary")
+
+
 def test_sync_and_async_multipart_streams_are_identical():
     prepared = _prepare(transport="http-binary")
     assert prepared.tensor_pack is not None
@@ -334,6 +341,18 @@ def test_downloaded_tensor_pack_metadata_is_strict():
     metadata = result_tensor_pack_metadata(payload)
     assert metadata.codec == "raw"
     assert metadata.decoded_size_bytes == 4
+
+
+def test_downloaded_tensor_pack_metadata_reports_protocol_limit():
+    payload = {
+        "tensor_pack": {
+            "size_bytes": (8 << 30) + 1,
+            "sha256": "0" * 64,
+        }
+    }
+
+    with pytest.raises(ValueError, match="size_bytes.*exceeds maximum"):
+        result_tensor_pack_metadata(payload)
 
 
 def test_zstd_result_metadata_and_exact_decompression():
@@ -495,6 +514,33 @@ def test_sync_http_client_downloads_result_pack_once():
 
     assert calls == 1
     assert destination.read() == payload
+
+
+def test_sync_http_client_rejects_protocol_limit_before_request():
+    calls = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(500)
+
+    client = APIClient(WeaverConfig(base_url="https://example.test"))
+    client._client.close()
+    client._client = httpx.Client(
+        base_url="https://example.test", transport=httpx.MockTransport(handler)
+    )
+    try:
+        with pytest.raises(ValueError, match="size_bytes.*exceeds maximum"):
+            client.download_tensor_pack(
+                "op-1",
+                io.BytesIO(),
+                size_bytes=(8 << 30) + 1,
+                sha256="0" * 64,
+            )
+    finally:
+        client.close()
+
+    assert calls == 0
 
 
 def test_sync_http_client_verifies_then_decompresses_zstd_result_pack():

--- a/tests/test_tensor_transport.py
+++ b/tests/test_tensor_transport.py
@@ -1,0 +1,704 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for training tensor transport."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import json
+import threading
+from email.parser import BytesParser
+from email.policy import default as email_policy
+from types import MethodType, SimpleNamespace
+
+import httpx
+import numpy as np
+import pytest
+import torch
+import zstandard
+
+from weaver._async_http import AsyncAPIClient
+from weaver._http import APIClient
+from weaver._payloads import (
+    parse_logprob_tensors,
+    prepare_forward_backward_operation,
+)
+from weaver.async_training_client import AsyncTrainingClient, _build_training_payload
+from weaver.config import WeaverConfig
+from weaver.tensor_transport import (
+    TENSOR_KEY,
+    MultipartLayout,
+    PreparedOperationBody,
+    TensorPack,
+    decompress_zstd_tensor_pack,
+    result_tensor_pack_metadata,
+)
+from weaver.training_client import TrainingClient
+from weaver.types import Datum, ModelInput
+
+
+def _datum() -> Datum:
+    return Datum(
+        model_input=ModelInput.from_ints([11, 12, 13]),
+        loss_fn_inputs={
+            "target_tokens": torch.tensor([12, 13, 14], dtype=torch.int64),
+            "weights": torch.tensor([0.0, 1.0, 1.0], dtype=torch.float32),
+        },
+        metadata={"source": "test"},
+    )
+
+
+def _payload(transport="default", loss_fn="cross_entropy"):
+    prepared = _prepare(transport=transport, loss_fn=loss_fn)
+    assert prepared.tensor_pack is None
+    return prepared.body["payload"]
+
+
+def _prepare(
+    *, transport="default", compression="raw", loss_fn="cross_entropy", seq_id=7, data=None
+):
+    return prepare_forward_backward_operation(
+        model_id="model-1",
+        seq_id=seq_id,
+        data=[_datum()] if data is None else data,
+        loss_fn=loss_fn,
+        loss_fn_config=None,
+        request_metadata=None,
+        tensor_transport=transport,
+        tensor_compression=compression,
+    )
+
+
+def _multipart_parts(layout: MultipartLayout) -> dict[str, bytes]:
+    body = b"".join(layout.sync_stream())
+    assert len(body) == layout.content_length
+    message = BytesParser(policy=email_policy).parsebytes(
+        f"Content-Type: {layout.content_type}\r\nMIME-Version: 1.0\r\n\r\n".encode() + body
+    )
+    return {
+        part.get_param("name", header="content-disposition"): part.get_payload(decode=True)
+        for part in message.iter_parts()
+    }
+
+
+def test_default_transport_remains_inline():
+    payload = _payload()
+    datum = payload["forward_backward_input"]["data"][0]
+
+    assert payload["tensor_transport"] == "default"
+    assert datum["model_input"]["chunks"][0]["tokens"] == [11, 12, 13]
+    assert datum["loss_fn_inputs"]["target_tokens"]["data"] == [12, 13, 14]
+    assert datum["loss_fn_inputs"]["weights"]["data"] == [0.0, 1.0, 1.0]
+
+
+def test_http_binary_normalizes_dense_input_dtypes():
+    datum = Datum(
+        model_input=ModelInput.from_ints([11, 12]),
+        loss_fn_inputs={
+            "target_tokens": torch.tensor([12, 13], dtype=torch.int32),
+            "weights": torch.tensor([0.0, 1.0], dtype=torch.float16),
+        },
+    )
+
+    prepared = _prepare(transport="http-binary", data=[datum])
+    try:
+        wire = prepared.body["payload"]["forward_backward_input"]["data"][0]
+        assert wire["loss_fn_inputs"]["target_tokens"][TENSOR_KEY]["dtype"] == "int64"
+        assert wire["loss_fn_inputs"]["weights"][TENSOR_KEY]["dtype"] == "float32"
+    finally:
+        prepared.close()
+
+
+def test_http_binary_builds_one_path_free_pack():
+    prepared = _prepare(transport="http-binary")
+    assert prepared.tensor_pack is not None
+    pack_path = prepared.tensor_pack.path
+    try:
+        payload = prepared.body["payload"]
+        datum = payload["forward_backward_input"]["data"][0]
+        refs = [
+            datum["model_input"]["chunks"][0]["tokens"],
+            datum["loss_fn_inputs"]["target_tokens"],
+            datum["loss_fn_inputs"]["weights"],
+        ]
+        assert all(TENSOR_KEY in ref for ref in refs)
+        assert all(
+            "path" not in descriptor and "uri" not in descriptor and "storage" not in descriptor
+            for ref in refs
+            for descriptor in [ref[TENSOR_KEY]]
+        )
+        assert prepared.tensor_pack.size_bytes == 60
+        assert prepared.tensor_pack.sha256 == hashlib.sha256(pack_path.read_bytes()).hexdigest()
+
+        layout = MultipartLayout(prepared.body, prepared.tensor_pack)
+        parts = _multipart_parts(layout)
+        manifest = json.loads(parts["manifest"])
+        assert set(parts) == {"manifest", "tensor_pack"}
+        assert manifest == {
+            "version": 1,
+            "request": prepared.body,
+            "tensor_pack": {
+                "size_bytes": 60,
+                "sha256": prepared.tensor_pack.sha256,
+                "codec": "raw",
+                "decoded_size_bytes": 60,
+            },
+        }
+        assert parts["tensor_pack"] == pack_path.read_bytes()
+    finally:
+        prepared.close()
+    assert not pack_path.exists()
+
+
+def test_http_binary_zstd_streams_one_compressed_pack():
+    prepared = _prepare(transport="http-binary", compression="zstd")
+    assert prepared.tensor_pack is not None
+    pack = prepared.tensor_pack
+    try:
+        wire = pack.path.read_bytes()
+        decoded = zstandard.ZstdDecompressor().decompress(
+            wire, max_output_size=pack.decoded_size_bytes
+        )
+        assert pack.codec == "zstd"
+        assert pack.decoded_size_bytes == 60
+        assert pack.size_bytes == len(wire)
+        assert pack.sha256 == hashlib.sha256(wire).hexdigest()
+        assert decoded == b"".join(
+            [
+                np.asarray([11, 12, 13], dtype="<i8").tobytes(),
+                np.asarray([12, 13, 14], dtype="<i8").tobytes(),
+                np.asarray([0.0, 1.0, 1.0], dtype="<f4").tobytes(),
+            ]
+        )
+
+        parts = _multipart_parts(MultipartLayout(prepared.body, pack))
+        manifest = json.loads(parts["manifest"])
+        assert manifest["request"]["payload"]["tensor_compression"] == "zstd"
+        assert manifest["tensor_pack"] == {
+            "size_bytes": len(wire),
+            "sha256": pack.sha256,
+            "codec": "zstd",
+            "decoded_size_bytes": 60,
+        }
+        assert parts["tensor_pack"] == wire
+    finally:
+        prepared.close()
+
+
+def test_http_binary_is_cross_entropy_only():
+    prepared = _prepare(transport="http-binary", compression="zstd", loss_fn="forward_logprob")
+
+    assert prepared.tensor_pack is None
+    payload = prepared.body["payload"]
+    assert payload["tensor_transport"] == "http-binary"
+    assert payload["tensor_compression"] == "zstd"
+    assert payload["forward_backward_input"]["data"][0]["model_input"]["chunks"][0]["tokens"] == [
+        11,
+        12,
+        13,
+    ]
+
+
+def test_sync_and_async_multipart_streams_are_identical():
+    prepared = _prepare(transport="http-binary")
+    assert prepared.tensor_pack is not None
+    try:
+        layout = MultipartLayout(prepared.body, prepared.tensor_pack)
+        sync_body = b"".join(layout.sync_stream())
+
+        async def collect() -> bytes:
+            chunks = [chunk async for chunk in layout.async_stream()]
+            return b"".join(chunks)
+
+        assert asyncio.run(collect()) == sync_body
+    finally:
+        prepared.close()
+
+
+def test_async_multipart_file_reads_yield_the_event_loop():
+    prepared = _prepare(transport="http-binary")
+    assert prepared.tensor_pack is not None
+
+    async def collect() -> int:
+        layout = MultipartLayout(prepared.body, prepared.tensor_pack)
+        ticks = 0
+        running = True
+
+        async def ticker() -> None:
+            nonlocal ticks
+            while running:
+                await asyncio.sleep(0)
+                ticks += 1
+
+        task = asyncio.create_task(ticker())
+        try:
+            _ = b"".join([chunk async for chunk in layout.async_stream()])
+        finally:
+            running = False
+            await task
+        return ticks
+
+    try:
+        assert asyncio.run(collect()) > 0
+    finally:
+        prepared.close()
+
+
+def test_parse_logprobs_materializes_http_tensor_pack():
+    values = np.asarray([-0.2, -0.4], dtype="<f4")
+    result = {
+        "result": {
+            "loss_fn_outputs": [
+                {
+                    "logprobs": {
+                        TENSOR_KEY: {
+                            "format": "raw-tensor",
+                            "codec": "raw",
+                            "dtype": "float32",
+                            "shape": [2],
+                            "offset": 0,
+                            "size_bytes": values.nbytes,
+                        }
+                    }
+                }
+            ]
+        },
+        "tensor_pack": {
+            "size_bytes": values.nbytes,
+            "sha256": hashlib.sha256(values.tobytes()).hexdigest(),
+        },
+    }
+
+    pack = io.BytesIO(values.tobytes())
+    tensors = parse_logprob_tensors(result, [_datum()], tensor_pack=pack)
+
+    assert tensors[0].tolist() == pytest.approx([-0.2, -0.4])
+    assert tensors[0].requires_grad
+
+
+def test_downloaded_tensor_pack_metadata_is_strict():
+    payload = {"tensor_pack": {"size_bytes": 4, "sha256": "0" * 64}}
+
+    metadata = result_tensor_pack_metadata(payload)
+    assert metadata.codec == "raw"
+    assert metadata.decoded_size_bytes == 4
+
+
+def test_zstd_result_metadata_and_exact_decompression():
+    decoded = b"tensor-pack" * 100
+    wire = zstandard.ZstdCompressor().compress(decoded)
+    payload = {
+        "tensor_pack": {
+            "size_bytes": len(wire),
+            "sha256": hashlib.sha256(wire).hexdigest(),
+            "codec": "zstd",
+            "decoded_size_bytes": len(decoded),
+        }
+    }
+
+    metadata = result_tensor_pack_metadata(payload)
+    destination = io.BytesIO()
+    decompress_zstd_tensor_pack(io.BytesIO(wire), destination, metadata.decoded_size_bytes)
+
+    assert metadata.codec == "zstd"
+    assert destination.read() == decoded
+
+
+@pytest.mark.parametrize(
+    ("wire", "decoded_size", "error"),
+    [
+        (zstandard.ZstdCompressor().compress(b"0123456789"), 9, "exceeds expected"),
+        (zstandard.ZstdCompressor().compress(b"0123456789"), 11, "has 10 bytes"),
+        (zstandard.ZstdCompressor().compress(b"0123456789")[:-1], 10, "truncated"),
+        (
+            zstandard.ZstdCompressor().compress(b"0123456789") + b"trailing",
+            10,
+            "trailing compressed data",
+        ),
+    ],
+)
+def test_zstd_decompression_rejects_invalid_bounds(wire, decoded_size, error):
+    with pytest.raises(ValueError, match=error):
+        decompress_zstd_tensor_pack(io.BytesIO(wire), io.BytesIO(), decoded_size)
+
+
+def test_sync_http_client_submits_multipart_without_retry():
+    prepared = _prepare(transport="http-binary")
+    assert prepared.tensor_pack is not None
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        body = request.read()
+        assert request.headers["content-type"].startswith("multipart/form-data; boundary=")
+        assert int(request.headers["content-length"]) == len(body)
+        raise httpx.WriteError("ambiguous failure", request=request)
+
+    client = APIClient(WeaverConfig(base_url="https://example.test"))
+    client._client.close()
+    client._client = httpx.Client(
+        base_url="https://example.test", transport=httpx.MockTransport(handler)
+    )
+    try:
+        with pytest.raises(httpx.WriteError, match="ambiguous failure"):
+            client.post_tensor_multipart(
+                "/api/v1/models/model-1/forward-backward-passes",
+                request=prepared.body,
+                tensor_pack=prepared.tensor_pack,
+            )
+        assert calls == 1
+    finally:
+        client.close()
+        prepared.close()
+
+
+def test_sync_http_client_downloads_result_pack_once():
+    payload = b"tensor-pack"
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        assert request.url.path == "/api/v1/operations/op-1/tensor-pack"
+        return httpx.Response(
+            200,
+            headers={"Content-Length": str(len(payload))},
+            stream=httpx.ByteStream(payload),
+        )
+
+    client = APIClient(WeaverConfig(base_url="https://example.test"))
+    client._client.close()
+    client._client = httpx.Client(
+        base_url="https://example.test", transport=httpx.MockTransport(handler)
+    )
+    destination = io.BytesIO()
+    try:
+        client.download_tensor_pack(
+            "op-1",
+            destination,
+            size_bytes=len(payload),
+            sha256=hashlib.sha256(payload).hexdigest(),
+        )
+    finally:
+        client.close()
+
+    assert calls == 1
+    assert destination.read() == payload
+
+
+def test_sync_http_client_verifies_then_decompresses_zstd_result_pack():
+    decoded = b"tensor-pack" * 100
+    wire = zstandard.ZstdCompressor().compress(decoded)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "Content-Length": str(len(wire)),
+                "X-Weaver-Tensor-Codec": "zstd",
+                "X-Weaver-Tensor-Decoded-Size": str(len(decoded)),
+            },
+            stream=httpx.ByteStream(wire),
+        )
+
+    client = APIClient(WeaverConfig(base_url="https://example.test"))
+    client._client.close()
+    client._client = httpx.Client(
+        base_url="https://example.test", transport=httpx.MockTransport(handler)
+    )
+    destination = io.BytesIO()
+    try:
+        client.download_tensor_pack(
+            "op-1",
+            destination,
+            size_bytes=len(wire),
+            sha256=hashlib.sha256(wire).hexdigest(),
+            codec="zstd",
+            decoded_size_bytes=len(decoded),
+        )
+    finally:
+        client.close()
+
+    assert destination.read() == decoded
+
+
+@pytest.mark.parametrize(
+    ("headers", "payload", "error"),
+    [
+        ({}, b"tensor-pack", "missing Content-Length"),
+        ({"Content-Length": "1"}, b"tensor-pack", "Content-Length is 1"),
+        ({"Content-Length": "10"}, b"tensor-pack", "exceeds expected 10 bytes"),
+    ],
+)
+def test_sync_http_client_bounds_result_pack(headers, payload, error):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers=headers, stream=httpx.ByteStream(payload))
+
+    client = APIClient(WeaverConfig(base_url="https://example.test"))
+    client._client.close()
+    client._client = httpx.Client(
+        base_url="https://example.test", transport=httpx.MockTransport(handler)
+    )
+    destination = io.BytesIO()
+    try:
+        with pytest.raises(ValueError, match=error):
+            client.download_tensor_pack(
+                "op-1", destination, size_bytes=10, sha256=hashlib.sha256(payload).hexdigest()
+            )
+    finally:
+        client.close()
+
+
+def test_async_http_client_streams_multipart_and_result_pack():
+    async def exercise() -> None:
+        prepared = _prepare(transport="http-binary")
+        assert prepared.tensor_pack is not None
+        uploads = 0
+        downloads = 0
+        result_pack = b"result-pack" * 100
+        result_wire = zstandard.ZstdCompressor().compress(result_pack)
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal uploads, downloads
+            if request.method == "POST":
+                uploads += 1
+                body = await request.aread()
+                assert int(request.headers["content-length"]) == len(body)
+                return httpx.Response(202, json={"id": "op-1", "status": "pending"})
+            downloads += 1
+            assert request.url.path == "/api/v1/operations/op-1/tensor-pack"
+            return httpx.Response(
+                200,
+                headers={
+                    "Content-Length": str(len(result_wire)),
+                    "X-Weaver-Tensor-Codec": "zstd",
+                    "X-Weaver-Tensor-Decoded-Size": str(len(result_pack)),
+                },
+                stream=httpx.ByteStream(result_wire),
+            )
+
+        client = AsyncAPIClient(WeaverConfig(base_url="https://example.test"))
+        await client._client.aclose()
+        client._client = httpx.AsyncClient(
+            base_url="https://example.test", transport=httpx.MockTransport(handler)
+        )
+        destination = io.BytesIO()
+        try:
+            response = await client.post_tensor_multipart(
+                "/api/v1/models/model-1/forward-backward-passes",
+                request=prepared.body,
+                tensor_pack=prepared.tensor_pack,
+            )
+            await client.download_tensor_pack(
+                "op-1",
+                destination,
+                size_bytes=len(result_wire),
+                sha256=hashlib.sha256(result_wire).hexdigest(),
+                codec="zstd",
+                decoded_size_bytes=len(result_pack),
+            )
+        finally:
+            await client.aclose()
+            prepared.close()
+
+        assert response["id"] == "op-1"
+        assert uploads == 1
+        assert downloads == 1
+        assert destination.read() == result_pack
+
+    asyncio.run(exercise())
+
+
+def _http_logprob_result(values: np.ndarray) -> dict:
+    return {
+        "result": {
+            "loss_fn_outputs": [
+                {
+                    "logprobs": {
+                        TENSOR_KEY: {
+                            "format": "raw-tensor",
+                            "codec": "raw",
+                            "dtype": "float32",
+                            "shape": list(values.shape),
+                            "offset": 0,
+                            "size_bytes": values.nbytes,
+                        }
+                    }
+                }
+            ]
+        },
+        "tensor_pack": {
+            "size_bytes": values.nbytes,
+            "sha256": hashlib.sha256(values.tobytes()).hexdigest(),
+        },
+    }
+
+
+def test_sync_custom_loss_downloads_one_operation_pack():
+    values = np.asarray([-0.2, -0.4, -0.6], dtype="<f4")
+    result = _http_logprob_result(values)
+
+    class DownloadClient:
+        calls = 0
+
+        def download_tensor_pack(
+            self,
+            operation_id,
+            destination,
+            *,
+            size_bytes,
+            sha256,
+            codec,
+            decoded_size_bytes,
+        ):
+            assert operation_id == "op-1"
+            assert size_bytes == values.nbytes
+            assert sha256 == hashlib.sha256(values.tobytes()).hexdigest()
+            assert codec == "raw"
+            assert decoded_size_bytes == values.nbytes
+            self.calls += 1
+            destination.write(values.tobytes())
+            destination.seek(0)
+
+    download_client = DownloadClient()
+    handle = SimpleNamespace(
+        operation_id="op-1",
+        client=download_client,
+        result=lambda: result,
+    )
+    client = TrainingClient(
+        service=SimpleNamespace(),
+        model_id="model-1",
+        base_model="base",
+        session_id="session-1",
+    )
+
+    def fake_forward(self, *args, **kwargs):
+        assert kwargs["wait"] is False
+        return handle
+
+    def fake_forward_backward(self, *args, **kwargs):
+        return {}
+
+    client.forward = MethodType(fake_forward, client)
+    client.forward_backward = MethodType(fake_forward_backward, client)
+
+    output = client.forward_backward_custom(
+        [_datum()], lambda _data, logprobs: (logprobs[0].sum(), {"ok": True})
+    )
+
+    assert download_client.calls == 1
+    assert output["metrics"] == {"ok": True}
+
+
+def test_async_custom_loss_downloads_one_operation_pack():
+    async def exercise() -> None:
+        values = np.asarray([-0.2, -0.4, -0.6], dtype="<f4")
+        result = _http_logprob_result(values)
+
+        class DownloadClient:
+            calls = 0
+
+            async def download_tensor_pack(
+                self,
+                operation_id,
+                destination,
+                *,
+                size_bytes,
+                sha256,
+                codec,
+                decoded_size_bytes,
+            ):
+                assert operation_id == "op-1"
+                assert size_bytes == values.nbytes
+                assert sha256 == hashlib.sha256(values.tobytes()).hexdigest()
+                assert codec == "raw"
+                assert decoded_size_bytes == values.nbytes
+                self.calls += 1
+                destination.write(values.tobytes())
+                destination.seek(0)
+
+        download_client = DownloadClient()
+
+        class Handle:
+            operation_id = "op-1"
+            client = download_client
+
+            async def result(self):
+                return result
+
+        client = AsyncTrainingClient(
+            service=SimpleNamespace(),
+            model_id="model-1",
+            base_model="base",
+            session_id="session-1",
+        )
+
+        async def fake_forward(self, *args, **kwargs):
+            assert kwargs["wait"] is False
+            return Handle()
+
+        async def fake_forward_backward(self, *args, **kwargs):
+            return {}
+
+        client.forward = MethodType(fake_forward, client)
+        client.forward_backward = MethodType(fake_forward_backward, client)
+        output = await client.forward_backward_custom(
+            [_datum()], lambda _data, logprobs: (logprobs[0].sum(), {"ok": True})
+        )
+
+        assert download_client.calls == 1
+        assert output["metrics"] == {"ok": True}
+
+    asyncio.run(exercise())
+
+
+def test_cancelled_async_payload_build_removes_eventual_temp_pack(tmp_path):
+    started = threading.Event()
+    release = threading.Event()
+    pack_path = tmp_path / "cancelled-pack.bin"
+
+    def builder(**_kwargs):
+        pack_path.write_bytes(b"pack")
+        started.set()
+        release.wait(timeout=5)
+        return PreparedOperationBody(
+            {"payload": {}},
+            TensorPack(pack_path, 4, hashlib.sha256(b"pack").hexdigest()),
+        )
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            _build_training_payload(
+                builder,
+                loss_fn="cross_entropy",
+                tensor_transport="http-binary",
+            )
+        )
+        assert await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        for _ in range(100):
+            if not pack_path.exists():
+                break
+            await asyncio.sleep(0.01)
+
+    asyncio.run(exercise())
+    assert not pack_path.exists()

--- a/tests/test_tensor_transport.py
+++ b/tests/test_tensor_transport.py
@@ -21,6 +21,7 @@ import hashlib
 import io
 import json
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from email.parser import BytesParser
 from email.policy import default as email_policy
 from types import MethodType, SimpleNamespace
@@ -545,6 +546,147 @@ def test_async_operation_refresh_materializes_binary_transition(codec):
         assert client.calls == 1
 
     asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("changed", [False, True])
+def test_operation_refresh_coordinates_with_inflight_materialization(changed):
+    first_values = np.asarray([-0.2, -0.4], dtype="<f4")
+    refreshed_values = np.asarray([-0.6, -0.8], dtype="<f4") if changed else first_values
+    first_response = _http_logprob_result(first_values)
+    refreshed_response = _http_logprob_result(refreshed_values)
+    packs = {
+        first_response["tensor_pack"]["sha256"]: first_values.tobytes(),
+        refreshed_response["tensor_pack"]["sha256"]: refreshed_values.tobytes(),
+    }
+    download_started = threading.Event()
+    allow_download = threading.Event()
+    refresh_started = threading.Event()
+    allow_refresh = threading.Event()
+    refresh_returning = threading.Event()
+
+    class CoordinatedClient:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, path):
+            assert path == "/api/v1/operations/op-1"
+            refresh_started.set()
+            if not changed:
+                assert allow_refresh.wait(timeout=5)
+            refresh_returning.set()
+            return {"status": "done", "response": refreshed_response}
+
+        def download_tensor_pack(self, operation_id, destination, **metadata):
+            assert operation_id == "op-1"
+            decoded = packs[metadata["sha256"]]
+            assert metadata["size_bytes"] == len(decoded)
+            assert metadata["decoded_size_bytes"] == len(decoded)
+            assert metadata["codec"] == "raw"
+            self.calls.append(metadata["sha256"])
+            if len(self.calls) == 1:
+                download_started.set()
+                assert allow_download.wait(timeout=5)
+            destination.write(decoded)
+            destination.seek(0)
+
+    client = CoordinatedClient()
+    handle = OperationHandle(
+        client=client,
+        operation_id="op-1",
+        _cached={"status": "done", "response": first_response},
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        result_future = pool.submit(handle.result)
+        assert download_started.wait(timeout=5)
+        refresh_future = pool.submit(handle.refresh)
+        assert refresh_started.wait(timeout=5)
+        if changed:
+            assert refresh_returning.wait(timeout=5)
+            allow_download.set()
+        else:
+            allow_download.set()
+            result_future.result(timeout=5)
+            allow_refresh.set()
+            assert refresh_returning.wait(timeout=5)
+        result_future.result(timeout=5)
+        refreshed_payload = refresh_future.result(timeout=5)
+
+    expected = _inline_logprob_result(refreshed_values)
+    assert refreshed_payload["response"] == expected
+    assert handle.response == expected
+    assert len(client.calls) == (2 if changed else 1)
+
+
+@pytest.mark.parametrize("changed", [False, True])
+def test_async_operation_refresh_coordinates_with_inflight_materialization(changed):
+    async def exercise() -> None:
+        first_values = np.asarray([-0.2, -0.4], dtype="<f4")
+        refreshed_values = np.asarray([-0.6, -0.8], dtype="<f4") if changed else first_values
+        first_response = _http_logprob_result(first_values)
+        refreshed_response = _http_logprob_result(refreshed_values)
+        packs = {
+            first_response["tensor_pack"]["sha256"]: first_values.tobytes(),
+            refreshed_response["tensor_pack"]["sha256"]: refreshed_values.tobytes(),
+        }
+        download_started = asyncio.Event()
+        allow_download = asyncio.Event()
+        refresh_started = asyncio.Event()
+        allow_refresh = asyncio.Event()
+        refresh_returning = asyncio.Event()
+
+        class CoordinatedClient:
+            def __init__(self):
+                self.calls = []
+
+            async def get(self, path):
+                assert path == "/api/v1/operations/op-1"
+                refresh_started.set()
+                if not changed:
+                    await allow_refresh.wait()
+                refresh_returning.set()
+                return {"status": "done", "response": refreshed_response}
+
+            async def download_tensor_pack(self, operation_id, destination, **metadata):
+                assert operation_id == "op-1"
+                decoded = packs[metadata["sha256"]]
+                assert metadata["size_bytes"] == len(decoded)
+                assert metadata["decoded_size_bytes"] == len(decoded)
+                assert metadata["codec"] == "raw"
+                self.calls.append(metadata["sha256"])
+                if len(self.calls) == 1:
+                    download_started.set()
+                    await allow_download.wait()
+                destination.write(decoded)
+                destination.seek(0)
+
+        client = CoordinatedClient()
+        handle = AsyncOperationHandle(
+            client=client,
+            operation_id="op-1",
+            _cached={"status": "done", "response": first_response},
+        )
+        result_task = asyncio.create_task(handle.result())
+        await download_started.wait()
+        refresh_task = asyncio.create_task(handle.refresh())
+        await refresh_started.wait()
+        if changed:
+            await refresh_returning.wait()
+            allow_download.set()
+        else:
+            allow_download.set()
+            await result_task
+            allow_refresh.set()
+            await refresh_returning.wait()
+        await result_task
+        refreshed_payload = await refresh_task
+
+        expected = _inline_logprob_result(refreshed_values)
+        assert refreshed_payload["response"] == expected
+        assert handle.response == expected
+        assert len(client.calls) == (2 if changed else 1)
+
+    asyncio.run(asyncio.wait_for(exercise(), timeout=10))
 
 
 def test_operation_wait_all_materializes_binary_results():

--- a/tests/test_tensor_transport.py
+++ b/tests/test_tensor_transport.py
@@ -375,23 +375,38 @@ def test_zstd_result_metadata_and_exact_decompression():
     assert destination.read() == decoded
 
 
-def test_zstd_decompression_accepts_bounded_concatenated_frames():
-    compressor = zstandard.ZstdCompressor()
-    wire = compressor.compress(b"abc") + compressor.compress(b"def")
+def test_zstd_decompression_accepts_one_streaming_frame():
+    decoded = b"streaming tensor pack" * 100
+    wire_file = io.BytesIO()
+    compressor = zstandard.ZstdCompressor(write_checksum=True).stream_writer(
+        wire_file, closefd=False
+    )
+    compressor.write(decoded)
+    compressor.close()
     destination = io.BytesIO()
 
-    decompress_zstd_tensor_pack(io.BytesIO(wire), destination, 6)
+    decompress_zstd_tensor_pack(wire_file, destination, len(decoded))
 
-    assert destination.read() == b"abcdef"
+    assert destination.read() == decoded
 
 
-def test_operation_results_bind_binary_pack_without_changing_inline_results():
+def test_zstd_decompression_rejects_concatenated_frames():
+    compressor = zstandard.ZstdCompressor()
+    wire = compressor.compress(b"abc") + compressor.compress(b"def")
+
+    with pytest.raises(ValueError, match="exactly one frame"):
+        decompress_zstd_tensor_pack(io.BytesIO(wire), io.BytesIO(), 6)
+
+
+@pytest.mark.parametrize("codec", ["raw", "zstd"])
+def test_operation_results_transparently_materialize_and_cache_binary_pack(codec):
     values = np.asarray([-0.2, -0.4], dtype="<f4")
-    binary = _http_logprob_result(values)
-    inline = {"result": {"loss_fn_outputs": [{"logprobs": {"data": [-0.2]}}]}}
+    binary = _http_logprob_result(values, codec=codec)
+    inline = _inline_logprob_result(values)
+    client = _SyncTensorPackClient(values.tobytes(), codec)
 
     binary_handle = OperationHandle(
-        client=SimpleNamespace(),
+        client=client,
         operation_id="op-1",
         _cached={"status": "done", "response": binary},
     )
@@ -401,9 +416,12 @@ def test_operation_results_bind_binary_pack_without_changing_inline_results():
         _cached={"status": "done", "response": inline},
     )
 
-    bound = binary_handle.result()
-    assert bound["tensor_pack"]["operation_id"] == "op-1"
-    assert "operation_id" not in binary["tensor_pack"]
+    waited = binary_handle.wait()
+    assert waited["response"] == inline
+    assert binary_handle.response == inline
+    assert binary_handle.result() == inline
+    assert "tensor_pack" not in binary_handle.result()
+    assert client.calls == 1
     assert inline_handle.result() is inline
 
 
@@ -416,19 +434,60 @@ def test_result_tensor_pack_detection_does_not_scan_inline_outputs():
     assert result_uses_http_tensor_pack({"tensor_pack": {"size_bytes": 1}})
 
 
-def test_async_operation_result_binds_binary_pack():
+@pytest.mark.parametrize("codec", ["raw", "zstd"])
+def test_async_operation_result_transparently_materializes_and_caches_pack(codec):
     async def exercise() -> None:
         values = np.asarray([-0.2, -0.4], dtype="<f4")
-        result = _http_logprob_result(values)
+        result = _http_logprob_result(values, codec=codec)
+        client = _AsyncTensorPackClient(values.tobytes(), codec)
         handle = AsyncOperationHandle(
-            client=SimpleNamespace(),
+            client=client,
             operation_id="op-1",
             _cached={"status": "done", "response": result},
         )
 
-        bound = await handle.result()
+        waited = await handle.wait()
+        expected = _inline_logprob_result(values)
+        assert waited["response"] == expected
+        assert handle.response == expected
+        assert await handle.result() == expected
+        assert "tensor_pack" not in await handle.result()
+        assert client.calls == 1
 
-        assert bound["tensor_pack"]["operation_id"] == "op-1"
+    asyncio.run(exercise())
+
+
+def test_operation_wait_all_materializes_binary_results():
+    values = np.asarray([-0.2, -0.4], dtype="<f4")
+    clients = [_SyncTensorPackClient(values.tobytes(), "raw") for _ in range(2)]
+    handles = [
+        OperationHandle(
+            client=client,
+            operation_id="op-1",
+            _cached={"status": "done", "response": _http_logprob_result(values)},
+        )
+        for client in clients
+    ]
+
+    assert OperationHandle.wait_all(handles) == [_inline_logprob_result(values)] * 2
+    assert [client.calls for client in clients] == [1, 1]
+
+
+def test_async_operation_wait_all_materializes_binary_results():
+    async def exercise() -> None:
+        values = np.asarray([-0.2, -0.4], dtype="<f4")
+        clients = [_AsyncTensorPackClient(values.tobytes(), "raw") for _ in range(2)]
+        handles = [
+            AsyncOperationHandle(
+                client=client,
+                operation_id="op-1",
+                _cached={"status": "done", "response": _http_logprob_result(values)},
+            )
+            for client in clients
+        ]
+
+        assert await AsyncOperationHandle.wait_all(handles) == [_inline_logprob_result(values)] * 2
+        assert [client.calls for client in clients] == [1, 1]
 
     asyncio.run(exercise())
 
@@ -442,7 +501,7 @@ def test_async_operation_result_binds_binary_pack():
         (
             zstandard.ZstdCompressor().compress(b"0123456789") + b"trailing",
             10,
-            "trailing compressed data",
+            "exactly one frame",
         ),
     ],
 )
@@ -666,7 +725,25 @@ def test_async_http_client_streams_multipart_and_result_pack():
     asyncio.run(exercise())
 
 
-def _http_logprob_result(values: np.ndarray) -> dict:
+def _inline_logprob_result(values: np.ndarray) -> dict:
+    return {
+        "result": {
+            "loss_fn_outputs": [
+                {
+                    "logprobs": {
+                        "data": values.tolist(),
+                        "dtype": "float32",
+                        "shape": list(values.shape),
+                    }
+                }
+            ]
+        }
+    }
+
+
+def _http_logprob_result(values: np.ndarray, *, codec: str = "raw") -> dict:
+    decoded = values.tobytes()
+    wire = zstandard.ZstdCompressor().compress(decoded) if codec == "zstd" else decoded
     return {
         "result": {
             "loss_fn_outputs": [
@@ -685,10 +762,37 @@ def _http_logprob_result(values: np.ndarray) -> dict:
             ]
         },
         "tensor_pack": {
-            "size_bytes": values.nbytes,
-            "sha256": hashlib.sha256(values.tobytes()).hexdigest(),
+            "size_bytes": len(wire),
+            "sha256": hashlib.sha256(wire).hexdigest(),
+            "codec": codec,
+            "decoded_size_bytes": len(decoded),
         },
     }
+
+
+class _SyncTensorPackClient:
+    def __init__(self, decoded: bytes, codec: str) -> None:
+        self.decoded = decoded
+        self.codec = codec
+        self.wire = zstandard.ZstdCompressor().compress(decoded) if codec == "zstd" else decoded
+        self.calls = 0
+
+    def download_tensor_pack(self, operation_id, destination, **metadata):
+        assert operation_id == "op-1"
+        assert metadata == {
+            "size_bytes": len(self.wire),
+            "sha256": hashlib.sha256(self.wire).hexdigest(),
+            "codec": self.codec,
+            "decoded_size_bytes": len(self.decoded),
+        }
+        self.calls += 1
+        destination.write(self.decoded)
+        destination.seek(0)
+
+
+class _AsyncTensorPackClient(_SyncTensorPackClient):
+    async def download_tensor_pack(self, operation_id, destination, **metadata):
+        super().download_tensor_pack(operation_id, destination, **metadata)
 
 
 def _nested_http_tensor_result() -> tuple[dict, bytes]:
@@ -696,64 +800,42 @@ def _nested_http_tensor_result() -> tuple[dict, bytes]:
     result = _http_logprob_result(values)
     reference = result["result"]["loss_fn_outputs"][0].pop("logprobs")
     result["result"]["loss_fn_outputs"][0]["custom"] = {"nested": [reference, reference]}
-    result["tensor_pack"]["operation_id"] = "op-1"
     return result, values.tobytes()
 
 
-def _write_test_tensor_pack(pack, operation_id, destination, **metadata):
-    assert operation_id == "op-1"
-    assert metadata == {
-        "size_bytes": len(pack),
-        "sha256": hashlib.sha256(pack).hexdigest(),
-        "codec": "raw",
-        "decoded_size_bytes": len(pack),
-    }
-    destination.write(pack)
-    destination.seek(0)
-
-
-def test_sync_client_materializes_every_nested_result_tensor():
+def test_sync_operation_materializes_every_nested_result_tensor():
     result, pack = _nested_http_tensor_result()
-    download_client = SimpleNamespace(
-        download_tensor_pack=lambda operation_id, destination, **metadata: (
-            _write_test_tensor_pack(pack, operation_id, destination, **metadata)
-        )
-    )
-    client = TrainingClient(
-        service=SimpleNamespace(http=download_client),
-        model_id="model-1",
-        base_model="base",
-        session_id="session-1",
+    download_client = _SyncTensorPackClient(pack, "raw")
+    handle = OperationHandle(
+        client=download_client,
+        operation_id="op-1",
+        _cached={"status": "done", "response": result},
     )
 
-    materialized = client.materialize_result_tensors(result)
+    materialized = handle.result()
 
     output = materialized["result"]["loss_fn_outputs"][0]
-    expected = torch.tensor([0.25, 0.5], dtype=torch.float32)
-    assert all(torch.equal(tensor, expected) for tensor in output["custom"]["nested"])
+    expected = {"data": [0.25, 0.5], "dtype": "float32", "shape": [2]}
+    assert output["custom"]["nested"] == [expected, expected]
+    assert "tensor_pack" not in materialized
     assert TENSOR_KEY in result["result"]["loss_fn_outputs"][0]["custom"]["nested"][0]
 
 
-def test_async_client_materializes_every_nested_result_tensor():
+def test_async_operation_materializes_every_nested_result_tensor():
     async def exercise() -> None:
         result, pack = _nested_http_tensor_result()
-
-        class DownloadClient:
-            async def download_tensor_pack(self, operation_id, destination, **metadata):
-                _write_test_tensor_pack(pack, operation_id, destination, **metadata)
-
-        client = AsyncTrainingClient(
-            service=SimpleNamespace(http=DownloadClient()),
-            model_id="model-1",
-            base_model="base",
-            session_id="session-1",
+        handle = AsyncOperationHandle(
+            client=_AsyncTensorPackClient(pack, "raw"),
+            operation_id="op-1",
+            _cached={"status": "done", "response": result},
         )
 
-        materialized = await client.materialize_result_tensors(result)
+        materialized = await handle.result()
 
         output = materialized["result"]["loss_fn_outputs"][0]
-        expected = torch.tensor([0.25, 0.5], dtype=torch.float32)
-        assert all(torch.equal(tensor, expected) for tensor in output["custom"]["nested"])
+        expected = {"data": [0.25, 0.5], "dtype": "float32", "shape": [2]}
+        assert output["custom"]["nested"] == [expected, expected]
+        assert "tensor_pack" not in materialized
 
     asyncio.run(exercise())
 

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -23,8 +23,10 @@ backoff sleeps) is awaited so the event loop stays free for other coroutines.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
+import tempfile
 from typing import Any, BinaryIO, Mapping, MutableMapping
 
 import httpx
@@ -39,17 +41,22 @@ from ._http import (
     DEFAULT_TIMEOUT,
     DOWNLOAD_CHUNK_SIZE,
     DOWNLOAD_TIMEOUT,
+    TENSOR_PACK_CHUNK_BYTES,
     USER_AGENT,
     DownloadURLExpiredError,
     WeaverAPIError,
     _is_connection_error,
+    _validate_tensor_pack_download,
+    _validate_tensor_pack_response_length,
+    _validate_tensor_pack_response_metadata,
     apply_request_span_attributes,
     compute_retry_delay,
     extract_model_id_from_path,
     raise_for_response,
 )
 from ._telemetry import get_tracer
-from .config import WeaverConfig
+from .config import TensorCompression, WeaverConfig
+from .tensor_transport import MultipartLayout, TensorPack, decompress_zstd_tensor_pack
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +136,38 @@ async def async_stream_download_to_file(
     return written
 
 
+async def _await_blocking_io(function: Any, *args: Any, **kwargs: Any) -> Any:
+    """Finish one in-flight file operation before propagating cancellation."""
+
+    task = asyncio.create_task(asyncio.to_thread(function, *args, **kwargs))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        try:
+            await task
+        except BaseException:
+            pass
+        raise
+
+
+async def _open_temporary_file() -> BinaryIO:
+    """Open a temporary file off-loop without leaking it on cancellation."""
+
+    task = asyncio.create_task(asyncio.to_thread(tempfile.TemporaryFile, mode="w+b"))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.add_done_callback(_close_completed_file)
+        raise
+
+
+def _close_completed_file(task: "asyncio.Task[BinaryIO]") -> None:
+    try:
+        task.result().close()
+    except BaseException:
+        pass
+
+
 class AsyncAPIClient:
     """Thin wrapper around ``httpx.AsyncClient`` with Weaver-specific behaviour."""
 
@@ -197,6 +236,117 @@ class AsyncAPIClient:
         max_retries: int | None = None,
     ) -> Any:
         return await self._request("POST", path, params=params, json=json, max_retries=max_retries)
+
+    async def post_tensor_multipart(
+        self,
+        path: str,
+        *,
+        request: Mapping[str, Any],
+        tensor_pack: TensorPack,
+    ) -> Any:
+        """Submit one non-retryable operation with a binary tensor attachment."""
+
+        layout = MultipartLayout(request, tensor_pack)
+        model_id = extract_model_id_from_path(path)
+        with self._tracer.start_as_current_span("weaver.post", kind=trace.SpanKind.CLIENT) as span:
+            apply_request_span_attributes(span, "POST", path, model_id)
+            self._ensure_fresh_client()
+            headers = dict(self._client.headers or {})
+            headers["Content-Type"] = layout.content_type
+            headers["Content-Length"] = str(layout.content_length)
+            inject(headers)
+            try:
+                response = await self._client.request(
+                    "POST",
+                    path,
+                    content=layout.async_stream(),
+                    headers=headers,
+                )
+                span.set_attribute("http.status_code", response.status_code)
+                if not response.is_success:
+                    span.set_status(Status(StatusCode.ERROR, f"HTTP {response.status_code}"))
+                    raise_for_response(response)
+                span.set_status(Status(StatusCode.OK))
+                if response.status_code == httpx.codes.NO_CONTENT or not response.content:
+                    return None
+                return response.json()
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                raise
+
+    async def download_tensor_pack(
+        self,
+        operation_id: str,
+        destination: BinaryIO,
+        *,
+        size_bytes: int,
+        sha256: str,
+        codec: TensorCompression = "raw",
+        decoded_size_bytes: int | None = None,
+    ) -> None:
+        """Download one bounded, verified operation result tensor pack."""
+
+        path = f"/api/v1/operations/{operation_id}/tensor-pack"
+        expected_digest, expected_decoded_size = _validate_tensor_pack_download(
+            size_bytes, sha256, codec, decoded_size_bytes
+        )
+        digest = hashlib.sha256()
+        received = 0
+        compressed = await _open_temporary_file() if codec == "zstd" else None
+        wire_destination = compressed if compressed is not None else destination
+        with self._tracer.start_as_current_span("weaver.get", kind=trace.SpanKind.CLIENT) as span:
+            apply_request_span_attributes(span, "GET", path, None)
+            self._ensure_fresh_client()
+            headers = dict(self._client.headers or {})
+            headers["Accept-Encoding"] = "identity"
+            inject(headers)
+            try:
+                async with self._client.stream("GET", path, headers=headers) as response:
+                    span.set_attribute("http.status_code", response.status_code)
+                    if not response.is_success:
+                        await response.aread()
+                        span.set_status(Status(StatusCode.ERROR, f"HTTP {response.status_code}"))
+                        raise_for_response(response)
+                    _validate_tensor_pack_response_length(response, size_bytes)
+                    _validate_tensor_pack_response_metadata(
+                        response,
+                        codec=codec,
+                        decoded_size_bytes=expected_decoded_size,
+                    )
+                    async for chunk in response.aiter_raw(chunk_size=TENSOR_PACK_CHUNK_BYTES):
+                        if received + len(chunk) > size_bytes:
+                            raise ValueError(
+                                f"downloaded tensor pack exceeds expected {size_bytes} bytes"
+                            )
+                        await _await_blocking_io(wire_destination.write, chunk)
+                        digest.update(chunk)
+                        received += len(chunk)
+                if received != size_bytes:
+                    raise ValueError(
+                        f"downloaded tensor pack has {received} bytes, expected {size_bytes}"
+                    )
+                if digest.hexdigest() != expected_digest:
+                    raise ValueError(
+                        "downloaded tensor pack SHA-256 does not match operation metadata"
+                    )
+                await _await_blocking_io(wire_destination.flush)
+                await _await_blocking_io(wire_destination.seek, 0)
+                if compressed is not None:
+                    await _await_blocking_io(
+                        decompress_zstd_tensor_pack,
+                        compressed,
+                        destination,
+                        expected_decoded_size,
+                    )
+                span.set_status(Status(StatusCode.OK))
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                raise
+            finally:
+                if compressed is not None:
+                    await _await_blocking_io(compressed.close)
 
     async def patch(self, path: str, *, json: Any) -> Any:
         return await self._request("PATCH", path, json=json)

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -16,9 +16,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import re
+import tempfile
 import time
 from typing import Any, BinaryIO, Mapping, MutableMapping
 
@@ -29,7 +31,8 @@ from opentelemetry.trace import Status, StatusCode
 
 from . import __version__
 from ._telemetry import get_tracer
-from .config import WeaverConfig
+from .config import TensorCompression, WeaverConfig
+from .tensor_transport import MultipartLayout, TensorPack, decompress_zstd_tensor_pack
 
 USER_AGENT: str = f"weaver-sdk/{__version__}"  # type: ignore[has-type]
 
@@ -38,6 +41,7 @@ DEFAULT_TIMEOUT = httpx.Timeout(timeout=60, connect=5.0)
 DEFAULT_MAX_RETRIES = 10
 DEFAULT_CONNECTION_RETRIES = 3
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=1000, max_keepalive_connections=20)
+TENSOR_PACK_CHUNK_BYTES = 8 * 1024 * 1024
 
 INITIAL_RETRY_DELAY = 0.5
 MAX_RETRY_DELAY = 10.0
@@ -312,6 +316,79 @@ def stream_download_to_file(
     return written
 
 
+def _validate_tensor_pack_expectation(size_bytes: int, sha256: str) -> str:
+    if isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes < 0:
+        raise ValueError("tensor pack size_bytes must be a non-negative integer")
+    if not isinstance(sha256, str) or len(sha256) != 64:
+        raise ValueError("tensor pack sha256 must be a SHA-256 hex digest")
+    try:
+        bytes.fromhex(sha256)
+    except ValueError as exc:
+        raise ValueError("tensor pack sha256 must be a SHA-256 hex digest") from exc
+    return sha256.lower()
+
+
+def _validate_tensor_pack_download(
+    size_bytes: int,
+    sha256: str,
+    codec: TensorCompression,
+    decoded_size_bytes: int | None,
+) -> tuple[str, int]:
+    digest = _validate_tensor_pack_expectation(size_bytes, sha256)
+    if codec not in {"raw", "zstd"}:
+        raise ValueError("tensor pack codec must be 'raw' or 'zstd'")
+    decoded_size = size_bytes if decoded_size_bytes is None else decoded_size_bytes
+    if isinstance(decoded_size, bool) or not isinstance(decoded_size, int) or decoded_size < 0:
+        raise ValueError("tensor pack decoded_size_bytes must be a non-negative integer")
+    if codec == "raw" and decoded_size != size_bytes:
+        raise ValueError("raw tensor pack decoded_size_bytes must equal size_bytes")
+    return digest, decoded_size
+
+
+def _validate_tensor_pack_response_length(response: httpx.Response, expected: int) -> None:
+    raw_length = response.headers.get("Content-Length")
+    if raw_length is None:
+        raise ValueError("tensor pack response is missing Content-Length")
+    try:
+        content_length = int(raw_length)
+    except ValueError as exc:
+        raise ValueError("tensor pack response has invalid Content-Length") from exc
+    if content_length != expected:
+        raise ValueError(
+            f"tensor pack response Content-Length is {content_length}, expected {expected}"
+        )
+
+
+def _validate_tensor_pack_response_metadata(
+    response: httpx.Response,
+    *,
+    codec: TensorCompression,
+    decoded_size_bytes: int,
+) -> None:
+    response_codec = response.headers.get("X-Weaver-Tensor-Codec", "raw")
+    if response_codec not in {"raw", "zstd"}:
+        raise ValueError(f"tensor pack response has unsupported codec {response_codec!r}")
+    raw_decoded_size = response.headers.get("X-Weaver-Tensor-Decoded-Size")
+    if raw_decoded_size is None:
+        if response_codec != "raw":
+            raise ValueError("zstd tensor pack response is missing decoded size")
+        response_decoded_size = int(response.headers["Content-Length"])
+    else:
+        try:
+            response_decoded_size = int(raw_decoded_size)
+        except ValueError as exc:
+            raise ValueError("tensor pack response has invalid decoded size") from exc
+        if response_decoded_size < 0:
+            raise ValueError("tensor pack response has invalid decoded size")
+    if response_codec != codec:
+        raise ValueError(f"tensor pack response codec is {response_codec!r}, expected {codec!r}")
+    if response_decoded_size != decoded_size_bytes:
+        raise ValueError(
+            "tensor pack response decoded size is "
+            f"{response_decoded_size}, expected {decoded_size_bytes}"
+        )
+
+
 class APIClient:
     """Thin wrapper around httpx.Client with Weaver-specific behavior."""
 
@@ -390,6 +467,116 @@ class APIClient:
         max_retries: int | None = None,
     ) -> Any:
         return self._request("POST", path, params=params, json=json, max_retries=max_retries)
+
+    def post_tensor_multipart(
+        self,
+        path: str,
+        *,
+        request: Mapping[str, Any],
+        tensor_pack: TensorPack,
+    ) -> Any:
+        """Submit one non-retryable operation with a binary tensor attachment."""
+
+        layout = MultipartLayout(request, tensor_pack)
+        model_id = self._extract_model_id_from_path(path)
+        with self._tracer.start_as_current_span("weaver.post", kind=trace.SpanKind.CLIENT) as span:
+            apply_request_span_attributes(span, "POST", path, model_id)
+            self._ensure_fresh_client()
+            headers = dict(self._client.headers or {})
+            headers["Content-Type"] = layout.content_type
+            headers["Content-Length"] = str(layout.content_length)
+            inject(headers)
+            try:
+                response = self._client.request(
+                    "POST",
+                    path,
+                    content=layout.sync_stream(),
+                    headers=headers,
+                )
+                span.set_attribute("http.status_code", response.status_code)
+                if not response.is_success:
+                    span.set_status(Status(StatusCode.ERROR, f"HTTP {response.status_code}"))
+                    self._raise_error(response)
+                span.set_status(Status(StatusCode.OK))
+                if response.status_code == httpx.codes.NO_CONTENT or not response.content:
+                    return None
+                return response.json()
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                raise
+
+    def download_tensor_pack(
+        self,
+        operation_id: str,
+        destination: BinaryIO,
+        *,
+        size_bytes: int,
+        sha256: str,
+        codec: TensorCompression = "raw",
+        decoded_size_bytes: int | None = None,
+    ) -> None:
+        """Download one bounded, verified operation result tensor pack."""
+
+        path = f"/api/v1/operations/{operation_id}/tensor-pack"
+        expected_digest, expected_decoded_size = _validate_tensor_pack_download(
+            size_bytes, sha256, codec, decoded_size_bytes
+        )
+        digest = hashlib.sha256()
+        received = 0
+        compressed = tempfile.TemporaryFile(mode="w+b") if codec == "zstd" else None
+        wire_destination = compressed if compressed is not None else destination
+        with self._tracer.start_as_current_span("weaver.get", kind=trace.SpanKind.CLIENT) as span:
+            apply_request_span_attributes(span, "GET", path, None)
+            self._ensure_fresh_client()
+            headers = dict(self._client.headers or {})
+            headers["Accept-Encoding"] = "identity"
+            inject(headers)
+            try:
+                with self._client.stream("GET", path, headers=headers) as response:
+                    span.set_attribute("http.status_code", response.status_code)
+                    if not response.is_success:
+                        response.read()
+                        span.set_status(Status(StatusCode.ERROR, f"HTTP {response.status_code}"))
+                        self._raise_error(response)
+                    _validate_tensor_pack_response_length(response, size_bytes)
+                    _validate_tensor_pack_response_metadata(
+                        response,
+                        codec=codec,
+                        decoded_size_bytes=expected_decoded_size,
+                    )
+                    for chunk in response.iter_raw(chunk_size=TENSOR_PACK_CHUNK_BYTES):
+                        if received + len(chunk) > size_bytes:
+                            raise ValueError(
+                                f"downloaded tensor pack exceeds expected {size_bytes} bytes"
+                            )
+                        wire_destination.write(chunk)
+                        digest.update(chunk)
+                        received += len(chunk)
+                if received != size_bytes:
+                    raise ValueError(
+                        f"downloaded tensor pack has {received} bytes, expected {size_bytes}"
+                    )
+                if digest.hexdigest() != expected_digest:
+                    raise ValueError(
+                        "downloaded tensor pack SHA-256 does not match operation metadata"
+                    )
+                wire_destination.flush()
+                wire_destination.seek(0)
+                if compressed is not None:
+                    decompress_zstd_tensor_pack(
+                        compressed,
+                        destination,
+                        expected_decoded_size,
+                    )
+                span.set_status(Status(StatusCode.OK))
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                raise
+            finally:
+                if compressed is not None:
+                    compressed.close()
 
     def patch(self, path: str, *, json: Any) -> Any:
         return self._request("PATCH", path, json=json)

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -32,7 +32,12 @@ from opentelemetry.trace import Status, StatusCode
 from . import __version__
 from ._telemetry import get_tracer
 from .config import TensorCompression, WeaverConfig
-from .tensor_transport import MultipartLayout, TensorPack, decompress_zstd_tensor_pack
+from .tensor_transport import (
+    MultipartLayout,
+    TensorPack,
+    _bounded_tensor_pack_size,
+    decompress_zstd_tensor_pack,
+)
 
 USER_AGENT: str = f"weaver-sdk/{__version__}"  # type: ignore[has-type]
 
@@ -317,8 +322,7 @@ def stream_download_to_file(
 
 
 def _validate_tensor_pack_expectation(size_bytes: int, sha256: str) -> str:
-    if isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes < 0:
-        raise ValueError("tensor pack size_bytes must be a non-negative integer")
+    _bounded_tensor_pack_size(size_bytes, "tensor_pack.size_bytes")
     if not isinstance(sha256, str) or len(sha256) != 64:
         raise ValueError("tensor pack sha256 must be a SHA-256 hex digest")
     try:
@@ -337,9 +341,10 @@ def _validate_tensor_pack_download(
     digest = _validate_tensor_pack_expectation(size_bytes, sha256)
     if codec not in {"raw", "zstd"}:
         raise ValueError("tensor pack codec must be 'raw' or 'zstd'")
-    decoded_size = size_bytes if decoded_size_bytes is None else decoded_size_bytes
-    if isinstance(decoded_size, bool) or not isinstance(decoded_size, int) or decoded_size < 0:
-        raise ValueError("tensor pack decoded_size_bytes must be a non-negative integer")
+    decoded_size = _bounded_tensor_pack_size(
+        size_bytes if decoded_size_bytes is None else decoded_size_bytes,
+        "tensor_pack.decoded_size_bytes",
+    )
     if codec == "raw" and decoded_size != size_bytes:
         raise ValueError("raw tensor pack decoded_size_bytes must equal size_bytes")
     return digest, decoded_size

--- a/weaver/_payloads.py
+++ b/weaver/_payloads.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pure request/response helpers shared by the sync and async clients.
-
-Keeping these IO-free and tokenizer-free means the synchronous and asyncio
-client implementations build identical payloads from a single source of truth.
-"""
+"""Request/response helpers shared by the sync and async clients."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, BinaryIO, Dict, List, Mapping, Sequence
 
+from .config import TensorCompression, TensorTransport
+from .tensor_transport import PreparedOperationBody, serialize_training_data
 from .types import Datum
 
 if TYPE_CHECKING:
@@ -61,6 +59,94 @@ def build_request_metadata(
 
 def serialize_data(data: Sequence[Datum]) -> List[Dict[str, Any]]:
     return [datum.to_payload() for datum in data]
+
+
+def _prepare_training_operation(
+    *,
+    input_key: str,
+    model_id: str,
+    seq_id: int,
+    data: Sequence[Datum],
+    loss_fn: str,
+    loss_fn_config: Mapping[str, Any] | None,
+    request_metadata: Dict[str, Any] | None,
+    tensor_transport: TensorTransport,
+    tensor_compression: TensorCompression,
+) -> PreparedOperationBody:
+    serialized = serialize_training_data(
+        data,
+        loss_fn=loss_fn,
+        transport=tensor_transport,
+        compression=tensor_compression,
+    )
+    payload: Dict[str, Any] = {
+        "model_id": model_id,
+        "seq_id": seq_id,
+        "tensor_transport": tensor_transport,
+        input_key: {
+            "loss_fn": loss_fn,
+            "data": serialized.data,
+        },
+    }
+    if tensor_transport == "http-binary":
+        payload["tensor_compression"] = tensor_compression
+    if loss_fn_config:
+        payload[input_key]["loss_fn_config"] = dict(loss_fn_config)
+    if request_metadata:
+        payload["metadata"] = request_metadata
+    return PreparedOperationBody({"payload": payload}, serialized.tensor_pack)
+
+
+def prepare_forward_operation(
+    *,
+    model_id: str,
+    seq_id: int,
+    data: Sequence[Datum],
+    loss_fn: str,
+    loss_fn_config: Mapping[str, Any] | None,
+    request_metadata: Dict[str, Any] | None,
+    tensor_transport: TensorTransport,
+    tensor_compression: TensorCompression = "raw",
+) -> PreparedOperationBody:
+    """Prepare a forward operation and optional HTTP tensor attachment."""
+
+    return _prepare_training_operation(
+        input_key="forward_input",
+        model_id=model_id,
+        seq_id=seq_id,
+        data=data,
+        loss_fn=loss_fn,
+        loss_fn_config=loss_fn_config,
+        request_metadata=request_metadata,
+        tensor_transport=tensor_transport,
+        tensor_compression=tensor_compression,
+    )
+
+
+def prepare_forward_backward_operation(
+    *,
+    model_id: str,
+    seq_id: int,
+    data: Sequence[Datum],
+    loss_fn: str,
+    loss_fn_config: Mapping[str, Any] | None,
+    request_metadata: Dict[str, Any] | None,
+    tensor_transport: TensorTransport,
+    tensor_compression: TensorCompression = "raw",
+) -> PreparedOperationBody:
+    """Prepare a forward/backward operation and optional HTTP tensor attachment."""
+
+    return _prepare_training_operation(
+        input_key="forward_backward_input",
+        model_id=model_id,
+        seq_id=seq_id,
+        data=data,
+        loss_fn=loss_fn,
+        loss_fn_config=loss_fn_config,
+        request_metadata=request_metadata,
+        tensor_transport=tensor_transport,
+        tensor_compression=tensor_compression,
+    )
 
 
 def forward_payload(
@@ -106,7 +192,10 @@ def forward_backward_payload(
 
 
 def parse_logprob_tensors(
-    fwd_result: Dict[str, Any], data: Sequence[Datum]
+    fwd_result: Dict[str, Any],
+    data: Sequence[Datum],
+    *,
+    tensor_pack: BinaryIO | None = None,
 ) -> List["torch.Tensor"]:
     """Extract per-datum logprob tensors (``requires_grad=True``) from a forward result."""
     import torch
@@ -119,12 +208,21 @@ def parse_logprob_tensors(
 
     logprob_tensors: List[torch.Tensor] = []
     for output in outputs:
-        lp = output.get("logprobs") or output.get("Logprobs")
-        if isinstance(lp, dict):
+        lp = output.get("logprobs")
+        if lp is None:
+            lp = output.get("Logprobs")
+        if isinstance(lp, dict) and "$tensor" in lp:
+            if tensor_pack is None:
+                raise ValueError("HTTP tensor logprobs require the operation tensor pack")
+            from .tensor_transport import materialize_http_tensor
+
+            lp = materialize_http_tensor(lp, tensor_pack)
+        elif isinstance(lp, dict):
             lp = lp["data"]
         if lp is None:
             raise ValueError("Missing logprobs in forward/backward output")
-        logprob_tensors.append(torch.tensor(lp, dtype=torch.float32).requires_grad_(True))
+        tensor = torch.as_tensor(lp, dtype=torch.float32).detach().clone()
+        logprob_tensors.append(tensor.requires_grad_(True))
     return logprob_tensors
 
 

--- a/weaver/_payloads.py
+++ b/weaver/_payloads.py
@@ -106,7 +106,7 @@ def prepare_forward_operation(
     loss_fn_config: Mapping[str, Any] | None,
     request_metadata: Dict[str, Any] | None,
     tensor_transport: TensorTransport,
-    tensor_compression: TensorCompression = "raw",
+    tensor_compression: TensorCompression = "zstd",
 ) -> PreparedOperationBody:
     """Prepare a forward operation and optional HTTP tensor attachment."""
 
@@ -132,7 +132,7 @@ def prepare_forward_backward_operation(
     loss_fn_config: Mapping[str, Any] | None,
     request_metadata: Dict[str, Any] | None,
     tensor_transport: TensorTransport,
-    tensor_compression: TensorCompression = "raw",
+    tensor_compression: TensorCompression = "zstd",
 ) -> PreparedOperationBody:
     """Prepare a forward/backward operation and optional HTTP tensor attachment."""
 

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -129,8 +129,9 @@ from ._safeio import (
     supports_dir_fd,
 )
 from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
-from .config import WeaverConfig
+from .config import TensorCompression, TensorTransport, WeaverConfig
 from .operations import AsyncOperationHandle, build_async_operation_handle
+from .tensor_transport import TensorPack
 from .types import LoraConfig
 from .types.deployment import Deployment
 from .types.weights_artifact import WeightsArtifact
@@ -191,6 +192,8 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         project: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
+        tensor_transport: TensorTransport | None = None,
+        tensor_compression: TensorCompression | None = None,
     ) -> None:
         """Initialize AsyncServiceClient.
 
@@ -207,8 +210,17 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
             project: Optional project UUID, organization-local slug, or display name
             user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
+            tensor_transport: Training tensor transport. Defaults to
+                ``WEAVER_TENSOR_TRANSPORT`` or ``"default"``.
+            tensor_compression: HTTP tensor-pack compression. Defaults to
+                ``WEAVER_TENSOR_COMPRESSION`` or ``"raw"``.
         """
-        self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
+        self._config = WeaverConfig.from_env(
+            base_url=base_url,
+            api_key=api_key,
+            tensor_transport=tensor_transport,
+            tensor_compression=tensor_compression,
+        )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
         self._session_name = name.strip() if name and name.strip() else None
@@ -242,6 +254,18 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         if self._http is None:
             raise RuntimeError("AsyncServiceClient is not connected")
         return self._http
+
+    @property
+    def tensor_transport(self) -> TensorTransport:
+        """Configured transport for dense training tensors."""
+
+        return self._config.tensor_transport
+
+    @property
+    def tensor_compression(self) -> TensorCompression:
+        """Configured HTTP tensor-pack compression."""
+
+        return self._config.tensor_compression
 
     async def connect(self, *, ensure_session: bool = True) -> None:
         """Connect, optionally without creating or fetching a Session."""
@@ -620,10 +644,21 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
             tokenizer_path=tokenizer_path,
         )
 
-    async def enqueue_operation(self, path: str, payload: Dict[str, Any]) -> AsyncOperationHandle:
-        # max_retries=1: operations like save_state are non-idempotent POSTs —
-        # retrying after a timeout would create duplicate server-side operations.
-        response = await self.http.post(path, json=payload, max_retries=1)
+    async def enqueue_operation(
+        self,
+        path: str,
+        payload: Dict[str, Any],
+        *,
+        tensor_pack: TensorPack | None = None,
+    ) -> AsyncOperationHandle:
+        if tensor_pack is None:
+            response = await self.http.post(path, json=payload, max_retries=1)
+        else:
+            response = await self.http.post_tensor_multipart(
+                path,
+                request=payload,
+                tensor_pack=tensor_pack,
+            )
         return build_async_operation_handle(self.http, response)
 
     async def _supported_model_scope_params(self) -> Dict[str, str]:

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -213,7 +213,7 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
             tensor_transport: Training tensor transport. Defaults to
                 ``WEAVER_TENSOR_TRANSPORT`` or ``"default"``.
             tensor_compression: HTTP tensor-pack compression. Defaults to
-                ``WEAVER_TENSOR_COMPRESSION`` or ``"raw"``.
+                ``WEAVER_TENSOR_COMPRESSION`` or ``"zstd"``.
         """
         self._config = WeaverConfig.from_env(
             base_url=base_url,

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -30,23 +30,39 @@ import asyncio
 import logging
 import math
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Sequence,
+    Tuple,
+    overload,
+)
 
 from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload, validate_resource_id
 from ._checkpoint_recovery import CHECKPOINT_RECOVERY_DELAYS, select_recovered_checkpoint
+from ._async_http import _await_blocking_io, _open_temporary_file
 from ._deployments import build_create_deployment_body, translate_deployment_error
 from ._http import WeaverAPIError
 from ._payloads import (
     build_request_metadata,
     build_surrogate_data,
-    forward_backward_payload,
-    forward_payload,
     parse_logprob_tensors,
+    prepare_forward_backward_operation,
+    prepare_forward_operation,
 )
 from ._sampling_utils import parse_model_id_from_weaver_path
 from ._utils import DEFAULT_SAMPLER_TTL_SECONDS, UNSET, _UnsetType, lookup_case_insensitive
 from .async_service_client import AsyncServiceClient
 from .operations import AsyncOperationHandle, build_async_operation_handle
+from .tensor_transport import (
+    PreparedOperationBody,
+    result_tensor_pack_metadata,
+    result_uses_http_tensor_pack,
+)
 from .types import AdamParams, Datum
 from .types.checkpoint import Checkpoint
 from .types.deployment import Deployment
@@ -61,6 +77,31 @@ if TYPE_CHECKING:
     from .types.router_replay import RouterReplayMetadata
 
 logger = logging.getLogger(__name__)
+
+
+def _close_prepared_payload(task: "asyncio.Task[PreparedOperationBody]") -> None:
+    """Release a payload whose background build outlived its caller."""
+
+    try:
+        task.result().close()
+    except BaseException:
+        pass
+
+
+async def _build_training_payload(
+    builder: Callable[..., PreparedOperationBody],
+    **kwargs: Any,
+) -> PreparedOperationBody:
+    """Build an async request without blocking the loop on pack file I/O."""
+
+    if kwargs.get("loss_fn") == "cross_entropy" and kwargs.get("tensor_transport") != "default":
+        task = asyncio.create_task(asyncio.to_thread(builder, **kwargs))
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            task.add_done_callback(_close_prepared_payload)
+            raise
+    return builder(**kwargs)
 
 
 class AsyncTrainingClient:
@@ -131,6 +172,15 @@ class AsyncTrainingClient:
     def _next_seq(self) -> int:
         return self._service.next_operation_seq(self.model_id)
 
+    async def _enqueue_prepared(
+        self, path: str, prepared: PreparedOperationBody
+    ) -> AsyncOperationHandle:
+        if prepared.tensor_pack is None:
+            return await self._service.enqueue_operation(path, prepared.body)
+        return await self._service.enqueue_operation(
+            path, prepared.body, tensor_pack=prepared.tensor_pack
+        )
+
     @overload
     async def forward(
         self,
@@ -178,18 +228,22 @@ class AsyncTrainingClient:
             wait: If True (default), awaits completion and returns the result dict;
                 if False, returns an ``AsyncOperationHandle`` immediately.
         """
-        payload = forward_payload(
+        payload = await _build_training_payload(
+            prepare_forward_operation,
             model_id=self.model_id,
             seq_id=self._next_seq(),
             data=data,
             loss_fn=loss_fn,
             loss_fn_config=loss_fn_config,
             request_metadata=build_request_metadata(metadata, router_replay),
+            tensor_transport=self._service.tensor_transport,
+            tensor_compression=self._service.tensor_compression,
         )
-        handle = await self._service.enqueue_operation(
-            f"/api/v1/models/{self.model_id}/forward-passes",
-            {"payload": payload},
-        )
+        try:
+            path = f"/api/v1/models/{self.model_id}/forward-passes"
+            handle = await self._enqueue_prepared(path, payload)
+        finally:
+            payload.close()
         return await handle.result() if wait else handle
 
     @overload
@@ -239,18 +293,22 @@ class AsyncTrainingClient:
             wait: If True (default), awaits completion and returns the result dict;
                 if False, returns an ``AsyncOperationHandle`` immediately.
         """
-        payload = forward_backward_payload(
+        payload = await _build_training_payload(
+            prepare_forward_backward_operation,
             model_id=self.model_id,
             seq_id=self._next_seq(),
             data=data,
             loss_fn=loss_fn,
             loss_fn_config=loss_fn_config,
             request_metadata=build_request_metadata(metadata, router_replay),
+            tensor_transport=self._service.tensor_transport,
+            tensor_compression=self._service.tensor_compression,
         )
-        handle = await self._service.enqueue_operation(
-            f"/api/v1/models/{self.model_id}/forward-backward-passes",
-            {"payload": payload},
-        )
+        try:
+            path = f"/api/v1/models/{self.model_id}/forward-backward-passes"
+            handle = await self._enqueue_prepared(path, payload)
+        finally:
+            payload.close()
         return await handle.result() if wait else handle
 
     async def forward_backward_custom(
@@ -269,15 +327,34 @@ class AsyncTrainingClient:
         user-computed gradients. See
         :meth:`weaver.training_client.TrainingClient.forward_backward_custom`.
         """
-        # Step A: forward pass to get logprobs
-        fwd_result = await self.forward(
-            data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True
+        fwd_handle = await self.forward(
+            data, "forward_logprob", loss_fn_config=loss_fn_config, wait=False
         )
+        fwd_result = await fwd_handle.result()
 
-        # Step B: parse logprobs from response
-        logprob_tensors = parse_logprob_tensors(fwd_result, data)
+        if result_uses_http_tensor_pack(fwd_result):
+            tensor_pack = await _open_temporary_file()
+            try:
+                metadata = result_tensor_pack_metadata(fwd_result)
+                await fwd_handle.client.download_tensor_pack(
+                    fwd_handle.operation_id,
+                    tensor_pack,
+                    size_bytes=metadata.size_bytes,
+                    sha256=metadata.sha256,
+                    codec=metadata.codec,
+                    decoded_size_bytes=metadata.decoded_size_bytes,
+                )
+                logprob_tensors = await _await_blocking_io(
+                    parse_logprob_tensors,
+                    fwd_result,
+                    data,
+                    tensor_pack=tensor_pack,
+                )
+            finally:
+                await _await_blocking_io(tensor_pack.close)
+        else:
+            logprob_tensors = await _await_blocking_io(parse_logprob_tensors, fwd_result, data)
 
-        # Step C: run user's loss function
         try:
             loss, metrics = loss_fn(data, logprob_tensors)
         except Exception as exc:
@@ -286,18 +363,11 @@ class AsyncTrainingClient:
         if loss.dim() != 0:
             raise ValueError(f"loss_fn must return a scalar loss, got shape {loss.shape}")
 
-        # Step D: backprop through user graph into logprob tensors
         loss.backward()
-
-        # Step E: build surrogate Datum objects from the propagated gradients
         surrogate_data = build_surrogate_data(data, logprob_tensors)
-
-        # Step F: surrogate backward pass
         await self.forward_backward(
             surrogate_data, "surrogate", loss_fn_config=loss_fn_config, wait=True
         )
-
-        # Step G: return loss and metrics
         return {"loss": loss.detach(), "metrics": metrics}
 
     @overload

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -43,8 +43,8 @@ from typing import (
 )
 
 from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload, validate_resource_id
-from ._checkpoint_recovery import CHECKPOINT_RECOVERY_DELAYS, select_recovered_checkpoint
 from ._async_http import _await_blocking_io, _open_temporary_file
+from ._checkpoint_recovery import CHECKPOINT_RECOVERY_DELAYS, select_recovered_checkpoint
 from ._deployments import build_create_deployment_body, translate_deployment_error
 from ._http import WeaverAPIError
 from ._payloads import (

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -43,7 +43,7 @@ from typing import (
 )
 
 from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload, validate_resource_id
-from ._async_http import _await_blocking_io, _open_temporary_file
+from ._async_http import _await_blocking_io
 from ._checkpoint_recovery import CHECKPOINT_RECOVERY_DELAYS, select_recovered_checkpoint
 from ._deployments import build_create_deployment_body, translate_deployment_error
 from ._http import WeaverAPIError
@@ -58,13 +58,7 @@ from ._sampling_utils import parse_model_id_from_weaver_path
 from ._utils import DEFAULT_SAMPLER_TTL_SECONDS, UNSET, _UnsetType, lookup_case_insensitive
 from .async_service_client import AsyncServiceClient
 from .operations import AsyncOperationHandle, build_async_operation_handle
-from .tensor_transport import (
-    PreparedOperationBody,
-    materialize_http_tensors,
-    result_tensor_pack_metadata,
-    result_tensor_pack_operation_id,
-    result_uses_http_tensor_pack,
-)
+from .tensor_transport import PreparedOperationBody
 from .types import AdamParams, Datum
 from .types.checkpoint import Checkpoint
 from .types.deployment import Deployment
@@ -124,35 +118,6 @@ class AsyncTrainingClient:
         self.tokenizer_path = tokenizer_path
         self.debug_info = debug_info
         self._tokenizer: Any = None
-
-    async def materialize_result_tensors(self, result: Mapping[str, Any]) -> Dict[str, Any]:
-        """Download every tensor referenced by an HTTP-binary result.
-
-        Args:
-            result: Completed operation result returned by this client.
-        Returns:
-            A copy with tensor references replaced by tensors.
-        Raises:
-            ValueError: If the result metadata or tensor pack is invalid.
-        """
-
-        if not isinstance(result.get("tensor_pack"), Mapping):
-            return dict(result)
-        metadata = result_tensor_pack_metadata(result)
-        tensor_pack = await _open_temporary_file()
-        try:
-            await self._service.http.download_tensor_pack(
-                result_tensor_pack_operation_id(result),
-                tensor_pack,
-                size_bytes=metadata.size_bytes,
-                sha256=metadata.sha256,
-                codec=metadata.codec,
-                decoded_size_bytes=metadata.decoded_size_bytes,
-            )
-            materialized = await _await_blocking_io(materialize_http_tensors, result, tensor_pack)
-        finally:
-            await _await_blocking_io(tensor_pack.close)
-        return dict(materialized)
 
     @property
     def training_run_id(self) -> str:
@@ -362,9 +327,6 @@ class AsyncTrainingClient:
             data, "forward_logprob", loss_fn_config=loss_fn_config, wait=False
         )
         fwd_result = await fwd_handle.result()
-
-        if result_uses_http_tensor_pack(fwd_result):
-            fwd_result = await self.materialize_result_tensors(fwd_result)
         logprob_tensors = await _await_blocking_io(parse_logprob_tensors, fwd_result, data)
 
         try:

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -60,7 +60,9 @@ from .async_service_client import AsyncServiceClient
 from .operations import AsyncOperationHandle, build_async_operation_handle
 from .tensor_transport import (
     PreparedOperationBody,
+    materialize_http_tensors,
     result_tensor_pack_metadata,
+    result_tensor_pack_operation_id,
     result_uses_http_tensor_pack,
 )
 from .types import AdamParams, Datum
@@ -122,6 +124,35 @@ class AsyncTrainingClient:
         self.tokenizer_path = tokenizer_path
         self.debug_info = debug_info
         self._tokenizer: Any = None
+
+    async def materialize_result_tensors(self, result: Mapping[str, Any]) -> Dict[str, Any]:
+        """Download every tensor referenced by an HTTP-binary result.
+
+        Args:
+            result: Completed operation result returned by this client.
+        Returns:
+            A copy with tensor references replaced by tensors.
+        Raises:
+            ValueError: If the result metadata or tensor pack is invalid.
+        """
+
+        if not isinstance(result.get("tensor_pack"), Mapping):
+            return dict(result)
+        metadata = result_tensor_pack_metadata(result)
+        tensor_pack = await _open_temporary_file()
+        try:
+            await self._service.http.download_tensor_pack(
+                result_tensor_pack_operation_id(result),
+                tensor_pack,
+                size_bytes=metadata.size_bytes,
+                sha256=metadata.sha256,
+                codec=metadata.codec,
+                decoded_size_bytes=metadata.decoded_size_bytes,
+            )
+            materialized = await _await_blocking_io(materialize_http_tensors, result, tensor_pack)
+        finally:
+            await _await_blocking_io(tensor_pack.close)
+        return dict(materialized)
 
     @property
     def training_run_id(self) -> str:
@@ -333,27 +364,8 @@ class AsyncTrainingClient:
         fwd_result = await fwd_handle.result()
 
         if result_uses_http_tensor_pack(fwd_result):
-            tensor_pack = await _open_temporary_file()
-            try:
-                metadata = result_tensor_pack_metadata(fwd_result)
-                await fwd_handle.client.download_tensor_pack(
-                    fwd_handle.operation_id,
-                    tensor_pack,
-                    size_bytes=metadata.size_bytes,
-                    sha256=metadata.sha256,
-                    codec=metadata.codec,
-                    decoded_size_bytes=metadata.decoded_size_bytes,
-                )
-                logprob_tensors = await _await_blocking_io(
-                    parse_logprob_tensors,
-                    fwd_result,
-                    data,
-                    tensor_pack=tensor_pack,
-                )
-            finally:
-                await _await_blocking_io(tensor_pack.close)
-        else:
-            logprob_tensors = await _await_blocking_io(parse_logprob_tensors, fwd_result, data)
+            fwd_result = await self.materialize_result_tensors(fwd_result)
+        logprob_tensors = await _await_blocking_io(parse_logprob_tensors, fwd_result, data)
 
         try:
             loss, metrics = loss_fn(data, logprob_tensors)

--- a/weaver/config.py
+++ b/weaver/config.py
@@ -37,7 +37,7 @@ def _tensor_transport(value: str | None) -> TensorTransport:
 
 
 def _tensor_compression(value: str | None) -> TensorCompression:
-    resolved = value or "raw"
+    resolved = value or "zstd"
     if resolved not in _TENSOR_COMPRESSIONS:
         supported = ", ".join(sorted(_TENSOR_COMPRESSIONS))
         raise ValueError(f"Unsupported tensor compression {resolved!r}. Supported: {supported}")
@@ -51,13 +51,11 @@ class WeaverConfig:
     base_url: str = _DEFAULT_BASE_URL
     api_key: str | None = None
     tensor_transport: TensorTransport = "default"
-    tensor_compression: TensorCompression = "raw"
+    tensor_compression: TensorCompression = "zstd"
 
     def __post_init__(self) -> None:
         self.tensor_transport = _tensor_transport(self.tensor_transport)
         self.tensor_compression = _tensor_compression(self.tensor_compression)
-        if self.tensor_compression != "raw" and self.tensor_transport != "http-binary":
-            raise ValueError("tensor_compression requires tensor_transport='http-binary'")
 
     @classmethod
     def from_env(

--- a/weaver/config.py
+++ b/weaver/config.py
@@ -18,9 +18,30 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional, cast
 
 _DEFAULT_BASE_URL = "https://weaver-console.nex-agi.cn"
+
+TensorTransport = Literal["default", "http-binary"]
+_TENSOR_TRANSPORTS = {"default", "http-binary"}
+TensorCompression = Literal["raw", "zstd"]
+_TENSOR_COMPRESSIONS = {"raw", "zstd"}
+
+
+def _tensor_transport(value: str | None) -> TensorTransport:
+    resolved = value or "default"
+    if resolved not in _TENSOR_TRANSPORTS:
+        supported = ", ".join(sorted(_TENSOR_TRANSPORTS))
+        raise ValueError(f"Unsupported tensor transport {resolved!r}. Supported: {supported}")
+    return cast(TensorTransport, resolved)
+
+
+def _tensor_compression(value: str | None) -> TensorCompression:
+    resolved = value or "raw"
+    if resolved not in _TENSOR_COMPRESSIONS:
+        supported = ", ".join(sorted(_TENSOR_COMPRESSIONS))
+        raise ValueError(f"Unsupported tensor compression {resolved!r}. Supported: {supported}")
+    return cast(TensorCompression, resolved)
 
 
 @dataclass(slots=True)
@@ -29,6 +50,14 @@ class WeaverConfig:
 
     base_url: str = _DEFAULT_BASE_URL
     api_key: str | None = None
+    tensor_transport: TensorTransport = "default"
+    tensor_compression: TensorCompression = "raw"
+
+    def __post_init__(self) -> None:
+        self.tensor_transport = _tensor_transport(self.tensor_transport)
+        self.tensor_compression = _tensor_compression(self.tensor_compression)
+        if self.tensor_compression != "raw" and self.tensor_transport != "http-binary":
+            raise ValueError("tensor_compression requires tensor_transport='http-binary'")
 
     @classmethod
     def from_env(
@@ -36,6 +65,8 @@ class WeaverConfig:
         *,
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
+        tensor_transport: TensorTransport | None = None,
+        tensor_compression: TensorCompression | None = None,
     ) -> "WeaverConfig":
         """Load configuration from kwargs with env fallbacks.
 
@@ -46,6 +77,12 @@ class WeaverConfig:
         return cls(
             base_url=base_url or os.getenv("WEAVER_BASE_URL") or _DEFAULT_BASE_URL,
             api_key=api_key or os.getenv("WEAVER_API_KEY"),
+            tensor_transport=_tensor_transport(
+                tensor_transport or os.getenv("WEAVER_TENSOR_TRANSPORT")
+            ),
+            tensor_compression=_tensor_compression(
+                tensor_compression or os.getenv("WEAVER_TENSOR_COMPRESSION")
+            ),
         )
 
     def require_auth(self) -> None:

--- a/weaver/operations.py
+++ b/weaver/operations.py
@@ -180,6 +180,9 @@ class OperationHandle(_OperationHandleMixin):
     def refresh(self) -> Dict[str, Any]:
         path = f"/api/v1/operations/{self.operation_id}"
         self._cached = self.client.get(path)
+        self._response_cache = _RESPONSE_UNSET
+        if self.status == "done":
+            self._materialize_response()
         return self._cached
 
     def _materialize_response(self) -> None:
@@ -188,7 +191,6 @@ class OperationHandle(_OperationHandleMixin):
             return
         response = lookup_case_insensitive(self._cached, "response")
         if not isinstance(response, Mapping) or not result_uses_http_tensor_pack(response):
-            self._cache_response(response)
             return
         with self._response_lock:
             if self._response_cache is not _RESPONSE_UNSET:
@@ -287,6 +289,9 @@ class AsyncOperationHandle(_OperationHandleMixin):
     async def refresh(self) -> Dict[str, Any]:
         path = f"/api/v1/operations/{self.operation_id}"
         self._cached = await self.client.get(path)
+        self._response_cache = _RESPONSE_UNSET
+        if self.status == "done":
+            await self._materialize_response()
         return self._cached
 
     async def _materialize_response(self) -> None:
@@ -295,7 +300,6 @@ class AsyncOperationHandle(_OperationHandleMixin):
             return
         response = lookup_case_insensitive(self._cached, "response")
         if not isinstance(response, Mapping) or not result_uses_http_tensor_pack(response):
-            self._cache_response(response)
             return
         async with self._response_lock:
             if self._response_cache is not _RESPONSE_UNSET:

--- a/weaver/operations.py
+++ b/weaver/operations.py
@@ -19,18 +19,25 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import tempfile
+import threading
 import time
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Optional
 
 from ._http import APIClient, WeaverAPIError, backoff_delays
 from ._utils import extract_id, lookup_case_insensitive
-from .tensor_transport import bind_result_tensor_pack_operation
+from .tensor_transport import (
+    materialize_http_tensor_payloads,
+    result_tensor_pack_metadata,
+    result_uses_http_tensor_pack,
+)
 
 if TYPE_CHECKING:
     from ._async_http import AsyncAPIClient
 
 logger = logging.getLogger(__name__)
+_RESPONSE_UNSET = object()
 
 _TRANSIENT_OPERATION_POLL_ERROR_FRAGMENTS = (
     "unexpected eof",
@@ -120,6 +127,7 @@ class _OperationHandleMixin:
 
     operation_id: str
     _cached: Dict[str, Any]
+    _response_cache: Any
 
     @property
     def status(self) -> Optional[str]:
@@ -128,9 +136,17 @@ class _OperationHandleMixin:
 
     @property
     def response(self) -> Any:
-        return bind_result_tensor_pack_operation(
-            lookup_case_insensitive(self._cached, "response"), self.operation_id
-        )
+        if self._response_cache is not _RESPONSE_UNSET:
+            return self._response_cache
+        return lookup_case_insensitive(self._cached, "response")
+
+    def _cache_response(self, response: Any) -> None:
+        self._response_cache = response
+        for key in self._cached:
+            if key.lower() == "response":
+                self._cached[key] = response
+                return
+        self._cached["response"] = response
 
     @property
     def error(self) -> Optional[str]:
@@ -151,6 +167,10 @@ class OperationHandle(_OperationHandleMixin):
     client: APIClient
     operation_id: str
     _cached: Dict[str, Any]
+    _response_cache: Any = field(default=_RESPONSE_UNSET, init=False, repr=False, compare=False)
+    _response_lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False, compare=False
+    )
 
     @classmethod
     def from_payload(cls, client: APIClient, payload: Dict[str, Any]) -> "OperationHandle":
@@ -162,11 +182,38 @@ class OperationHandle(_OperationHandleMixin):
         self._cached = self.client.get(path)
         return self._cached
 
+    def _materialize_response(self) -> None:
+        if self._response_cache is not _RESPONSE_UNSET:
+            self._cache_response(self._response_cache)
+            return
+        response = lookup_case_insensitive(self._cached, "response")
+        if not isinstance(response, Mapping) or not result_uses_http_tensor_pack(response):
+            self._cache_response(response)
+            return
+        with self._response_lock:
+            if self._response_cache is not _RESPONSE_UNSET:
+                self._cache_response(self._response_cache)
+                return
+            metadata = result_tensor_pack_metadata(response)
+            with tempfile.TemporaryFile(mode="w+b") as tensor_pack:
+                self.client.download_tensor_pack(
+                    self.operation_id,
+                    tensor_pack,
+                    size_bytes=metadata.size_bytes,
+                    sha256=metadata.sha256,
+                    codec=metadata.codec,
+                    decoded_size_bytes=metadata.decoded_size_bytes,
+                )
+                materialized = dict(materialize_http_tensor_payloads(response, tensor_pack))
+            materialized.pop("tensor_pack", None)
+            self._cache_response(materialized)
+
     def wait(self) -> Dict[str, Any]:
         transient_error_count = 0
         max_transient_errors = _operation_poll_transient_retries()
         if self.done():
             self._raise_if_failed()
+            self._materialize_response()
             return self._cached
         for delay in _operation_poll_delays():
             time.sleep(delay)
@@ -192,6 +239,7 @@ class OperationHandle(_OperationHandleMixin):
         if not self.done():
             raise WeaverAPIError(504, "timeout", "Operation polling timed out", True)
         self._raise_if_failed()
+        self._materialize_response()
         return self._cached
 
     def result(self) -> Any:
@@ -224,6 +272,10 @@ class AsyncOperationHandle(_OperationHandleMixin):
     client: "AsyncAPIClient"
     operation_id: str
     _cached: Dict[str, Any]
+    _response_cache: Any = field(default=_RESPONSE_UNSET, init=False, repr=False, compare=False)
+    _response_lock: asyncio.Lock = field(
+        default_factory=asyncio.Lock, init=False, repr=False, compare=False
+    )
 
     @classmethod
     def from_payload(
@@ -237,11 +289,47 @@ class AsyncOperationHandle(_OperationHandleMixin):
         self._cached = await self.client.get(path)
         return self._cached
 
+    async def _materialize_response(self) -> None:
+        if self._response_cache is not _RESPONSE_UNSET:
+            self._cache_response(self._response_cache)
+            return
+        response = lookup_case_insensitive(self._cached, "response")
+        if not isinstance(response, Mapping) or not result_uses_http_tensor_pack(response):
+            self._cache_response(response)
+            return
+        async with self._response_lock:
+            if self._response_cache is not _RESPONSE_UNSET:
+                self._cache_response(self._response_cache)
+                return
+            from ._async_http import _await_blocking_io, _open_temporary_file
+
+            metadata = result_tensor_pack_metadata(response)
+            tensor_pack = await _open_temporary_file()
+            try:
+                await self.client.download_tensor_pack(
+                    self.operation_id,
+                    tensor_pack,
+                    size_bytes=metadata.size_bytes,
+                    sha256=metadata.sha256,
+                    codec=metadata.codec,
+                    decoded_size_bytes=metadata.decoded_size_bytes,
+                )
+                materialized = dict(
+                    await _await_blocking_io(
+                        materialize_http_tensor_payloads, response, tensor_pack
+                    )
+                )
+            finally:
+                await _await_blocking_io(tensor_pack.close)
+            materialized.pop("tensor_pack", None)
+            self._cache_response(materialized)
+
     async def wait(self) -> Dict[str, Any]:
         transient_error_count = 0
         max_transient_errors = _operation_poll_transient_retries()
         if self.done():
             self._raise_if_failed()
+            await self._materialize_response()
             return self._cached
         for delay in _operation_poll_delays():
             await asyncio.sleep(delay)
@@ -267,6 +355,7 @@ class AsyncOperationHandle(_OperationHandleMixin):
         if not self.done():
             raise WeaverAPIError(504, "timeout", "Operation polling timed out", True)
         self._raise_if_failed()
+        await self._materialize_response()
         return self._cached
 
     async def result(self) -> Any:

--- a/weaver/operations.py
+++ b/weaver/operations.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
 from ._http import APIClient, WeaverAPIError, backoff_delays
 from ._utils import extract_id, lookup_case_insensitive
+from .tensor_transport import bind_result_tensor_pack_operation
 
 if TYPE_CHECKING:
     from ._async_http import AsyncAPIClient
@@ -127,7 +128,9 @@ class _OperationHandleMixin:
 
     @property
     def response(self) -> Any:
-        return lookup_case_insensitive(self._cached, "response")
+        return bind_result_tensor_pack_operation(
+            lookup_case_insensitive(self._cached, "response"), self.operation_id
+        )
 
     @property
     def error(self) -> Optional[str]:
@@ -192,8 +195,8 @@ class OperationHandle(_OperationHandleMixin):
         return self._cached
 
     def result(self) -> Any:
-        payload = self.wait()
-        return lookup_case_insensitive(payload, "response")
+        self.wait()
+        return self.response
 
     @classmethod
     def wait_all(cls, handles: List["OperationHandle"]) -> List[Any]:
@@ -267,8 +270,8 @@ class AsyncOperationHandle(_OperationHandleMixin):
         return self._cached
 
     async def result(self) -> Any:
-        payload = await self.wait()
-        return lookup_case_insensitive(payload, "response")
+        await self.wait()
+        return self.response
 
     def __await__(self):
         return self.result().__await__()

--- a/weaver/operations.py
+++ b/weaver/operations.py
@@ -128,6 +128,7 @@ class _OperationHandleMixin:
     operation_id: str
     _cached: Dict[str, Any]
     _response_cache: Any
+    _response_source: Any
 
     @property
     def status(self) -> Optional[str]:
@@ -147,6 +148,25 @@ class _OperationHandleMixin:
                 self._cached[key] = response
                 return
         self._cached["response"] = response
+
+    def _install_refreshed_payload(self, payload: Dict[str, Any]) -> bool:
+        response = lookup_case_insensitive(payload, "response")
+        status = lookup_case_insensitive(payload, "status")
+        reuse_cache = (
+            str(status).lower() == "done"
+            and self._response_cache is not _RESPONSE_UNSET
+            and self._response_source is not _RESPONSE_UNSET
+            and isinstance(response, Mapping)
+            and result_uses_http_tensor_pack(response)
+            and response == self._response_source
+        )
+        self._cached = payload
+        if reuse_cache:
+            self._cache_response(self._response_cache)
+            return True
+        self._response_cache = _RESPONSE_UNSET
+        self._response_source = _RESPONSE_UNSET
+        return False
 
     @property
     def error(self) -> Optional[str]:
@@ -168,6 +188,7 @@ class OperationHandle(_OperationHandleMixin):
     operation_id: str
     _cached: Dict[str, Any]
     _response_cache: Any = field(default=_RESPONSE_UNSET, init=False, repr=False, compare=False)
+    _response_source: Any = field(default=_RESPONSE_UNSET, init=False, repr=False, compare=False)
     _response_lock: threading.Lock = field(
         default_factory=threading.Lock, init=False, repr=False, compare=False
     )
@@ -179,36 +200,38 @@ class OperationHandle(_OperationHandleMixin):
 
     def refresh(self) -> Dict[str, Any]:
         path = f"/api/v1/operations/{self.operation_id}"
-        self._cached = self.client.get(path)
-        self._response_cache = _RESPONSE_UNSET
-        if self.status == "done":
-            self._materialize_response()
-        return self._cached
+        payload = self.client.get(path)
+        with self._response_lock:
+            reused_cache = self._install_refreshed_payload(payload)
+            if self.status == "done" and not reused_cache:
+                self._materialize_response_locked()
+            return self._cached
 
     def _materialize_response(self) -> None:
+        with self._response_lock:
+            self._materialize_response_locked()
+
+    def _materialize_response_locked(self) -> None:
         if self._response_cache is not _RESPONSE_UNSET:
             self._cache_response(self._response_cache)
             return
         response = lookup_case_insensitive(self._cached, "response")
         if not isinstance(response, Mapping) or not result_uses_http_tensor_pack(response):
             return
-        with self._response_lock:
-            if self._response_cache is not _RESPONSE_UNSET:
-                self._cache_response(self._response_cache)
-                return
-            metadata = result_tensor_pack_metadata(response)
-            with tempfile.TemporaryFile(mode="w+b") as tensor_pack:
-                self.client.download_tensor_pack(
-                    self.operation_id,
-                    tensor_pack,
-                    size_bytes=metadata.size_bytes,
-                    sha256=metadata.sha256,
-                    codec=metadata.codec,
-                    decoded_size_bytes=metadata.decoded_size_bytes,
-                )
-                materialized = dict(materialize_http_tensor_payloads(response, tensor_pack))
-            materialized.pop("tensor_pack", None)
-            self._cache_response(materialized)
+        metadata = result_tensor_pack_metadata(response)
+        with tempfile.TemporaryFile(mode="w+b") as tensor_pack:
+            self.client.download_tensor_pack(
+                self.operation_id,
+                tensor_pack,
+                size_bytes=metadata.size_bytes,
+                sha256=metadata.sha256,
+                codec=metadata.codec,
+                decoded_size_bytes=metadata.decoded_size_bytes,
+            )
+            materialized = dict(materialize_http_tensor_payloads(response, tensor_pack))
+        materialized.pop("tensor_pack", None)
+        self._response_source = response
+        self._cache_response(materialized)
 
     def wait(self) -> Dict[str, Any]:
         transient_error_count = 0
@@ -275,6 +298,7 @@ class AsyncOperationHandle(_OperationHandleMixin):
     operation_id: str
     _cached: Dict[str, Any]
     _response_cache: Any = field(default=_RESPONSE_UNSET, init=False, repr=False, compare=False)
+    _response_source: Any = field(default=_RESPONSE_UNSET, init=False, repr=False, compare=False)
     _response_lock: asyncio.Lock = field(
         default_factory=asyncio.Lock, init=False, repr=False, compare=False
     )
@@ -288,45 +312,45 @@ class AsyncOperationHandle(_OperationHandleMixin):
 
     async def refresh(self) -> Dict[str, Any]:
         path = f"/api/v1/operations/{self.operation_id}"
-        self._cached = await self.client.get(path)
-        self._response_cache = _RESPONSE_UNSET
-        if self.status == "done":
-            await self._materialize_response()
-        return self._cached
+        payload = await self.client.get(path)
+        async with self._response_lock:
+            reused_cache = self._install_refreshed_payload(payload)
+            if self.status == "done" and not reused_cache:
+                await self._materialize_response_locked()
+            return self._cached
 
     async def _materialize_response(self) -> None:
+        async with self._response_lock:
+            await self._materialize_response_locked()
+
+    async def _materialize_response_locked(self) -> None:
         if self._response_cache is not _RESPONSE_UNSET:
             self._cache_response(self._response_cache)
             return
         response = lookup_case_insensitive(self._cached, "response")
         if not isinstance(response, Mapping) or not result_uses_http_tensor_pack(response):
             return
-        async with self._response_lock:
-            if self._response_cache is not _RESPONSE_UNSET:
-                self._cache_response(self._response_cache)
-                return
-            from ._async_http import _await_blocking_io, _open_temporary_file
+        from ._async_http import _await_blocking_io, _open_temporary_file
 
-            metadata = result_tensor_pack_metadata(response)
-            tensor_pack = await _open_temporary_file()
-            try:
-                await self.client.download_tensor_pack(
-                    self.operation_id,
-                    tensor_pack,
-                    size_bytes=metadata.size_bytes,
-                    sha256=metadata.sha256,
-                    codec=metadata.codec,
-                    decoded_size_bytes=metadata.decoded_size_bytes,
-                )
-                materialized = dict(
-                    await _await_blocking_io(
-                        materialize_http_tensor_payloads, response, tensor_pack
-                    )
-                )
-            finally:
-                await _await_blocking_io(tensor_pack.close)
-            materialized.pop("tensor_pack", None)
-            self._cache_response(materialized)
+        metadata = result_tensor_pack_metadata(response)
+        tensor_pack = await _open_temporary_file()
+        try:
+            await self.client.download_tensor_pack(
+                self.operation_id,
+                tensor_pack,
+                size_bytes=metadata.size_bytes,
+                sha256=metadata.sha256,
+                codec=metadata.codec,
+                decoded_size_bytes=metadata.decoded_size_bytes,
+            )
+            materialized = dict(
+                await _await_blocking_io(materialize_http_tensor_payloads, response, tensor_pack)
+            )
+        finally:
+            await _await_blocking_io(tensor_pack.close)
+        materialized.pop("tensor_pack", None)
+        self._response_source = response
+        self._cache_response(materialized)
 
     async def wait(self) -> Dict[str, Any]:
         transient_error_count = 0

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -82,8 +82,9 @@ from ._safeio import (
     supports_dir_fd,
 )
 from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
-from .config import WeaverConfig
+from .config import TensorCompression, TensorTransport, WeaverConfig
 from .operations import OperationHandle, build_operation_handle
+from .tensor_transport import TensorPack
 from .types import LoraConfig
 from .types.deployment import Deployment
 from .types.weights_artifact import WeightsArtifact
@@ -118,6 +119,8 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         project: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
+        tensor_transport: TensorTransport | None = None,
+        tensor_compression: TensorCompression | None = None,
     ) -> None:
         """Initialize ServiceClient.
 
@@ -134,10 +137,16 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             project: Optional project UUID, organization-local slug, or display name
             user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
+            tensor_transport: Training tensor transport. Defaults to
+                ``WEAVER_TENSOR_TRANSPORT`` or ``"default"``.
+            tensor_compression: HTTP tensor-pack compression. Defaults to
+                ``WEAVER_TENSOR_COMPRESSION`` or ``"raw"``.
         """
         self._config = WeaverConfig.from_env(
             base_url=base_url,
             api_key=api_key,
+            tensor_transport=tensor_transport,
+            tensor_compression=tensor_compression,
         )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
@@ -172,6 +181,18 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         if self._http is None:
             raise RuntimeError("ServiceClient is not connected")
         return self._http
+
+    @property
+    def tensor_transport(self) -> TensorTransport:
+        """Configured transport for dense training tensors."""
+
+        return self._config.tensor_transport
+
+    @property
+    def tensor_compression(self) -> TensorCompression:
+        """Configured HTTP tensor-pack compression."""
+
+        return self._config.tensor_compression
 
     def connect(self, *, ensure_session: bool = True) -> None:
         """Connect, optionally without creating or fetching a Session."""
@@ -575,11 +596,21 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             tokenizer_path=tokenizer_path,
         )
 
-    def enqueue_operation(self, path: str, payload: Dict[str, Any]) -> OperationHandle:
-        # max_retries=1 means a single attempt with no retries.  Operations
-        # like save_state are non-idempotent POSTs — retrying after a timeout
-        # would create duplicate server-side operations.
-        response = self.http.post(path, json=payload, max_retries=1)
+    def enqueue_operation(
+        self,
+        path: str,
+        payload: Dict[str, Any],
+        *,
+        tensor_pack: TensorPack | None = None,
+    ) -> OperationHandle:
+        if tensor_pack is None:
+            response = self.http.post(path, json=payload, max_retries=1)
+        else:
+            response = self.http.post_tensor_multipart(
+                path,
+                request=payload,
+                tensor_pack=tensor_pack,
+            )
         return build_operation_handle(self.http, response)
 
     def _supported_model_scope_params(self) -> Dict[str, str]:

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -140,7 +140,7 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             tensor_transport: Training tensor transport. Defaults to
                 ``WEAVER_TENSOR_TRANSPORT`` or ``"default"``.
             tensor_compression: HTTP tensor-pack compression. Defaults to
-                ``WEAVER_TENSOR_COMPRESSION`` or ``"raw"``.
+                ``WEAVER_TENSOR_COMPRESSION`` or ``"zstd"``.
         """
         self._config = WeaverConfig.from_env(
             base_url=base_url,

--- a/weaver/tensor_transport.py
+++ b/weaver/tensor_transport.py
@@ -20,6 +20,7 @@ import asyncio
 import hashlib
 import json
 import math
+import os
 import secrets
 import tempfile
 from contextlib import ExitStack
@@ -332,21 +333,32 @@ class AsyncMultipartStream(httpx.AsyncByteStream):
 
 
 def result_uses_http_tensor_pack(payload: Mapping[str, Any]) -> bool:
-    """Return whether detailed logprobs reference an HTTP result pack."""
+    """Return whether a result advertises an HTTP tensor pack."""
 
-    result = payload.get("result")
-    outputs = result.get("loss_fn_outputs") if isinstance(result, Mapping) else None
-    if not isinstance(outputs, list):
-        return False
-    for output in outputs:
-        if not isinstance(output, Mapping):
-            continue
-        logprobs = output.get("logprobs")
-        if logprobs is None:
-            logprobs = output.get("Logprobs")
-        if isinstance(logprobs, Mapping) and TENSOR_KEY in logprobs:
-            return True
-    return False
+    return isinstance(payload.get("tensor_pack"), Mapping)
+
+
+def bind_result_tensor_pack_operation(payload: Any, operation_id: str) -> Any:
+    """Attach the operation needed to retrieve a referenced result pack."""
+
+    if not isinstance(payload, Mapping):
+        return payload
+    metadata = payload.get("tensor_pack")
+    if not isinstance(metadata, Mapping):
+        return payload
+    bound = dict(payload)
+    bound["tensor_pack"] = {**metadata, "operation_id": operation_id}
+    return bound
+
+
+def result_tensor_pack_operation_id(payload: Mapping[str, Any]) -> str:
+    """Return the operation identifier bound to an HTTP result pack."""
+
+    metadata = payload.get("tensor_pack")
+    operation_id = metadata.get("operation_id") if isinstance(metadata, Mapping) else None
+    if not isinstance(operation_id, str) or not operation_id:
+        raise ValueError("HTTP tensor result is missing tensor_pack.operation_id")
+    return operation_id
 
 
 def result_tensor_pack_metadata(payload: Mapping[str, Any]) -> TensorPackMetadata:
@@ -388,7 +400,7 @@ def decompress_zstd_tensor_pack(
     destination: BinaryIO,
     decoded_size_bytes: int,
 ) -> None:
-    """Decode exactly one bounded Zstandard frame into ``destination``."""
+    """Decode bounded concatenated Zstandard frames into ``destination``."""
 
     expected_size = _nonnegative_int(decoded_size_bytes, "tensor_pack.decoded_size_bytes")
     source.seek(0)
@@ -402,8 +414,8 @@ def decompress_zstd_tensor_pack(
     )
     try:
         while True:
-            # Reading one byte past the declared size detects expansion and
-            # concatenated frames without allowing an unbounded allocation.
+            # Reading one byte past the declared combined size detects
+            # expansion without allowing an unbounded allocation.
             read_size = min(_STREAM_CHUNK_BYTES, expected_size - decoded + 1)
             try:
                 output = reader.read(read_size)
@@ -438,6 +450,18 @@ def materialize_http_tensor(reference: Mapping[str, Any], pack: BinaryIO) -> tor
     return _materialize_raw_tensor_slice(descriptor, pack, name="$tensor")
 
 
+def materialize_http_tensors(value: Any, pack: BinaryIO) -> Any:
+    """Return a copy with every nested HTTP tensor reference materialized."""
+
+    if isinstance(value, Mapping):
+        if TENSOR_KEY in value:
+            return materialize_http_tensor(value, pack)
+        return {key: materialize_http_tensors(item, pack) for key, item in value.items()}
+    if isinstance(value, list):
+        return [materialize_http_tensors(item, pack) for item in value]
+    return value
+
+
 def _materialize_raw_tensor_slice(
     descriptor: Mapping[str, Any], source: BinaryIO, *, name: str
 ) -> torch.Tensor:
@@ -461,6 +485,13 @@ def _materialize_raw_tensor_slice(
     offset = _nonnegative_int(descriptor.get("offset", 0), f"{name}.offset")
     if math.prod(shape) * torch.empty((), dtype=dtype).element_size() != size_bytes:
         raise ValueError(f"{name} size_bytes does not match shape and dtype")
+
+    original_position = source.tell()
+    source.seek(0, os.SEEK_END)
+    pack_size = source.tell()
+    source.seek(original_position)
+    if offset > pack_size or size_bytes > pack_size - offset:
+        raise ValueError(f"{name} slice exceeds the tensor pack")
     if size_bytes == 0:
         return torch.empty(shape, dtype=dtype)
 

--- a/weaver/tensor_transport.py
+++ b/weaver/tensor_transport.py
@@ -41,6 +41,7 @@ TENSOR_KEY = "$tensor"
 _RAW_CODEC = "raw"
 _FORMAT = "raw-tensor"
 _STREAM_CHUNK_BYTES = 8 * 1024 * 1024
+_MAX_TENSOR_PACK_BYTES = 8 << 30
 _ZSTD_LEVEL = 3
 _ZSTD_THREADS = 4
 _TORCH_TO_NAME: dict[torch.dtype, str] = {
@@ -62,12 +63,16 @@ class TensorPack:
     decoded_size_bytes: int | None = None
 
     def __post_init__(self) -> None:
+        self.size_bytes = _bounded_tensor_pack_size(self.size_bytes, "tensor_pack.size_bytes")
         if self.codec not in ("raw", "zstd"):
             raise ValueError("tensor pack codec must be 'raw' or 'zstd'")
         if self.decoded_size_bytes is None:
             if self.codec != "raw":
                 raise ValueError("zstd tensor packs require decoded_size_bytes")
             self.decoded_size_bytes = self.size_bytes
+        self.decoded_size_bytes = _bounded_tensor_pack_size(
+            self.decoded_size_bytes, "tensor_pack.decoded_size_bytes"
+        )
         if self.codec == "raw" and self.decoded_size_bytes != self.size_bytes:
             raise ValueError("raw tensor pack decoded_size_bytes must equal size_bytes")
 
@@ -166,6 +171,7 @@ class _PackWriter:
 
         offset = self._offset
         size_bytes = raw.nbytes
+        _bounded_tensor_pack_size(offset + size_bytes, "tensor_pack.decoded_size_bytes")
         self._handle.write(raw)
         if self._codec == "raw":
             self._sha256.update(raw)
@@ -190,9 +196,10 @@ class _PackWriter:
         else:
             self._handle.flush()
         self._resources.close()
+        wire_size = _bounded_tensor_pack_size(self._path.stat().st_size, "tensor_pack.size_bytes")
         return TensorPack(
             self._path,
-            self._path.stat().st_size,
+            wire_size,
             self._sha256.hexdigest(),
             codec=self._codec,
             decoded_size_bytes=self._offset,
@@ -367,7 +374,7 @@ def result_tensor_pack_metadata(payload: Mapping[str, Any]) -> TensorPackMetadat
     metadata = payload.get("tensor_pack")
     if not isinstance(metadata, Mapping):
         raise ValueError("HTTP tensor result is missing tensor_pack metadata")
-    expected_size = _nonnegative_int(metadata.get("size_bytes"), "tensor_pack.size_bytes")
+    expected_size = _bounded_tensor_pack_size(metadata.get("size_bytes"), "tensor_pack.size_bytes")
     expected_sha256 = metadata.get("sha256")
     if not isinstance(expected_sha256, str) or len(expected_sha256) != 64:
         raise ValueError("tensor_pack.sha256 must be a SHA-256 hex digest")
@@ -384,7 +391,7 @@ def result_tensor_pack_metadata(payload: Mapping[str, Any]) -> TensorPackMetadat
             raise ValueError("zstd tensor packs require tensor_pack.decoded_size_bytes")
         decoded_size = expected_size
     else:
-        decoded_size = _nonnegative_int(raw_decoded_size, "tensor_pack.decoded_size_bytes")
+        decoded_size = _bounded_tensor_pack_size(raw_decoded_size, "tensor_pack.decoded_size_bytes")
     if codec == "raw" and decoded_size != expected_size:
         raise ValueError("raw tensor pack decoded_size_bytes must equal size_bytes")
     return TensorPackMetadata(
@@ -402,7 +409,7 @@ def decompress_zstd_tensor_pack(
 ) -> None:
     """Decode bounded concatenated Zstandard frames into ``destination``."""
 
-    expected_size = _nonnegative_int(decoded_size_bytes, "tensor_pack.decoded_size_bytes")
+    expected_size = _bounded_tensor_pack_size(decoded_size_bytes, "tensor_pack.decoded_size_bytes")
     source.seek(0)
     destination.seek(0)
     destination.truncate(0)
@@ -513,6 +520,13 @@ def _nonnegative_int(value: Any, field: str) -> int:
     if isinstance(value, bool) or not isinstance(value, Integral) or value < 0:
         raise ValueError(f"{field} must be a non-negative integer")
     return int(value)
+
+
+def _bounded_tensor_pack_size(value: Any, field: str) -> int:
+    size = _nonnegative_int(value, field)
+    if size > _MAX_TENSOR_PACK_BYTES:
+        raise ValueError(f"{field} {size} exceeds maximum {_MAX_TENSOR_PACK_BYTES} bytes")
+    return size
 
 
 async def _await_blocking_io(function: Any, *args: Any) -> Any:

--- a/weaver/tensor_transport.py
+++ b/weaver/tensor_transport.py
@@ -213,7 +213,7 @@ def serialize_training_data(
     *,
     loss_fn: str,
     transport: TensorTransport,
-    compression: TensorCompression = "raw",
+    compression: TensorCompression = "zstd",
 ) -> SerializedTrainingData:
     """Serialize datums, optimizing dense cross-entropy tensors only."""
 

--- a/weaver/tensor_transport.py
+++ b/weaver/tensor_transport.py
@@ -1,0 +1,516 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Binary transport for dense cross-entropy training tensors."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import secrets
+import tempfile
+from contextlib import ExitStack
+from dataclasses import dataclass
+from numbers import Integral
+from pathlib import Path
+from typing import Any, BinaryIO, Iterator, Mapping, Sequence, cast
+
+import httpx
+import torch
+import zstandard
+
+from .config import TensorCompression, TensorTransport
+from .types import Datum
+from .types.tensor import TensorData, tensor_payload
+
+TENSOR_KEY = "$tensor"
+_RAW_CODEC = "raw"
+_FORMAT = "raw-tensor"
+_STREAM_CHUNK_BYTES = 8 * 1024 * 1024
+_ZSTD_LEVEL = 3
+_ZSTD_THREADS = 4
+_TORCH_TO_NAME: dict[torch.dtype, str] = {
+    torch.int64: "int64",
+    torch.int32: "int32",
+    torch.float32: "float32",
+    torch.float64: "float64",
+}
+
+
+@dataclass(slots=True)
+class TensorPack:
+    """One temporary HTTP tensor pack owned by a prepared request."""
+
+    path: Path
+    size_bytes: int
+    sha256: str
+    codec: TensorCompression = "raw"
+    decoded_size_bytes: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.codec not in ("raw", "zstd"):
+            raise ValueError("tensor pack codec must be 'raw' or 'zstd'")
+        if self.decoded_size_bytes is None:
+            if self.codec != "raw":
+                raise ValueError("zstd tensor packs require decoded_size_bytes")
+            self.decoded_size_bytes = self.size_bytes
+        if self.codec == "raw" and self.decoded_size_bytes != self.size_bytes:
+            raise ValueError("raw tensor pack decoded_size_bytes must equal size_bytes")
+
+    def close(self) -> None:
+        """Remove the client-local temporary pack."""
+
+        self.path.unlink(missing_ok=True)
+
+
+@dataclass(frozen=True, slots=True)
+class TensorPackMetadata:
+    """Trusted bounds and digest for one operation result pack."""
+
+    size_bytes: int
+    sha256: str
+    codec: TensorCompression
+    decoded_size_bytes: int
+
+
+@dataclass(slots=True)
+class SerializedTrainingData:
+    """Serialized datums plus an optional HTTP attachment."""
+
+    data: list[dict[str, Any]]
+    tensor_pack: TensorPack | None = None
+
+
+@dataclass(slots=True)
+class PreparedOperationBody:
+    """An operation JSON body and its optional HTTP tensor pack."""
+
+    body: dict[str, Any]
+    tensor_pack: TensorPack | None = None
+
+    def close(self) -> None:
+        """Release request-local resources after submission."""
+
+        if self.tensor_pack is not None:
+            self.tensor_pack.close()
+
+
+class _DigestingWriter:
+    """Hash compressed bytes while forwarding them to a file."""
+
+    def __init__(self, handle: BinaryIO, digest: Any) -> None:
+        self._handle = handle
+        self._digest = digest
+
+    def write(self, data: bytes | bytearray | memoryview) -> int:
+        self._digest.update(data)
+        return self._handle.write(data)
+
+    def flush(self) -> None:
+        self._handle.flush()
+
+
+class _PackWriter:
+    """Write request tensors incrementally and produce offset descriptors."""
+
+    def __init__(
+        self,
+        *,
+        compression: TensorCompression,
+    ) -> None:
+        if compression not in ("raw", "zstd"):
+            raise ValueError(f"unsupported tensor compression: {compression!r}")
+
+        self._codec: TensorCompression = compression
+        self._offset: int = 0
+        self._sha256: Any = hashlib.sha256()
+        with tempfile.NamedTemporaryFile(
+            prefix="weaver-tensors-", suffix=".bin", delete=False
+        ) as handle:
+            self._path = Path(handle.name)
+        self._resources: ExitStack = ExitStack()
+        self._file: BinaryIO = self._resources.enter_context(self._path.open("wb"))
+        if self._codec == "zstd":
+            sink = _DigestingWriter(self._file, self._sha256)
+            self._handle: BinaryIO = cast(
+                BinaryIO,
+                zstandard.ZstdCompressor(level=_ZSTD_LEVEL, threads=_ZSTD_THREADS).stream_writer(
+                    cast(BinaryIO, sink), closefd=False
+                ),
+            )
+        else:
+            self._handle = self._file
+
+    def put_tensor(self, tensor: torch.Tensor) -> dict[str, Any]:
+        """Append one tensor and return its transport-specific descriptor."""
+
+        dtype_name = _TORCH_TO_NAME.get(tensor.dtype)
+        if dtype_name is None:
+            raise TypeError(f"unsupported dtype for tensor transport: {tensor.dtype}")
+        array = tensor.detach().cpu().contiguous().numpy()
+        raw = memoryview(array).cast("B")  # type: ignore[arg-type]
+
+        offset = self._offset
+        size_bytes = raw.nbytes
+        self._handle.write(raw)
+        if self._codec == "raw":
+            self._sha256.update(raw)
+        self._offset += size_bytes
+
+        descriptor = {
+            "format": _FORMAT,
+            "codec": _RAW_CODEC,
+            "dtype": dtype_name,
+            "shape": list(array.shape),
+            "offset": offset,
+            "size_bytes": size_bytes,
+        }
+        return {TENSOR_KEY: descriptor}
+
+    def commit(self) -> TensorPack:
+        """Finish and return the HTTP attachment metadata."""
+
+        if self._codec == "zstd":
+            self._handle.close()
+            self._file.flush()
+        else:
+            self._handle.flush()
+        self._resources.close()
+        return TensorPack(
+            self._path,
+            self._path.stat().st_size,
+            self._sha256.hexdigest(),
+            codec=self._codec,
+            decoded_size_bytes=self._offset,
+        )
+
+    def abort(self) -> None:
+        """Close and remove an unpublished pack."""
+
+        try:
+            if not self._handle.closed:
+                self._handle.close()
+        finally:
+            self._resources.close()
+        self._path.unlink(missing_ok=True)
+
+
+def serialize_training_data(
+    data: Sequence[Datum],
+    *,
+    loss_fn: str,
+    transport: TensorTransport,
+    compression: TensorCompression = "raw",
+) -> SerializedTrainingData:
+    """Serialize datums, optimizing dense cross-entropy tensors only."""
+
+    if loss_fn != "cross_entropy" or transport == "default":
+        return SerializedTrainingData([datum.to_payload() for datum in data])
+
+    writer = _PackWriter(compression=compression)
+    try:
+        payload: list[dict[str, Any]] = []
+        for datum in data:
+            chunks: list[dict[str, Any]] = []
+            for chunk in datum.model_input.chunks:
+                tokens = torch.as_tensor(chunk.tokens, dtype=torch.int64)
+                chunks.append({"type": chunk.type, "tokens": writer.put_tensor(tokens)})
+
+            loss_inputs: dict[str, Any] = {}
+            for name, value in datum.loss_fn_inputs.items():
+                if name in {"target_tokens", "weights"} and isinstance(
+                    value, (torch.Tensor, TensorData)
+                ):
+                    tensor = value if isinstance(value, torch.Tensor) else value.to_tensor()
+                    wire_dtype = torch.int64 if name == "target_tokens" else torch.float32
+                    loss_inputs[name] = writer.put_tensor(tensor.to(dtype=wire_dtype))
+                elif isinstance(value, TensorData):
+                    loss_inputs[name] = value.to_dict()
+                elif isinstance(value, torch.Tensor):
+                    loss_inputs[name] = tensor_payload(value).to_dict()
+                else:
+                    loss_inputs[name] = value
+            datum_payload: dict[str, Any] = {
+                "model_input": {"chunks": chunks},
+                "loss_fn_inputs": loss_inputs,
+            }
+            if datum.metadata:
+                datum_payload["metadata"] = dict(datum.metadata)
+            payload.append(datum_payload)
+        tensor_pack = writer.commit()
+    except BaseException:
+        writer.abort()
+        raise
+
+    return SerializedTrainingData(payload, tensor_pack)
+
+
+class MultipartLayout:
+    """Byte-identical multipart layout shared by sync and async clients."""
+
+    def __init__(self, request: Mapping[str, Any], tensor_pack: TensorPack) -> None:
+        boundary = f"weaver-{secrets.token_hex(16)}"
+        manifest = json.dumps(
+            {
+                "version": 1,
+                "request": request,
+                "tensor_pack": {
+                    "size_bytes": tensor_pack.size_bytes,
+                    "sha256": tensor_pack.sha256,
+                    "codec": tensor_pack.codec,
+                    "decoded_size_bytes": tensor_pack.decoded_size_bytes,
+                },
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        marker = boundary.encode("ascii")
+        self.prefix = (
+            b"--"
+            + marker
+            + b'\r\nContent-Disposition: form-data; name="manifest"\r\n'
+            + b"Content-Type: application/json\r\n\r\n"
+            + manifest
+            + b"\r\n--"
+            + marker
+            + b'\r\nContent-Disposition: form-data; name="tensor_pack"; filename="pack.bin"\r\n'
+            + b"Content-Type: application/octet-stream\r\n\r\n"
+        )
+        self.suffix = b"\r\n--" + marker + b"--\r\n"
+        self.content_type = f"multipart/form-data; boundary={boundary}"
+        self.content_length = len(self.prefix) + tensor_pack.size_bytes + len(self.suffix)
+        self.pack_path = tensor_pack.path
+
+    def sync_stream(self) -> "SyncMultipartStream":
+        return SyncMultipartStream(self)
+
+    def async_stream(self) -> "AsyncMultipartStream":
+        return AsyncMultipartStream(self)
+
+
+class SyncMultipartStream(httpx.SyncByteStream):
+    """Replayable synchronous stream for one multipart tensor request."""
+
+    def __init__(self, layout: MultipartLayout) -> None:
+        self._layout = layout
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield self._layout.prefix
+        with self._layout.pack_path.open("rb") as handle:
+            while chunk := handle.read(_STREAM_CHUNK_BYTES):
+                yield chunk
+        yield self._layout.suffix
+
+
+class AsyncMultipartStream(httpx.AsyncByteStream):
+    """Asynchronous stream that keeps pack file I/O off the event loop."""
+
+    def __init__(self, layout: MultipartLayout) -> None:
+        self._layout = layout
+
+    async def __aiter__(self):  # type: ignore[no-untyped-def]
+        yield self._layout.prefix
+        handle = await _open_binary_file(self._layout.pack_path)
+        try:
+            while chunk := await _await_blocking_io(handle.read, _STREAM_CHUNK_BYTES):
+                yield chunk
+        finally:
+            await _await_blocking_io(handle.close)
+        yield self._layout.suffix
+
+
+def result_uses_http_tensor_pack(payload: Mapping[str, Any]) -> bool:
+    """Return whether detailed logprobs reference an HTTP result pack."""
+
+    result = payload.get("result")
+    outputs = result.get("loss_fn_outputs") if isinstance(result, Mapping) else None
+    if not isinstance(outputs, list):
+        return False
+    for output in outputs:
+        if not isinstance(output, Mapping):
+            continue
+        logprobs = output.get("logprobs")
+        if logprobs is None:
+            logprobs = output.get("Logprobs")
+        if isinstance(logprobs, Mapping) and TENSOR_KEY in logprobs:
+            return True
+    return False
+
+
+def result_tensor_pack_metadata(payload: Mapping[str, Any]) -> TensorPackMetadata:
+    """Parse the required size and digest for an HTTP result pack."""
+
+    metadata = payload.get("tensor_pack")
+    if not isinstance(metadata, Mapping):
+        raise ValueError("HTTP tensor result is missing tensor_pack metadata")
+    expected_size = _nonnegative_int(metadata.get("size_bytes"), "tensor_pack.size_bytes")
+    expected_sha256 = metadata.get("sha256")
+    if not isinstance(expected_sha256, str) or len(expected_sha256) != 64:
+        raise ValueError("tensor_pack.sha256 must be a SHA-256 hex digest")
+    try:
+        bytes.fromhex(expected_sha256)
+    except ValueError as exc:
+        raise ValueError("tensor_pack.sha256 must be a SHA-256 hex digest") from exc
+    codec = metadata.get("codec", "raw")
+    if codec not in ("raw", "zstd"):
+        raise ValueError("tensor_pack.codec must be 'raw' or 'zstd'")
+    raw_decoded_size = metadata.get("decoded_size_bytes")
+    if raw_decoded_size is None:
+        if codec != "raw":
+            raise ValueError("zstd tensor packs require tensor_pack.decoded_size_bytes")
+        decoded_size = expected_size
+    else:
+        decoded_size = _nonnegative_int(raw_decoded_size, "tensor_pack.decoded_size_bytes")
+    if codec == "raw" and decoded_size != expected_size:
+        raise ValueError("raw tensor pack decoded_size_bytes must equal size_bytes")
+    return TensorPackMetadata(
+        size_bytes=expected_size,
+        sha256=expected_sha256.lower(),
+        codec=cast(TensorCompression, codec),
+        decoded_size_bytes=decoded_size,
+    )
+
+
+def decompress_zstd_tensor_pack(
+    source: BinaryIO,
+    destination: BinaryIO,
+    decoded_size_bytes: int,
+) -> None:
+    """Decode exactly one bounded Zstandard frame into ``destination``."""
+
+    expected_size = _nonnegative_int(decoded_size_bytes, "tensor_pack.decoded_size_bytes")
+    source.seek(0)
+    destination.seek(0)
+    destination.truncate(0)
+    decoded = 0
+    reader = zstandard.ZstdDecompressor().stream_reader(
+        source,
+        read_across_frames=True,
+        closefd=False,
+    )
+    try:
+        while True:
+            # Reading one byte past the declared size detects expansion and
+            # concatenated frames without allowing an unbounded allocation.
+            read_size = min(_STREAM_CHUNK_BYTES, expected_size - decoded + 1)
+            try:
+                output = reader.read(read_size)
+            except zstandard.ZstdError as exc:
+                raise ValueError(
+                    "zstd tensor pack is invalid, truncated, or has trailing compressed data"
+                ) from exc
+            if not output:
+                break
+            if decoded == expected_size:
+                raise ValueError("zstd tensor pack has trailing compressed data")
+            if decoded + len(output) > expected_size:
+                raise ValueError(f"decoded tensor pack exceeds expected {expected_size} bytes")
+            destination.write(output)
+            decoded += len(output)
+    finally:
+        reader.close()
+
+    if decoded != expected_size:
+        raise ValueError(
+            "zstd tensor pack is truncated or size-mismatched: "
+            f"decoded tensor pack has {decoded} bytes, expected {expected_size}"
+        )
+    destination.flush()
+    destination.seek(0)
+
+
+def materialize_http_tensor(reference: Mapping[str, Any], pack: BinaryIO) -> torch.Tensor:
+    descriptor = reference.get(TENSOR_KEY)
+    if not isinstance(descriptor, Mapping):
+        raise ValueError("$tensor must contain an object descriptor")
+    return _materialize_raw_tensor_slice(descriptor, pack, name="$tensor")
+
+
+def _materialize_raw_tensor_slice(
+    descriptor: Mapping[str, Any], source: BinaryIO, *, name: str
+) -> torch.Tensor:
+    dtypes = {
+        "int64": torch.int64,
+        "int32": torch.int32,
+        "float32": torch.float32,
+        "float64": torch.float64,
+    }
+    dtype_name = descriptor.get("dtype")
+    dtype = dtypes.get(dtype_name) if isinstance(dtype_name, str) else None
+    if descriptor.get("format") != _FORMAT or descriptor.get("codec", _RAW_CODEC) != _RAW_CODEC:
+        raise ValueError(f"{name} must use raw-tensor/raw")
+    if dtype is None:
+        raise TypeError(f"unsupported {name} dtype: {dtype_name!r}")
+    raw_shape = descriptor.get("shape")
+    if not isinstance(raw_shape, list):
+        raise ValueError(f"{name} shape must be a list")
+    shape = [_nonnegative_int(value, f"{name}.shape") for value in raw_shape]
+    size_bytes = _nonnegative_int(descriptor.get("size_bytes"), f"{name}.size_bytes")
+    offset = _nonnegative_int(descriptor.get("offset", 0), f"{name}.offset")
+    if math.prod(shape) * torch.empty((), dtype=dtype).element_size() != size_bytes:
+        raise ValueError(f"{name} size_bytes does not match shape and dtype")
+    if size_bytes == 0:
+        return torch.empty(shape, dtype=dtype)
+
+    data = bytearray(size_bytes)
+    view = memoryview(data)
+    source.seek(offset)
+    read = 0
+    while read < size_bytes:
+        count = source.readinto(view[read:])  # type: ignore[attr-defined]
+        if not count:
+            break
+        read += count
+    if read != size_bytes:
+        raise ValueError(f"{name} slice exceeds the tensor pack")
+    return torch.frombuffer(data, dtype=dtype).reshape(shape)
+
+
+def _nonnegative_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return int(value)
+
+
+async def _await_blocking_io(function: Any, *args: Any) -> Any:
+    """Finish one in-flight file operation before propagating cancellation."""
+
+    task = asyncio.create_task(asyncio.to_thread(function, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        try:
+            await task
+        except BaseException:
+            pass
+        raise
+
+
+async def _open_binary_file(path: Path) -> BinaryIO:
+    """Open a pack off-loop without leaking the handle on cancellation."""
+
+    task = asyncio.create_task(asyncio.to_thread(path.open, "rb"))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.add_done_callback(_close_completed_file)
+        raise
+
+
+def _close_completed_file(task: "asyncio.Task[BinaryIO]") -> None:
+    try:
+        task.result().close()
+    except BaseException:
+        pass

--- a/weaver/tensor_transport.py
+++ b/weaver/tensor_transport.py
@@ -44,6 +44,7 @@ _STREAM_CHUNK_BYTES = 8 * 1024 * 1024
 _MAX_TENSOR_PACK_BYTES = 8 << 30
 _ZSTD_LEVEL = 3
 _ZSTD_THREADS = 4
+_ZSTD_FRAME_MAGIC = b"\x28\xb5\x2f\xfd"
 _TORCH_TO_NAME: dict[torch.dtype, str] = {
     torch.int64: "int64",
     torch.int32: "int32",
@@ -345,29 +346,6 @@ def result_uses_http_tensor_pack(payload: Mapping[str, Any]) -> bool:
     return isinstance(payload.get("tensor_pack"), Mapping)
 
 
-def bind_result_tensor_pack_operation(payload: Any, operation_id: str) -> Any:
-    """Attach the operation needed to retrieve a referenced result pack."""
-
-    if not isinstance(payload, Mapping):
-        return payload
-    metadata = payload.get("tensor_pack")
-    if not isinstance(metadata, Mapping):
-        return payload
-    bound = dict(payload)
-    bound["tensor_pack"] = {**metadata, "operation_id": operation_id}
-    return bound
-
-
-def result_tensor_pack_operation_id(payload: Mapping[str, Any]) -> str:
-    """Return the operation identifier bound to an HTTP result pack."""
-
-    metadata = payload.get("tensor_pack")
-    operation_id = metadata.get("operation_id") if isinstance(metadata, Mapping) else None
-    if not isinstance(operation_id, str) or not operation_id:
-        raise ValueError("HTTP tensor result is missing tensor_pack.operation_id")
-    return operation_id
-
-
 def result_tensor_pack_metadata(payload: Mapping[str, Any]) -> TensorPackMetadata:
     """Parse the required size and digest for an HTTP result pack."""
 
@@ -407,22 +385,23 @@ def decompress_zstd_tensor_pack(
     destination: BinaryIO,
     decoded_size_bytes: int,
 ) -> None:
-    """Decode bounded concatenated Zstandard frames into ``destination``."""
+    """Decode exactly one bounded Zstandard frame into ``destination``."""
 
     expected_size = _bounded_tensor_pack_size(decoded_size_bytes, "tensor_pack.decoded_size_bytes")
+    _validate_single_zstd_frame(source)
     source.seek(0)
     destination.seek(0)
     destination.truncate(0)
     decoded = 0
     reader = zstandard.ZstdDecompressor().stream_reader(
         source,
-        read_across_frames=True,
+        read_across_frames=False,
         closefd=False,
     )
     try:
         while True:
-            # Reading one byte past the declared combined size detects
-            # expansion without allowing an unbounded allocation.
+            # Reading one byte past the declared size detects expansion
+            # without allowing an unbounded allocation.
             read_size = min(_STREAM_CHUNK_BYTES, expected_size - decoded + 1)
             try:
                 output = reader.read(read_size)
@@ -450,6 +429,56 @@ def decompress_zstd_tensor_pack(
     destination.seek(0)
 
 
+def _validate_single_zstd_frame(source: BinaryIO) -> None:
+    """Reject truncated frames and any bytes following the first frame."""
+
+    original_position = source.tell()
+    try:
+        source.seek(0, os.SEEK_END)
+        wire_size = source.tell()
+        source.seek(0)
+
+        def read_exact(size: int) -> bytes:
+            data = source.read(size)
+            if len(data) != size:
+                raise ValueError("zstd tensor pack is truncated")
+            return data
+
+        if read_exact(4) != _ZSTD_FRAME_MAGIC:
+            raise ValueError("zstd tensor pack has an invalid frame header")
+        descriptor = read_exact(1)[0]
+        if descriptor & 0x08:
+            raise ValueError("zstd tensor pack has an invalid frame header")
+
+        single_segment = bool(descriptor & 0x20)
+        content_size_flag = descriptor >> 6
+        dictionary_id_size = (0, 1, 2, 4)[descriptor & 0x03]
+        content_size = (1 if single_segment else 0, 2, 4, 8)[content_size_flag]
+        header_suffix = (0 if single_segment else 1) + dictionary_id_size + content_size
+        read_exact(header_suffix)
+
+        while True:
+            block_header = int.from_bytes(read_exact(3), "little")
+            last_block = bool(block_header & 0x01)
+            block_type = (block_header >> 1) & 0x03
+            block_size = block_header >> 3
+            if block_type == 3:
+                raise ValueError("zstd tensor pack has an invalid block header")
+            encoded_size = 1 if block_type == 1 else block_size
+            if encoded_size > wire_size - source.tell():
+                raise ValueError("zstd tensor pack is truncated")
+            source.seek(encoded_size, os.SEEK_CUR)
+            if last_block:
+                break
+
+        if descriptor & 0x04:
+            read_exact(4)
+        if source.tell() != wire_size:
+            raise ValueError("zstd tensor pack must contain exactly one frame")
+    finally:
+        source.seek(original_position)
+
+
 def materialize_http_tensor(reference: Mapping[str, Any], pack: BinaryIO) -> torch.Tensor:
     descriptor = reference.get(TENSOR_KEY)
     if not isinstance(descriptor, Mapping):
@@ -457,15 +486,23 @@ def materialize_http_tensor(reference: Mapping[str, Any], pack: BinaryIO) -> tor
     return _materialize_raw_tensor_slice(descriptor, pack, name="$tensor")
 
 
-def materialize_http_tensors(value: Any, pack: BinaryIO) -> Any:
-    """Return a copy with every nested HTTP tensor reference materialized."""
+def materialize_http_tensor_payloads(value: Any, pack: BinaryIO) -> Any:
+    """Reconstruct legacy inline tensor payloads from nested references."""
 
     if isinstance(value, Mapping):
         if TENSOR_KEY in value:
-            return materialize_http_tensor(value, pack)
-        return {key: materialize_http_tensors(item, pack) for key, item in value.items()}
+            descriptor = value.get(TENSOR_KEY)
+            if not isinstance(descriptor, Mapping):
+                raise ValueError("$tensor must contain an object descriptor")
+            tensor = _materialize_raw_tensor_slice(descriptor, pack, name="$tensor")
+            return {
+                "data": tensor.tolist(),
+                "dtype": descriptor.get("dtype"),
+                "shape": list(tensor.shape),
+            }
+        return {key: materialize_http_tensor_payloads(item, pack) for key, item in value.items()}
     if isinstance(value, list):
-        return [materialize_http_tensors(item, pack) for item in value]
+        return [materialize_http_tensor_payloads(item, pack) for item in value]
     return value
 
 

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import math
+import tempfile
 import time
 from datetime import datetime, timezone
 from functools import cached_property
@@ -30,15 +31,20 @@ from ._http import WeaverAPIError
 from ._payloads import (
     build_request_metadata,
     build_surrogate_data,
-    forward_backward_payload,
-    forward_payload,
     parse_logprob_tensors,
+    prepare_forward_backward_operation,
+    prepare_forward_operation,
     serialize_data,
 )
 from ._sampling_utils import parse_model_id_from_weaver_path
 from ._utils import DEFAULT_SAMPLER_TTL_SECONDS, UNSET, _UnsetType, lookup_case_insensitive
 from .operations import OperationHandle, build_operation_handle
 from .service_client import ServiceClient
+from .tensor_transport import (
+    PreparedOperationBody,
+    result_tensor_pack_metadata,
+    result_uses_http_tensor_pack,
+)
 from .types import AdamParams, Datum
 from .types.checkpoint import Checkpoint
 from .types.deployment import Deployment
@@ -140,6 +146,13 @@ class TrainingClient:
     ) -> Dict[str, Any] | None:
         return build_request_metadata(metadata, router_replay)
 
+    def _enqueue_prepared(self, path: str, prepared: PreparedOperationBody) -> OperationHandle:
+        if prepared.tensor_pack is None:
+            return self._service.enqueue_operation(path, prepared.body)
+        return self._service.enqueue_operation(
+            path, prepared.body, tensor_pack=prepared.tensor_pack
+        )
+
     @overload
     def forward(
         self,
@@ -187,18 +200,21 @@ class TrainingClient:
                 Passing this argument raises ``ValueError``.
             wait: If True, blocks until the operation completes.
         """
-        payload = forward_payload(
+        prepared = prepare_forward_operation(
             model_id=self.model_id,
             seq_id=self._next_seq(),
             data=data,
             loss_fn=loss_fn,
             loss_fn_config=loss_fn_config,
             request_metadata=build_request_metadata(metadata, router_replay),
+            tensor_transport=self._service.tensor_transport,
+            tensor_compression=self._service.tensor_compression,
         )
-        handle = self._service.enqueue_operation(
-            f"/api/v1/models/{self.model_id}/forward-passes",
-            {"payload": payload},
-        )
+        try:
+            path = f"/api/v1/models/{self.model_id}/forward-passes"
+            handle = self._enqueue_prepared(path, prepared)
+        finally:
+            prepared.close()
         return handle.result() if wait else handle
 
     @overload
@@ -248,18 +264,21 @@ class TrainingClient:
                 Passing this argument raises ``ValueError``.
             wait: If True, blocks until the operation completes.
         """
-        payload = forward_backward_payload(
+        prepared = prepare_forward_backward_operation(
             model_id=self.model_id,
             seq_id=self._next_seq(),
             data=data,
             loss_fn=loss_fn,
             loss_fn_config=loss_fn_config,
             request_metadata=build_request_metadata(metadata, router_replay),
+            tensor_transport=self._service.tensor_transport,
+            tensor_compression=self._service.tensor_compression,
         )
-        handle = self._service.enqueue_operation(
-            f"/api/v1/models/{self.model_id}/forward-backward-passes",
-            {"payload": payload},
-        )
+        try:
+            path = f"/api/v1/models/{self.model_id}/forward-backward-passes"
+            handle = self._enqueue_prepared(path, prepared)
+        finally:
+            prepared.close()
         return handle.result() if wait else handle
 
     def forward_backward_custom(
@@ -287,13 +306,29 @@ class TrainingClient:
             data: Sequence of training data.
             loss_fn: ``(data, logprob_tensors) -> (loss, metrics)``
         """
-        # Step A: forward pass to get logprobs
-        fwd_result = self.forward(data, "forward_logprob", loss_fn_config=loss_fn_config, wait=True)
+        fwd_handle = self.forward(
+            data,
+            "forward_logprob",
+            loss_fn_config=loss_fn_config,
+            wait=False,
+        )
+        fwd_result = fwd_handle.result()
 
-        # Step B: parse logprobs from response
-        logprob_tensors = parse_logprob_tensors(fwd_result, data)
+        if result_uses_http_tensor_pack(fwd_result):
+            with tempfile.TemporaryFile(mode="w+b") as tensor_pack:
+                metadata = result_tensor_pack_metadata(fwd_result)
+                fwd_handle.client.download_tensor_pack(
+                    fwd_handle.operation_id,
+                    tensor_pack,
+                    size_bytes=metadata.size_bytes,
+                    sha256=metadata.sha256,
+                    codec=metadata.codec,
+                    decoded_size_bytes=metadata.decoded_size_bytes,
+                )
+                logprob_tensors = parse_logprob_tensors(fwd_result, data, tensor_pack=tensor_pack)
+        else:
+            logprob_tensors = parse_logprob_tensors(fwd_result, data)
 
-        # Step C: run user's loss function
         try:
             loss, metrics = loss_fn(data, logprob_tensors)
         except Exception as exc:
@@ -302,16 +337,9 @@ class TrainingClient:
         if loss.dim() != 0:
             raise ValueError(f"loss_fn must return a scalar loss, got shape {loss.shape}")
 
-        # Step D: backprop through user graph into logprob tensors
         loss.backward()
-
-        # Step E: build surrogate Datum objects from the propagated gradients
         surrogate_data = build_surrogate_data(data, logprob_tensors)
-
-        # Step F: surrogate backward pass
         self.forward_backward(surrogate_data, "surrogate", loss_fn_config=loss_fn_config, wait=True)
-
-        # Step G: return loss and metrics
         return {"loss": loss.detach(), "metrics": metrics}
 
     @overload

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -42,7 +42,9 @@ from .operations import OperationHandle, build_operation_handle
 from .service_client import ServiceClient
 from .tensor_transport import (
     PreparedOperationBody,
+    materialize_http_tensors,
     result_tensor_pack_metadata,
+    result_tensor_pack_operation_id,
     result_uses_http_tensor_pack,
 )
 from .types import AdamParams, Datum
@@ -152,6 +154,30 @@ class TrainingClient:
         return self._service.enqueue_operation(
             path, prepared.body, tensor_pack=prepared.tensor_pack
         )
+
+    def materialize_result_tensors(self, result: Mapping[str, Any]) -> Dict[str, Any]:
+        """Download every tensor referenced by an HTTP-binary result.
+
+        Args:
+            result: Completed operation result returned by this client.
+        Returns:
+            A copy with tensor references replaced by tensors.
+        Raises:
+            ValueError: If the result metadata or tensor pack is invalid.
+        """
+        if not isinstance(result.get("tensor_pack"), Mapping):
+            return dict(result)
+        metadata = result_tensor_pack_metadata(result)
+        with tempfile.TemporaryFile(mode="w+b") as tensor_pack:
+            self._service.http.download_tensor_pack(
+                result_tensor_pack_operation_id(result),
+                tensor_pack,
+                size_bytes=metadata.size_bytes,
+                sha256=metadata.sha256,
+                codec=metadata.codec,
+                decoded_size_bytes=metadata.decoded_size_bytes,
+            )
+            return dict(materialize_http_tensors(result, tensor_pack))
 
     @overload
     def forward(
@@ -315,19 +341,8 @@ class TrainingClient:
         fwd_result = fwd_handle.result()
 
         if result_uses_http_tensor_pack(fwd_result):
-            with tempfile.TemporaryFile(mode="w+b") as tensor_pack:
-                metadata = result_tensor_pack_metadata(fwd_result)
-                fwd_handle.client.download_tensor_pack(
-                    fwd_handle.operation_id,
-                    tensor_pack,
-                    size_bytes=metadata.size_bytes,
-                    sha256=metadata.sha256,
-                    codec=metadata.codec,
-                    decoded_size_bytes=metadata.decoded_size_bytes,
-                )
-                logprob_tensors = parse_logprob_tensors(fwd_result, data, tensor_pack=tensor_pack)
-        else:
-            logprob_tensors = parse_logprob_tensors(fwd_result, data)
+            fwd_result = self.materialize_result_tensors(fwd_result)
+        logprob_tensors = parse_logprob_tensors(fwd_result, data)
 
         try:
             loss, metrics = loss_fn(data, logprob_tensors)

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import logging
 import math
-import tempfile
 import time
 from datetime import datetime, timezone
 from functools import cached_property
@@ -40,13 +39,7 @@ from ._sampling_utils import parse_model_id_from_weaver_path
 from ._utils import DEFAULT_SAMPLER_TTL_SECONDS, UNSET, _UnsetType, lookup_case_insensitive
 from .operations import OperationHandle, build_operation_handle
 from .service_client import ServiceClient
-from .tensor_transport import (
-    PreparedOperationBody,
-    materialize_http_tensors,
-    result_tensor_pack_metadata,
-    result_tensor_pack_operation_id,
-    result_uses_http_tensor_pack,
-)
+from .tensor_transport import PreparedOperationBody
 from .types import AdamParams, Datum
 from .types.checkpoint import Checkpoint
 from .types.deployment import Deployment
@@ -154,30 +147,6 @@ class TrainingClient:
         return self._service.enqueue_operation(
             path, prepared.body, tensor_pack=prepared.tensor_pack
         )
-
-    def materialize_result_tensors(self, result: Mapping[str, Any]) -> Dict[str, Any]:
-        """Download every tensor referenced by an HTTP-binary result.
-
-        Args:
-            result: Completed operation result returned by this client.
-        Returns:
-            A copy with tensor references replaced by tensors.
-        Raises:
-            ValueError: If the result metadata or tensor pack is invalid.
-        """
-        if not isinstance(result.get("tensor_pack"), Mapping):
-            return dict(result)
-        metadata = result_tensor_pack_metadata(result)
-        with tempfile.TemporaryFile(mode="w+b") as tensor_pack:
-            self._service.http.download_tensor_pack(
-                result_tensor_pack_operation_id(result),
-                tensor_pack,
-                size_bytes=metadata.size_bytes,
-                sha256=metadata.sha256,
-                codec=metadata.codec,
-                decoded_size_bytes=metadata.decoded_size_bytes,
-            )
-            return dict(materialize_http_tensors(result, tensor_pack))
 
     @overload
     def forward(
@@ -339,9 +308,6 @@ class TrainingClient:
             wait=False,
         )
         fwd_result = fwd_handle.result()
-
-        if result_uses_http_tensor_pack(fwd_result):
-            fwd_result = self.materialize_result_tensors(fwd_result)
         logprob_tensors = parse_logprob_tensors(fwd_result, data)
 
         try:


### PR DESCRIPTION
## Summary
- Add opt-in `http-binary` transport for dense training inputs and loss-function outputs.
- Support raw or Zstandard-compressed tensor packs, avoiding large numeric JSON object graphs and repeated serialization.
- Keep `default` on the existing inline-JSON path for synchronous and asynchronous clients.

## Coordination
`http-binary` requires the corresponding control-plane and training-worker support to be deployed together. The default path does not.

## Input-handoff performance
128-GPU end-to-end SFT, one ~33.5M-token batch, submit-ahead disabled:

| Transport | Request payload | Synchronous submit |
| --- | ---: | ---: |
| `default` (inline JSON) | 433–435 MB | 86.5 s |
| `http-binary` / raw | 669.1 MB | 14.0 s |
| `http-binary` / Zstandard | 38.1 MB | 3.24 s |

The default path also spent 44.7 s from acceptance to trainer readiness, for about 131 s total handoff. Raw and Zstandard HTTP transport both produced correct end-to-end results.

## Testing
- Full SDK test suite — 208 passed
- Black, isort, license, and diff checks
- 128-GPU end-to-end SFT passed
