### PR TITLE
fix(training): enforce packed microbatch token budget

### DIFF
--- a/examples/streaming_sft.py
+++ b/examples/streaming_sft.py
@@ -171,6 +171,8 @@ async def run(args: argparse.Namespace) -> None:
         tokenizer = await asyncio.to_thread(training.get_tokenizer)
         batches = iter(
             TokenBudgetBatcher(
+                # Requires Megatron Bridge balanced packing: TRAINER_MICRO_BATCH_SIZE=0,
+                # matching DP/token budget, and router replay disabled.
                 iter_tokenized_examples(args.data, tokenizer),
                 length_fn=lambda example: len(example.input_tokens),
                 global_batch_size=args.global_batch_size,

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -39,8 +39,35 @@ def test_predict_packed_batch_shape_balances_dp_and_microbatches():
     assert shape.tokens_per_dp == (13, 13)
     assert shape.samples_per_dp == (2, 2)
     assert shape.microbatches_per_dp == 2
+    assert shape.max_microbatch_tokens == 8
     assert shape.global_microbatches == 4
     assert shape.dp_safe
+
+
+def test_predict_packed_batch_shape_detects_second_stage_overflow():
+    shape = predict_packed_batch_shape(
+        [6, 6, 6],
+        dp_size=1,
+        max_tokens_per_gpu=10,
+    )
+
+    assert shape.microbatches_per_dp == 2
+    assert shape.max_microbatch_tokens == 12
+
+
+def test_token_budget_batcher_carries_second_stage_overflow():
+    batches = list(
+        TokenBudgetBatcher(
+            range(4),
+            length_fn=lambda _: 6,
+            global_batch_size=2,
+            dp_size=1,
+            max_tokens_per_gpu=10,
+        )
+    )
+
+    assert [batch.items for batch in batches] == [(0, 1), (2, 3)]
+    assert all(batch.shape.max_microbatch_tokens <= 10 for batch in batches)
 
 
 def test_token_budget_batcher_reads_only_through_next_boundary():

--- a/weaver/training_pipeline.py
+++ b/weaver/training_pipeline.py
@@ -63,6 +63,7 @@ class PackedBatchShape:
         microbatches_per_dp: Synchronized microbatch count on each DP rank.
         samples_per_dp: Source-sample counts assigned to each DP rank.
         tokens_per_dp: Token counts assigned to each DP rank.
+        max_microbatch_tokens: Largest predicted packed microbatch.
     """
 
     samples: int
@@ -70,6 +71,7 @@ class PackedBatchShape:
     microbatches_per_dp: int
     samples_per_dp: tuple[int, ...]
     tokens_per_dp: tuple[int, ...]
+    max_microbatch_tokens: int = 0
 
     @property
     def global_microbatches(self) -> int:
@@ -193,12 +195,18 @@ def predict_packed_batch_shape(
     tokens_per_dp = tuple(sum(lengths[index] for index in part) for part in partitions)
     samples_per_dp = tuple(len(part) for part in partitions)
     microbatches = max(math.ceil(tokens / max_tokens_per_gpu) for tokens in tokens_per_dp)
+    microbatch_tokens: list[int] = []
+    for part in partitions:
+        rank_lengths = [lengths[index] for index in part]
+        for microbatch in _balanced_partitions(rank_lengths, microbatches):
+            microbatch_tokens.append(sum(rank_lengths[index] for index in microbatch))
     return PackedBatchShape(
         samples=len(lengths),
         tokens=sum(lengths),
         microbatches_per_dp=microbatches,
         samples_per_dp=samples_per_dp,
         tokens_per_dp=tokens_per_dp,
+        max_microbatch_tokens=max(microbatch_tokens, default=0),
     )
 
 
@@ -280,7 +288,11 @@ class TokenBudgetBatcher(Generic[T]):
                         dp_size=self._dp_size,
                         max_tokens_per_gpu=self._max_tokens_per_gpu,
                     )
-                    if previous.microbatches_per_dp == target and previous.dp_safe:
+                    if (
+                        previous.microbatches_per_dp == target
+                        and previous.dp_safe
+                        and previous.max_microbatch_tokens <= self._max_tokens_per_gpu
+                    ):
                         global_capacity = self._global_batch_size * self._max_tokens_per_gpu
                         if previous.tokens * 100 >= global_capacity * _MIN_SAFE_FILL_PERCENT:
                             yield TokenBudgetBatch(tuple(items[:-1]), previous)
@@ -301,7 +313,11 @@ class TokenBudgetBatcher(Generic[T]):
             )
             boundary_probes += 1
             if candidate.microbatches_per_dp <= target:
-                if candidate.microbatches_per_dp == target and candidate.dp_safe:
+                if (
+                    candidate.microbatches_per_dp == target
+                    and candidate.dp_safe
+                    and candidate.max_microbatch_tokens <= self._max_tokens_per_gpu
+                ):
                     shape = candidate
                     if boundary_probes >= _MAX_BOUNDARY_PROBES:
                         yield TokenBudgetBatch(tuple(items), shape)
@@ -312,7 +328,9 @@ class TokenBudgetBatcher(Generic[T]):
                         max_length = 0
                         probing_boundary = False
                         boundary_probes = 0
-                continue
+                    continue
+                if shape is None:
+                    continue
 
             overflow_item = items.pop()
             overflow_length = lengths.pop()
@@ -344,12 +362,15 @@ class TokenBudgetBatcher(Generic[T]):
             and final_shape is not None
             and final_shape.microbatches_per_dp == target
             and final_shape.dp_safe
+            and final_shape.max_microbatch_tokens <= self._max_tokens_per_gpu
         ):
             yield TokenBudgetBatch(tuple(items), final_shape)
         elif items and not self._drop_last:
             assert final_shape is not None
             if not final_shape.dp_safe:
                 raise ValueError("incomplete final request is not DP-safe")
+            if final_shape.max_microbatch_tokens > self._max_tokens_per_gpu:
+                raise ValueError("incomplete final request exceeds max_tokens_per_gpu")
             yield TokenBudgetBatch(tuple(items), final_shape)
 
 


### PR DESCRIPTION
## Summary
- mirror the trainer's second balanced-partition stage and expose the largest predicted microbatch
- emit only DP-safe request boundaries within `max_tokens_per_gpu`, while preserving the overflow sample
- state the balanced-packing requirements next to the streaming SFT example

## Testing
- `python -m pytest -q` — 196 passed
- Black, isort, mypy, pylint, license, and diff checks passed
- validated six DP8/GBS128 requests from the `sample_1000.jsonl` length manifest; every predicted microbatch was at most 262,144 tokens
