### PR TITLE
fix(async): auto-terminate created models on exit (atexit parity with sync ServiceClient)

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -15,6 +15,11 @@
 """Tests for the asyncio client stack (AsyncAPIClient + AsyncOperationHandle)."""
 
 import asyncio
+import atexit as _atexit
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -22,6 +27,7 @@ import pytest
 
 from weaver import _async_http
 from weaver._async_http import AsyncAPIClient
+from weaver.async_service_client import AsyncServiceClient
 from weaver.config import WeaverConfig
 from weaver.operations import AsyncOperationHandle, WeaverOperationError
 
@@ -223,3 +229,176 @@ class TestAsyncOperationHandle:
             return await AsyncOperationHandle.wait_all(handles)
 
         assert asyncio.run(run()) == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# AsyncServiceClient atexit safety net (parity with sync ServiceClient)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncAtexit:
+    """The async client must terminate created models on exit, like the sync one."""
+
+    def test_handler_terminates_created_models_on_fresh_client(self, monkeypatch):
+        """The atexit handler spins a throwaway loop + fresh client and reuses
+        ``terminate_model`` for every created model."""
+        svc = AsyncServiceClient(base_url="https://test.example.com", api_key="sk-test")
+        svc._created_models = ["m1", "m2"]
+
+        fresh = MagicMock()
+        fresh.post = AsyncMock(return_value={})
+        fresh.aclose = AsyncMock()
+        monkeypatch.setattr("weaver.async_service_client.AsyncAPIClient", lambda config: fresh)
+
+        svc._atexit_terminate_created_models()
+
+        posted_paths = [call.args[0] for call in fresh.post.call_args_list]
+        assert posted_paths == [
+            "/api/v1/models/m1/terminate",
+            "/api/v1/models/m2/terminate",
+        ]
+        fresh.aclose.assert_awaited_once()
+        assert svc._closed is True
+        assert svc._http is None  # fresh client is dropped after use
+
+    def test_handler_is_noop_after_aclose(self, monkeypatch):
+        svc = AsyncServiceClient(base_url="https://test.example.com", api_key="sk-test")
+        svc._created_models = ["m1"]
+        svc._closed = True
+
+        factory = MagicMock()
+        monkeypatch.setattr("weaver.async_service_client.AsyncAPIClient", factory)
+
+        svc._atexit_terminate_created_models()
+
+        factory.assert_not_called()  # already closed -> nothing to do
+
+    def test_handler_is_noop_without_created_models(self, monkeypatch):
+        svc = AsyncServiceClient(base_url="https://test.example.com", api_key="sk-test")
+
+        factory = MagicMock()
+        monkeypatch.setattr("weaver.async_service_client.AsyncAPIClient", factory)
+
+        svc._atexit_terminate_created_models()
+
+        factory.assert_not_called()
+
+    def test_connect_registers_and_aclose_unregisters(self, monkeypatch):
+        svc = AsyncServiceClient(base_url="https://test.example.com", api_key="sk-test")
+
+        registered: list = []
+        unregistered: list = []
+        monkeypatch.setattr(_atexit, "register", lambda fn: registered.append(fn))
+        monkeypatch.setattr(_atexit, "unregister", lambda fn: unregistered.append(fn))
+
+        svc._register_atexit()
+        assert svc._atexit_registered is True
+        assert registered == [svc._atexit_terminate_created_models]
+
+        asyncio.run(svc.aclose())
+        assert svc._atexit_registered is False
+        assert unregistered == [svc._atexit_terminate_created_models]
+
+
+def _build_async_atexit_script(marker_path: str, exit_code: str = "") -> str:
+    """Build a subprocess script that verifies the atexit handler terminates
+    created models when the process exits without ``aclose()``.
+
+    Runs a real in-process HTTP server so the handler's throwaway-loop request
+    path is exercised end-to-end; the server appends to ``marker_path`` whenever
+    a ``/terminate`` is received.
+    """
+    return f"""
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from weaver.async_service_client import AsyncServiceClient
+
+MARKER = {marker_path!r}
+
+
+class _H(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _send(self, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)
+        path = self.path
+        if path.endswith("/terminate"):
+            with open(MARKER, "a") as fh:
+                fh.write(path + chr(10))
+            return self._send({{}})
+        if path == "/api/v1/sessions":
+            return self._send({{"id": "sess-1"}})
+        if path.endswith("/models"):
+            return self._send({{"id": "model-xyz", "base_model": "x"}})
+        return self._send({{}})
+
+    def do_GET(self):
+        return self._send({{"items": []}})
+
+    def log_message(self, *a, **k):
+        return
+
+
+httpd = ThreadingHTTPServer(("127.0.0.1", 0), _H)
+threading.Thread(target=httpd.serve_forever, daemon=True).start()
+host, port = httpd.server_address
+base_url = "http://%s:%d" % (host, port)
+
+
+async def setup():
+    client = AsyncServiceClient(base_url=base_url, api_key="sk-test", heartbeat_interval=1000)
+    await client.connect()
+    await client.create_model(base_model="x", training_mode="full_ft")
+    # NOTE: deliberately no `await client.aclose()` -> exercise the atexit net.
+
+
+asyncio.run(setup())
+{exit_code}
+"""
+
+
+def test_atexit_terminates_created_models_on_normal_exit():
+    """A process that creates a model via AsyncServiceClient and exits without
+    aclose() must still terminate the model through the atexit handler."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        marker = Path(tmpdir) / "terminated.marker"
+        result = subprocess.run(
+            [sys.executable, "-c", _build_async_atexit_script(str(marker))],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"subprocess failed: {result.stderr}"
+        assert marker.exists(), "no /terminate sent on normal exit"
+        assert "/models/model-xyz/terminate" in marker.read_text()
+
+
+def test_atexit_terminates_created_models_on_exception_exit():
+    """The atexit safety net must also fire on an unhandled-exception exit."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        marker = Path(tmpdir) / "terminated.marker"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                _build_async_atexit_script(str(marker), 'raise RuntimeError("boom")'),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode != 0
+        assert marker.exists(), "no /terminate sent on exception exit"
+        assert "/models/model-xyz/terminate" in marker.read_text()

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -51,14 +51,27 @@ Integrating without hangs:
   it repeatedly.
 * **Always close** via ``async with`` or ``await svc.aclose()`` so the heartbeat
   task is cancelled before the loop closes (otherwise asyncio cancels it at
-  shutdown and may log a "Task was destroyed but it is pending" warning).
+  shutdown and may log a "Task was destroyed but it is pending" warning), and so
+  models created through this client are terminated promptly (see below).
 * **Multiple threads**: give each thread its own loop and its own client, or
   marshal calls onto the owning loop with ``asyncio.run_coroutine_threadsafe``.
