### PR TITLE
feat: add project and metrics console protocol

### DIFF
--- a/tests/test_cli_scope.py
+++ b/tests/test_cli_scope.py
@@ -1,0 +1,53 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for organization/project discovery CLI commands."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from weaver.cli import cli
+
+
+def test_list_organizations_is_sessionless(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_organizations.return_value = [{"id": "org-1", "name": "Research"}]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(cli, ["list", "organizations", "--format", "json"])
+
+    assert result.exit_code == 0
+    client.connect.assert_called_once_with(ensure_session=False)
+    client.list_organizations.assert_called_once_with()
+    client.close.assert_called_once_with()
+
+
+def test_list_projects_accepts_org_id_and_is_sessionless(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_projects.return_value = [{"id": "project-1", "name": "Default Project"}]
+    with patch("weaver.cli.ServiceClient", return_value=client) as constructor:
+        result = CliRunner().invoke(
+            cli,
+            ["list", "projects", "--organization-id", "org-1", "--format", "json"],
+        )
+
+    assert result.exit_code == 0
+    constructor.assert_called_once_with(base_url=None, api_key=None, organization_id="org-1")
+    client.connect.assert_called_once_with(ensure_session=False)
+    client.list_projects.assert_called_once_with("org-1")
+    client.close.assert_called_once_with()

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -1,0 +1,109 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from weaver.async_service_client import AsyncServiceClient
+from weaver.async_training_client import AsyncTrainingClient
+from weaver.service_client import ServiceClient
+from weaver.training_client import TrainingClient
+
+
+def test_service_client_creates_session_in_project_with_constructor_metadata() -> None:
+    client = ServiceClient(project_id="project-1", user_metadata={"recipe": "grpo"})
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-1"}
+
+    client.ensure_session()
+
+    args, kwargs = client._http.post.call_args
+    assert args[0] == "/api/v1/sessions"
+    assert kwargs["json"]["project_id"] == "project-1"
+    assert kwargs["json"]["user_metadata"] == {"recipe": "grpo"}
+
+
+def test_training_client_logs_custom_metrics_and_exposes_training_run_id() -> None:
+    service = ServiceClient()
+    service._http = MagicMock()
+    client = TrainingClient(
+        service=service,
+        model_id="run-1",
+        base_model="test/model",
+        session_id="session-1",
+    )
+    occurred_at = datetime(2026, 8, 3, tzinfo=timezone.utc)
+
+    client.log_metrics(
+        {"eval/reward": 0.75, "eval/pass_rate": 0.5},
+        step=12,
+        occurred_at=occurred_at,
+        labels={"split": "eval"},
+    )
+
+    assert client.training_run_id == client.model_id == "run-1"
+    args, kwargs = service._http.post.call_args
+    assert args[0] == "/api/v1/sessions/session-1/metrics"
+    assert kwargs["json"]["metrics"][0] == {
+        "model_id": "run-1",
+        "name": "eval/reward",
+        "value": 0.75,
+        "step": 12,
+        "occurred_at": occurred_at.isoformat(),
+        "labels": {"split": "eval"},
+    }
+
+
+def test_training_client_rejects_non_finite_metrics() -> None:
+    service = ServiceClient()
+    service._http = MagicMock()
+    client = TrainingClient(
+        service=service,
+        model_id="run-1",
+        base_model="test/model",
+        session_id="session-1",
+    )
+    with pytest.raises(ValueError, match="must be finite"):
+        client.log_metrics({"train/loss": float("nan")}, step=1)
+    service._http.post.assert_not_called()
+
+
+def test_async_console_protocol_matches_sync_client() -> None:
+    async def run() -> None:
+        service = AsyncServiceClient(project_id="project-2", user_metadata={"recipe": "sft"})
+        service._http = MagicMock()
+        service._http.post = AsyncMock(return_value={"id": "session-2"})
+        await service.ensure_session()
+        _, session_kwargs = service._http.post.call_args
+        assert session_kwargs["json"]["project_id"] == "project-2"
+        assert session_kwargs["json"]["user_metadata"] == {"recipe": "sft"}
+
+        training = AsyncTrainingClient(
+            service=service,
+            model_id="run-2",
+            base_model="test/model",
+            session_id="session-2",
+        )
+        await training.log_metrics({"eval/reward": 0.8}, step=3)
+        assert training.training_run_id == "run-2"
+        args, metric_kwargs = service._http.post.call_args
+        assert args[0] == "/api/v1/sessions/session-2/metrics"
+        assert metric_kwargs["json"]["metrics"][0]["step"] == 3
+
+    asyncio.run(run())

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -44,6 +44,53 @@ def test_service_client_creates_session_in_project_with_constructor_metadata() -
     assert kwargs["json"]["user_metadata"] == {"recipe": "grpo"}
 
 
+def test_empty_scope_ids_are_omitted_so_server_fallback_applies(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_ORGANIZATION_ID", "organization-from-env")
+    monkeypatch.setenv("WEAVER_PROJECT_ID", "project-from-env")
+    client = ServiceClient(organization_id="  ", project_id="")
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-default"}
+
+    client.ensure_session()
+
+    payload = client._http.post.call_args.kwargs["json"]
+    assert "organization_id" not in payload
+    assert "project_id" not in payload
+
+
+def test_scope_ids_use_environment_when_constructor_values_are_absent(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_ORGANIZATION_ID", " organization-from-env ")
+    monkeypatch.setenv("WEAVER_PROJECT_ID", " project-from-env ")
+    client = ServiceClient()
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-env"}
+
+    client.ensure_session()
+
+    payload = client._http.post.call_args.kwargs["json"]
+    assert payload["organization_id"] == "organization-from-env"
+    assert payload["project_id"] == "project-from-env"
+
+
+def test_project_discovery_falls_back_to_first_organization(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    client = ServiceClient(organization_id="")
+    client._http = MagicMock()
+    client._http.get.side_effect = [
+        [{"id": "organization-default", "name": "Default"}],
+        [{"id": "project-default", "name": "Default Project", "is_default": True}],
+    ]
+
+    projects = client.list_projects("")
+
+    assert projects[0]["id"] == "project-default"
+    assert client._http.get.call_args_list[0].args[0] == "/api/v1/organizations"
+    assert (
+        client._http.get.call_args_list[1].args[0]
+        == "/api/v1/organizations/organization-default/projects"
+    )
+
+
 def test_training_client_logs_custom_metrics_and_exposes_training_run_id() -> None:
     service = ServiceClient()
     service._http = MagicMock()
@@ -115,5 +162,23 @@ def test_async_console_protocol_matches_sync_client() -> None:
         args, metric_kwargs = service._http.post.call_args
         assert args[0] == "/api/v1/sessions/session-2/metrics"
         assert metric_kwargs["json"]["metrics"][0]["step"] == 3
+
+    asyncio.run(run())
+
+
+def test_async_empty_scope_ids_are_omitted(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_ORGANIZATION_ID", "organization-from-env")
+    monkeypatch.setenv("WEAVER_PROJECT_ID", "project-from-env")
+
+    async def run() -> None:
+        service = AsyncServiceClient(organization_id=" ", project_id="")
+        service._http = MagicMock()
+        service._http.post = AsyncMock(return_value={"id": "session-default"})
+
+        await service.ensure_session()
+
+        payload = service._http.post.call_args.kwargs["json"]
+        assert "organization_id" not in payload
+        assert "project_id" not in payload
 
     asyncio.run(run())

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -27,7 +27,11 @@ from weaver.training_client import TrainingClient
 
 
 def test_service_client_creates_session_in_project_with_constructor_metadata() -> None:
-    client = ServiceClient(project_id="project-1", user_metadata={"recipe": "grpo"})
+    client = ServiceClient(
+        organization_id="organization-1",
+        project_id="project-1",
+        user_metadata={"recipe": "grpo"},
+    )
     client._http = MagicMock()
     client._http.post.return_value = {"id": "session-1"}
 
@@ -35,6 +39,7 @@ def test_service_client_creates_session_in_project_with_constructor_metadata() -
 
     args, kwargs = client._http.post.call_args
     assert args[0] == "/api/v1/sessions"
+    assert kwargs["json"]["organization_id"] == "organization-1"
     assert kwargs["json"]["project_id"] == "project-1"
     assert kwargs["json"]["user_metadata"] == {"recipe": "grpo"}
 
@@ -86,11 +91,16 @@ def test_training_client_rejects_non_finite_metrics() -> None:
 
 def test_async_console_protocol_matches_sync_client() -> None:
     async def run() -> None:
-        service = AsyncServiceClient(project_id="project-2", user_metadata={"recipe": "sft"})
+        service = AsyncServiceClient(
+            organization_id="organization-2",
+            project_id="project-2",
+            user_metadata={"recipe": "sft"},
+        )
         service._http = MagicMock()
         service._http.post = AsyncMock(return_value={"id": "session-2"})
         await service.ensure_session()
         _, session_kwargs = service._http.post.call_args
+        assert session_kwargs["json"]["organization_id"] == "organization-2"
         assert session_kwargs["json"]["project_id"] == "project-2"
         assert session_kwargs["json"]["user_metadata"] == {"recipe": "sft"}
 

--- a/weaver/_utils.py
+++ b/weaver/_utils.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict
 
 
@@ -45,6 +46,21 @@ UNSET = _UnsetType()
 # shared storage. Callers can pass an explicit ``ttl_seconds`` (including
 # ``None`` for permanent retention) to override it.
 DEFAULT_SAMPLER_TTL_SECONDS = 3600  # 1 hour
+
+
+def optional_scope_id(value: str | None, env_var: str) -> str | None:
+    """Resolve and normalize an optional organization/project identifier.
+
+    ``None`` allows the environment variable to provide a default. An
+    explicitly empty value is normalized to ``None`` so session creation can
+    rely on the server's default-organization/default-project fallback.
+    """
+
+    candidate = os.getenv(env_var) if value is None else value
+    if candidate is None:
+        return None
+    normalized = candidate.strip()
+    return normalized or None
 
 
 def lookup_case_insensitive(payload: Dict[str, Any], name: str) -> Any:

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -88,6 +88,7 @@ class AsyncServiceClient:
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
@@ -99,6 +100,7 @@ class AsyncServiceClient:
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            organization_id: Optional Organization that owns a newly created session
             project_id: Optional Project used for a newly created session
             user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
@@ -106,6 +108,7 @@ class AsyncServiceClient:
         self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._organization_id = organization_id
         self._project_id = project_id
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
@@ -198,6 +201,8 @@ class AsyncServiceClient:
             ),
             "sdk_version": __version__,
         }
+        if self._organization_id:
+            payload["organization_id"] = self._organization_id
         if self._project_id:
             payload["project_id"] = self._project_id
         session = await self.http.post("/api/v1/sessions", json=payload)

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -64,7 +64,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from . import __version__
 from ._async_http import AsyncAPIClient
-from ._utils import extract_id, lookup_case_insensitive
+from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import AsyncOperationHandle, build_async_operation_handle
 from .types import LoraConfig
@@ -108,8 +108,8 @@ class AsyncServiceClient:
         self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
-        self._organization_id = organization_id
-        self._project_id = project_id
+        self._organization_id = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        self._project_id = optional_scope_id(project_id, "WEAVER_PROJECT_ID")
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
@@ -135,10 +135,13 @@ class AsyncServiceClient:
             raise RuntimeError("AsyncServiceClient is not connected")
         return self._http
 
-    async def connect(self) -> None:
-        if self._http is not None:
+    async def connect(self, *, ensure_session: bool = True) -> None:
+        """Connect, optionally without creating or fetching a Session."""
+
+        if self._http is None:
+            self._http = AsyncAPIClient(self._config)
+        if not ensure_session or self._session is not None:
             return
-        self._http = AsyncAPIClient(self._config)
         if self._session_id:
             await self._fetch_session(self._session_id)
         else:
@@ -146,7 +149,7 @@ class AsyncServiceClient:
         self._start_heartbeat()
 
     async def _ensure_connected(self) -> None:
-        if self._http is None:
+        if self._http is None or self._session is None:
             await self.connect()
 
     async def terminate_model(
@@ -448,6 +451,32 @@ class AsyncServiceClient:
                 if name:
                     names.append(str(name))
         return names
+
+    async def list_organizations(self) -> List[Dict[str, Any]]:
+        """List organizations available to the authenticated user."""
+
+        payload = await self.http.get("/api/v1/organizations")
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
+
+    async def list_projects(self, organization_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List projects, falling back to the user's first organization."""
+
+        resolved = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        if resolved is None:
+            resolved = self._organization_id
+        if resolved is None:
+            organizations = await self.list_organizations()
+            if not organizations:
+                return []
+            resolved = str(organizations[0].get("id", "")).strip() or None
+        if resolved is None:
+            return []
+        payload = await self.http.get(f"/api/v1/organizations/{resolved}/projects")
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
 
     async def list_training_runs(self, *, limit: int = 25, offset: int = 0) -> Dict[str, Any]:
         """List training runs with pagination."""

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -88,6 +88,8 @@ class AsyncServiceClient:
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
     ) -> None:
         """Initialize AsyncServiceClient.
@@ -97,11 +99,15 @@ class AsyncServiceClient:
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            project_id: Optional Project used for a newly created session
+            user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
         """
         self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._project_id = project_id
+        self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
         self._http: AsyncAPIClient | None = None
@@ -187,9 +193,13 @@ class AsyncServiceClient:
             return self._session
         payload = {
             "tags": list(tags or self._default_tags),
-            "user_metadata": user_metadata or {},
+            "user_metadata": (
+                user_metadata if user_metadata is not None else self._session_user_metadata
+            ),
             "sdk_version": __version__,
         }
+        if self._project_id:
+            payload["project_id"] = self._project_id
         session = await self.http.post("/api/v1/sessions", json=payload)
         self._session_id = extract_id(session)
         self._session = session
@@ -228,6 +238,7 @@ class AsyncServiceClient:
         training_mode: Optional[str] = None,
         lora_config: Union[LoraConfig, Dict[str, Any]] = DEFAULT_LORA_CONFIG,
         user_metadata: Optional[Dict[str, Any]] = None,
+        performance_tier: Optional[str] = None,
     ) -> "AsyncTrainingClient":
         """Create a training model with LoRA or FullFT configuration.
 
@@ -248,6 +259,8 @@ class AsyncServiceClient:
             )
         if user_metadata is not None:
             payload["user_metadata"] = user_metadata
+        if performance_tier is not None:
+            payload["performance_tier"] = performance_tier
 
         response = await self.http.post(
             f"/api/v1/sessions/{self.session_id}/models",
@@ -277,6 +290,14 @@ class AsyncServiceClient:
             tokenizer_path=tokenizer_path,
             debug_info=debug_info,
         )
+
+    async def create_training_client(self, **kwargs: Any) -> "AsyncTrainingClient":
+        """Create a Training Run client; compatibility alias for create_model."""
+
+        # The required base_model is supplied through kwargs by this compatibility
+        # alias; create_model performs the normal runtime validation.
+        # pylint: disable-next=missing-kwoa
+        return await self.create_model(**kwargs)
 
     def _next_model_seq(self) -> int:
         value = self._model_seq_counter

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -27,6 +27,8 @@ later, which lets several server-side operations overlap::
 from __future__ import annotations
 
 import logging
+import math
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
 from ._payloads import (
@@ -71,6 +73,52 @@ class AsyncTrainingClient:
         self.tokenizer_path = tokenizer_path
         self.debug_info = debug_info
         self._tokenizer: Any = None
+
+    @property
+    def training_run_id(self) -> str:
+        """Canonical identifier for this Training Run; model_id is retained."""
+
+        return self.model_id
+
+    async def log_metrics(
+        self,
+        metrics: Mapping[str, float],
+        *,
+        step: int,
+        occurred_at: datetime | None = None,
+        labels: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist application-side scalar metrics in Weaver."""
+
+        if step < 0:
+            raise ValueError("step must be non-negative")
+        if len(metrics) > 1000:
+            raise ValueError("at most 1000 metrics may be logged per call")
+        at = occurred_at or datetime.now(timezone.utc)
+        if at.tzinfo is None:
+            at = at.replace(tzinfo=timezone.utc)
+        points = []
+        for name, raw_value in metrics.items():
+            metric_name = str(name).strip()
+            if not metric_name:
+                raise ValueError("metric names must not be empty")
+            value = float(raw_value)
+            if not math.isfinite(value):
+                raise ValueError(f"metric {metric_name!r} must be finite")
+            points.append(
+                {
+                    "model_id": self.model_id,
+                    "name": metric_name,
+                    "value": value,
+                    "step": step,
+                    "occurred_at": at.isoformat(),
+                    "labels": dict(labels or {}),
+                }
+            )
+        if points:
+            await self._service.http.post(
+                f"/api/v1/sessions/{self.session_id}/metrics", json={"metrics": points}
+            )
 
     def _next_seq(self) -> int:
         return self._service.next_operation_seq(self.model_id)

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -146,6 +146,40 @@ def create_models_table(items: List[Dict[str, Any]]) -> Table:
     return table
 
 
+def create_organizations_table(items: List[Dict[str, Any]]) -> Table:
+    """Create a copy-friendly organization table."""
+
+    table = Table(title="Organizations", box=box.ROUNDED)
+    table.add_column("Organization ID", style="cyan", no_wrap=True)
+    table.add_column("Name", style="green")
+    table.add_column("Slug", style="blue")
+    for item in items:
+        table.add_row(
+            str(item.get("id", "")),
+            str(item.get("name", "")),
+            str(item.get("slug", "")),
+        )
+    return table
+
+
+def create_projects_table(items: List[Dict[str, Any]]) -> Table:
+    """Create a copy-friendly project table."""
+
+    table = Table(title="Projects", box=box.ROUNDED)
+    table.add_column("Project ID", style="cyan", no_wrap=True)
+    table.add_column("Name", style="green")
+    table.add_column("Slug", style="blue")
+    table.add_column("Default", justify="center")
+    for item in items:
+        table.add_row(
+            str(item.get("id", "")),
+            str(item.get("name", "")),
+            str(item.get("slug", "")),
+            "yes" if item.get("is_default") else "",
+        )
+    return table
+
+
 def display_training_run_detail(data: Dict[str, Any]) -> None:
     """Display detailed training run information."""
     console.print("\n[bold cyan]Training Run Details[/bold cyan]\n")
@@ -243,6 +277,73 @@ def show():
 @cli.group()
 def checkpoint():
     """Manage checkpoints."""
+
+
+@list.command("organizations")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def list_organizations_cmd(output_format: str, base_url: Optional[str], api_key: Optional[str]):
+    """List organizations available to the current user."""
+
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        items = client.list_organizations()
+        if output_format == "json":
+            format_json_output(items)
+        else:
+            console.print(create_organizations_table(items))
+            console.print(f"\n{len(items)} organizations")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+@list.command("projects")
+@click.option(
+    "--organization-id",
+    "--org-id",
+    "org_id",
+    envvar="WEAVER_ORGANIZATION_ID",
+    help="Organization ID; defaults to the first available organization",
+)
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def list_projects_cmd(
+    org_id: Optional[str], output_format: str, base_url: Optional[str], api_key: Optional[str]
+):
+    """List projects in an organization."""
+
+    client = ServiceClient(base_url=base_url, api_key=api_key, organization_id=org_id)
+    try:
+        client.connect(ensure_session=False)
+        items = client.list_projects(org_id)
+        if output_format == "json":
+            format_json_output(items)
+        else:
+            console.print(create_projects_table(items))
+            console.print(f"\n{len(items)} projects")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
 
 
 @list.command("training-runs")

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from . import __version__
 from ._http import APIClient
-from ._utils import extract_id, lookup_case_insensitive
+from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import OperationHandle, build_operation_handle
 from .types import LoraConfig
@@ -72,8 +72,8 @@ class ServiceClient:
         )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
-        self._organization_id = organization_id
-        self._project_id = project_id
+        self._organization_id = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        self._project_id = optional_scope_id(project_id, "WEAVER_PROJECT_ID")
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
@@ -100,16 +100,19 @@ class ServiceClient:
             raise RuntimeError("ServiceClient is not connected")
         return self._http
 
-    def connect(self) -> None:
-        if self._http is not None:
+    def connect(self, *, ensure_session: bool = True) -> None:
+        """Connect, optionally without creating or fetching a Session."""
+
+        if self._http is None:
+            self._http = APIClient(self._config)
+            atexit.register(self.close)
+        if not ensure_session or self._session is not None:
             return
-        self._http = APIClient(self._config)
         if self._session_id:
             self._fetch_session(self._session_id)
         else:
             self.ensure_session()
         self._start_heartbeat()
-        atexit.register(self.close)
 
     def terminate_model(
         self,
@@ -461,7 +464,6 @@ class ServiceClient:
     def list_supported_models(self) -> List[str]:
         """Return supported model names exposed by the server."""
         payload = self.http.get("/api/v1/supported-models")
-        print(f"payload: {payload}")
         if not isinstance(payload, dict):
             return []
         items = payload.get("items")
@@ -477,6 +479,32 @@ class ServiceClient:
                 if name:
                     names.append(str(name))
         return names
+
+    def list_organizations(self) -> List[Dict[str, Any]]:
+        """List organizations available to the authenticated user."""
+
+        payload = self.http.get("/api/v1/organizations")
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
+
+    def list_projects(self, organization_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List projects, falling back to the user's first organization."""
+
+        resolved = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        if resolved is None:
+            resolved = self._organization_id
+        if resolved is None:
+            organizations = self.list_organizations()
+            if not organizations:
+                return []
+            resolved = str(organizations[0].get("id", "")).strip() or None
+        if resolved is None:
+            return []
+        payload = self.http.get(f"/api/v1/organizations/{resolved}/projects")
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
 
     def get_supported_model_config(self, base_model: str) -> Optional[Dict[str, Any]]:
         """Get configuration for a specific supported model.

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -49,6 +49,8 @@ class ServiceClient:
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
     ) -> None:
         """Initialize ServiceClient.
@@ -58,6 +60,8 @@ class ServiceClient:
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            project_id: Optional Project used for a newly created session
+            user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
         """
         self._config = WeaverConfig.from_env(
@@ -66,6 +70,8 @@ class ServiceClient:
         )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._project_id = project_id
+        self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
         self._http: APIClient | None = None
@@ -156,9 +162,13 @@ class ServiceClient:
             return self._session
         payload = {
             "tags": list(tags or self._default_tags),
-            "user_metadata": user_metadata or {},
+            "user_metadata": (
+                user_metadata if user_metadata is not None else self._session_user_metadata
+            ),
             "sdk_version": __version__,
         }
+        if self._project_id:
+            payload["project_id"] = self._project_id
         session = self.http.post("/api/v1/sessions", json=payload)
         self._session_id = extract_id(session)
         self._session = session
@@ -303,6 +313,15 @@ class ServiceClient:
             tokenizer_path=tokenizer_path,
             debug_info=debug_info,
         )
+
+    def create_training_client(self, **kwargs: Any) -> "TrainingClient":
+        """Create a Training Run client.
+
+        This is the canonical product name for :meth:`create_model`. The old
+        method remains supported for compatibility with existing recipes.
+        """
+
+        return self.create_model(**kwargs)
 
     def _next_model_seq(self) -> int:
         value = self._model_seq_counter

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -49,6 +49,7 @@ class ServiceClient:
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
@@ -60,6 +61,7 @@ class ServiceClient:
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            organization_id: Optional Organization that owns a newly created session
             project_id: Optional Project used for a newly created session
             user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
@@ -70,6 +72,7 @@ class ServiceClient:
         )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._organization_id = organization_id
         self._project_id = project_id
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
@@ -167,6 +170,8 @@ class ServiceClient:
             ),
             "sdk_version": __version__,
         }
+        if self._organization_id:
+            payload["organization_id"] = self._organization_id
         if self._project_id:
             payload["project_id"] = self._project_id
         session = self.http.post("/api/v1/sessions", json=payload)

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import logging
+import math
+from datetime import datetime, timezone
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
@@ -62,6 +64,60 @@ class TrainingClient:
         self.session_id = session_id
         self.tokenizer_path = tokenizer_path
         self.debug_info = debug_info
+
+    @property
+    def training_run_id(self) -> str:
+        """Canonical identifier for this Training Run.
+
+        ``model_id`` remains available as a compatibility alias.
+        """
+
+        return self.model_id
+
+    def log_metrics(
+        self,
+        metrics: Mapping[str, float],
+        *,
+        step: int,
+        occurred_at: datetime | None = None,
+        labels: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist user-defined scalar metrics in Weaver.
+
+        Trainer-produced loss and optimizer metrics are captured by the server
+        completion protocol automatically; this method is for application-side
+        metrics such as rewards and evaluation scores.
+        """
+
+        if step < 0:
+            raise ValueError("step must be non-negative")
+        if len(metrics) > 1000:
+            raise ValueError("at most 1000 metrics may be logged per call")
+        at = occurred_at or datetime.now(timezone.utc)
+        if at.tzinfo is None:
+            at = at.replace(tzinfo=timezone.utc)
+        points = []
+        for name, raw_value in metrics.items():
+            metric_name = str(name).strip()
+            if not metric_name:
+                raise ValueError("metric names must not be empty")
+            value = float(raw_value)
+            if not math.isfinite(value):
+                raise ValueError(f"metric {metric_name!r} must be finite")
+            points.append(
+                {
+                    "model_id": self.model_id,
+                    "name": metric_name,
+                    "value": value,
+                    "step": step,
+                    "occurred_at": at.isoformat(),
+                    "labels": dict(labels or {}),
+                }
+            )
+        if points:
+            self._service.http.post(
+                f"/api/v1/sessions/{self.session_id}/metrics", json={"metrics": points}
+            )
 
     def _next_seq(self) -> int:
         return self._service.next_operation_seq(self.model_id)


### PR DESCRIPTION
## What changed

- let sync and async `ServiceClient` select both `organization_id` and `project_id` when creating a Session
- support constructor-level Session metadata with explicit-call override behavior
- expose `training_run_id` while retaining `model_id` compatibility
- add sync and async `create_training_client()` aliases for canonical product terminology
- add sync and async `log_metrics()` batch reporting for reward, eval, and application scalars
- validate metric count, step, names, and finite values client-side
- restore async `performance_tier` parity with the sync client

## Protocol boundary

The server validates that `project_id` belongs to `organization_id`; either field may be omitted for backward compatibility, in which case the server selects the user's organization/default project. Trainer-produced loss and optimizer metrics are captured from the trainer completion callback by weaver-server. `log_metrics()` intentionally handles only application-side values, avoiding duplicate trainer scalar writes.

Existing recipes remain compatible: `create_model()`, `model_id`, and clients that do not send organization/project IDs continue to work.

## Validation

- `pytest tests/test_console_protocol.py -q` (4 passed for the latest organization protocol change)
- black and isort checks on the changed files
- commit hooks: large-file/YAML/EOF checks, black, isort, pylint, mypy
- repository-wide license-header and trailing-whitespace hooks were skipped for the latest commit because they currently fail or rewrite unrelated pre-existing GitHub workflow files
- `git diff --check`