+
+atexit safety net
+~~~~~~~~~~~~~~~~~
+For parity with the sync ``ServiceClient``, ``connect()`` registers an
+``atexit`` handler that terminates any models this client created if the process
+exits without an explicit ``aclose()``. Because the owning loop is usually
+already closed at interpreter shutdown, the handler creates a **throwaway** event
+loop and a fresh ``AsyncAPIClient`` solely to fire the terminate requests — the
+library still never runs coroutines on the caller's loop. Prefer ``async with``
+or ``await svc.aclose()``: the atexit path is only a best-effort backstop and,
+like the sync client, does not cover ``SIGKILL`` (the server-side reaper does).
 """
 
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
@@ -112,6 +125,7 @@ class AsyncServiceClient:
         self._sampling_seq_counter = 1
         self._operation_seq_by_model: Dict[str, int] = {}
         self._created_models: List[str] = []
+        self._atexit_registered = False
 
     async def __aenter__(self) -> "AsyncServiceClient":
         await self.connect()
@@ -135,6 +149,7 @@ class AsyncServiceClient:
         else:
             await self.ensure_session()
         self._start_heartbeat()
+        self._register_atexit()
 
     async def _ensure_connected(self) -> None:
         if self._http is None:
@@ -154,7 +169,66 @@ class AsyncServiceClient:
             json=payload if payload else None,
         )
 
+    def _register_atexit(self) -> None:
+        """Register a best-effort atexit safety net (sync-client parity).
+
+        Mirrors ``ServiceClient.connect()``'s ``atexit.register(self.close)``: on
+        interpreter shutdown, models created through this client are terminated
+        even if the caller forgot to ``await aclose()`` or use ``async with``.
+        """
+        if self._atexit_registered:
+            return
+        atexit.register(self._atexit_terminate_created_models)
+        self._atexit_registered = True
+
+    def _atexit_terminate_created_models(self) -> None:
+        """Terminate created models at interpreter shutdown (best-effort).
+
+        Runs from ``atexit``, where the client's owning event loop is typically
+        already closed, so we cannot ``await aclose()`` on it. Instead we spin up
+        a throwaway loop with a fresh HTTP client and fire the terminate
+        requests. This is the async twin of the sync client's
+        ``atexit.register(self.close)`` safety net. It does not cover ``SIGKILL``;
+        the server-side reaper remains the backstop for that.
+        """
+        if self._closed or not self._created_models:
+            return
+        self._closed = True
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(self._terminate_created_models_isolated())
+            finally:
+                loop.close()
+        except Exception as exc:  # pragma: no cover - best effort cleanup
+            logger.debug("atexit model cleanup failed: %s", exc)
+
+    async def _terminate_created_models_isolated(self) -> None:
+        """Terminate every created model on a fresh HTTP client.
+
+        Used only by the atexit safety net: the original ``AsyncAPIClient`` is
+        bound to the (now closed) owning loop, so a fresh client is created on
+        the throwaway loop to issue the terminate requests. Reuses
+        :meth:`terminate_model` so the request logic is not forked.
+        """
+        self._http = AsyncAPIClient(self._config)
+        try:
+            for model_id in list(self._created_models):
+                try:
+                    logger.debug("Terminating model %s during atexit cleanup", model_id)
+                    await self.terminate_model(model_id)
+                except Exception as exc:  # pragma: no cover - best effort cleanup
+                    logger.debug("Failed to terminate model %s: %s", model_id, exc)
+        finally:
+            try:
+                await self._http.aclose()
+            finally:
+                self._http = None
+
     async def aclose(self) -> None:
+        if self._atexit_registered:
+            atexit.unregister(self._atexit_terminate_created_models)
+            self._atexit_registered = False
         if self._closed:
             return
         self._closed = True


### PR DESCRIPTION
## Summary

Fixes #95. `AsyncServiceClient` had the model-teardown logic in `aclose()` but, unlike the sync `ServiceClient`, registered **no `atexit` handler** in `connect()`. A process that created a model through the async client and then exited without `async with` / `await aclose()` leaked the model's trainer + inference instances until the server-side reaper reclaimed them (~20 min later). This restores the graceful-exit parity the sync client already had.

## Changes

- **`AsyncServiceClient.connect()`** now registers a best-effort `atexit` handler (`_atexit_terminate_created_models`) that terminates every created model on interpreter shutdown.
- Because the client's owning event loop is typically **already closed** at interpreter shutdown, the handler spins up a **throwaway** event loop + a fresh `AsyncAPIClient` solely to fire the terminate requests. The library still never runs coroutines on the caller's loop (async-compat rule 4 preserved).
- The handler **reuses `terminate_model`** — no forked request logic (async-compat rule 1). It is idempotent with `aclose()` (guards on `_closed`), and `aclose()` **unregisters** it so an explicitly-closed client leaves no dangling atexit ref.
- Documented the safety net in the `AsyncServiceClient` "Event loop model" docstring (async-compat rule 4).

Like the sync client, this covers **graceful exit only**; `SIGKILL` still relies on the server-side reaper — noted in both the docstring and the original issue.

## Tests (`tests/test_async_client.py`)

- Unit: handler terminates each created model via a fresh client; no-op when already closed / no created models; `connect()` registers and `aclose()` unregisters the handler.
- Integration (subprocess, real embedded HTTP server): proves `/models/<id>/terminate` is actually sent when a process creates a model and exits **without** `aclose()`, on both **normal exit** and **unhandled-exception exit** — mirroring the existing sync `test_atexit_calls_close_*` tests.

## Notes

- No sync-side change needed: the sync `ServiceClient` already has this behavior; this brings the async twin to parity.
- `make format` / black / isort / pylint / mypy / license-header pre-commit hooks pass.