### PR TITLE
feat: add organization and quota SDK protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ pip install nex-weaver
 
 Configuration can be provided via keyword arguments or environment variables:
 - `WEAVER_API_KEY`
+- `WEAVER_ORGANIZATION_ID` / `WEAVER_PROJECT_ID` for canonical IDs
+- `WEAVER_ORGANIZATION` / `WEAVER_PROJECT` for UUIDs, slugs, or display names
+
+Canonical IDs take precedence. When no organization or project is configured,
+the server keeps its stable personal-organization/default-project fallback.
 
 ## Quickstart
 
@@ -34,6 +39,22 @@ def main():
 if __name__ == "__main__":
     main()
 ```
+
+Select a scope by human-readable references, or discover and resolve available scopes:
+
+```python
+with ServiceClient(organization="research", project="alignment") as client:
+    client.ensure_session()
+```
+
+```bash
+weaver organizations list
+weaver projects list --organization research
+weaver scope resolve --organization research --project alignment
+```
+
+Organization slugs are globally unique. Project slugs and names are unique inside
+their organization; an ambiguous display name is rejected instead of guessed.
 
 ## Usage
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,6 +18,10 @@ pip install nex-weaver
 
 通过关键字参数或环境变量配置：
 - `WEAVER_API_KEY`
+- `WEAVER_ORGANIZATION_ID` / `WEAVER_PROJECT_ID`：规范 UUID
+- `WEAVER_ORGANIZATION` / `WEAVER_PROJECT`：UUID、slug 或展示名称
+
+规范 UUID 的优先级更高。组织和项目均为空时，服务端继续使用稳定的个人组织和默认项目回退逻辑。
 
 ## 快速开始
 
@@ -32,6 +36,21 @@ def main():
 if __name__ == "__main__":
     main()
 ```
+
+可以使用易读的引用选择范围，也可以通过 CLI 查询和解析：
+
+```python
+with ServiceClient(organization="research", project="alignment") as client:
+    client.ensure_session()
+```
+
+```bash
+weaver organizations list
+weaver projects list --organization research
+weaver scope resolve --organization research --project alignment
+```
+
+组织 slug 全局唯一；项目 slug 和名称在组织内唯一。展示名称存在歧义时会明确报错，不会猜测选择。
 
 ## 使用方法
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.9.0"
+version = "1.10.0"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [

--- a/tests/test_async_no_deadlock.py
+++ b/tests/test_async_no_deadlock.py
@@ -91,8 +91,8 @@ class _Handler(BaseHTTPRequestHandler):
             if count >= _POLLS_TILL_DONE:
                 return self._send(200, {"id": op_id, "status": "done", "response": {"op": op_id}})
             return self._send(200, {"id": op_id, "status": "running"})
-        if self.path == "/api/v1/supported-models":
-            return self._send(200, {"items": []})
+        if self.path.partition("?")[0] == "/api/v1/supported-models":
+            return self._send(200, {"items": [], "pagination": {"total_count": 0}})
         return self._send(404, {})
 
     def log_message(self, *_args, **_kwargs) -> None:  # silence test noise

--- a/tests/test_cli_scope.py
+++ b/tests/test_cli_scope.py
@@ -1,0 +1,53 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for organization/project discovery CLI commands."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from weaver.cli import cli
+
+
+def test_list_organizations_is_sessionless(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_organizations.return_value = [{"id": "org-1", "name": "Research"}]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(cli, ["list", "organizations", "--format", "json"])
+
+    assert result.exit_code == 0
+    client.connect.assert_called_once_with(ensure_session=False)
+    client.list_organizations.assert_called_once_with()
+    client.close.assert_called_once_with()
+
+
+def test_list_projects_accepts_org_id_and_is_sessionless(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_projects.return_value = [{"id": "project-1", "name": "Default Project"}]
+    with patch("weaver.cli.ServiceClient", return_value=client) as constructor:
+        result = CliRunner().invoke(
+            cli,
+            ["list", "projects", "--organization-id", "org-1", "--format", "json"],
+        )
+
+    assert result.exit_code == 0
+    constructor.assert_called_once_with(base_url=None, api_key=None, organization_id="org-1")
+    client.connect.assert_called_once_with(ensure_session=False)
+    client.list_projects.assert_called_once_with("org-1")
+    client.close.assert_called_once_with()

--- a/tests/test_cli_scope.py
+++ b/tests/test_cli_scope.py
@@ -103,3 +103,73 @@ def test_scope_json_is_stable_and_does_not_leak_internal_fields(monkeypatch) -> 
 
     assert result.exit_code == 0
     assert json.loads(result.output) == [{"id": "org-1", "name": "Research", "role": "admin"}]
+
+
+def test_projects_list_accepts_organization_slug_or_name(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.resolve_scope.return_value = {
+        "organization": {"id": "org-resolved", "slug": "research"},
+        "project": {"id": "default-project"},
+    }
+    client.list_projects.return_value = [
+        {"id": "project-1", "name": "RL", "current_user_role": "manager"}
+    ]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(
+            cli,
+            ["projects", "list", "--organization", "research", "--format", "json"],
+        )
+
+    assert result.exit_code == 0
+    client.resolve_scope.assert_called_once_with("research", None)
+    client.list_projects.assert_called_once_with("org-resolved")
+
+
+def test_scope_resolve_cli_returns_canonical_ids(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.resolve_scope.return_value = {
+        "organization": {"id": "org-1", "slug": "research", "name": "Research"},
+        "project": {"id": "project-1", "slug": "training", "name": "Training"},
+    }
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "scope",
+                "resolve",
+                "--organization",
+                "Research",
+                "--project",
+                "Training",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "org-1" in result.output
+    assert "project-1" in result.output
+    client.resolve_scope.assert_called_once_with("Research", "Training")
+
+
+def test_projects_list_rejects_conflicting_organization_options(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    with patch("weaver.cli.ServiceClient") as constructor:
+        result = CliRunner().invoke(
+            cli,
+            [
+                "projects",
+                "list",
+                "--organization-id",
+                "org-id",
+                "--organization",
+                "org-slug",
+            ],
+        )
+
+    assert result.exit_code == 2
+    assert "either --organization-id or --organization" in result.output
+    constructor.assert_not_called()

--- a/tests/test_cli_scope.py
+++ b/tests/test_cli_scope.py
@@ -14,6 +14,7 @@
 
 """Tests for organization/project discovery CLI commands."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -51,3 +52,54 @@ def test_list_projects_accepts_org_id_and_is_sessionless(monkeypatch) -> None:
     client.connect.assert_called_once_with(ensure_session=False)
     client.list_projects.assert_called_once_with("org-1")
     client.close.assert_called_once_with()
+
+
+def test_resource_first_organization_command_is_supported(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_organizations.return_value = [
+        {"id": "org-1", "name": "Research", "current_user_role": "admin"}
+    ]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(cli, ["organizations", "list"])
+
+    assert result.exit_code == 0
+    assert "org-1" in result.output
+    assert "Research" in result.output
+    assert "admin" in result.output
+
+
+def test_resource_first_projects_command_is_supported(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_projects.return_value = [
+        {"id": "project-1", "name": "RL", "current_user_role": "member"}
+    ]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(cli, ["projects", "list", "--organization-id", "org-1"])
+
+    assert result.exit_code == 0
+    assert "project-1" in result.output
+    assert "RL" in result.output
+    assert "member" in result.output
+
+
+def test_scope_json_is_stable_and_does_not_leak_internal_fields(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_organizations.return_value = [
+        {
+            "id": "org-1",
+            "name": "Research",
+            "slug": "internal-slug",
+            "current_user_role": "admin",
+        }
+    ]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(cli, ["organizations", "list", "--format", "json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == [{"id": "org-1", "name": "Research", "role": "admin"}]

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -172,23 +172,86 @@ def test_explicit_scope_resolution_does_not_inherit_unrelated_environment(monkey
     )
 
 
-def test_project_discovery_falls_back_to_first_organization(monkeypatch) -> None:
+def test_project_discovery_falls_back_to_stable_default_organization(monkeypatch) -> None:
     monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
     client = ServiceClient(organization_id="")
     client._http = MagicMock()
     client._http.get.side_effect = [
-        [{"id": "organization-default", "name": "Default"}],
+        {
+            "organization": {"id": "organization-default", "name": "Default"},
+            "project": {"id": "project-default", "name": "Default Project"},
+        },
         [{"id": "project-default", "name": "Default Project", "is_default": True}],
     ]
 
     projects = client.list_projects("")
 
     assert projects[0]["id"] == "project-default"
-    assert client._http.get.call_args_list[0].args[0] == "/api/v1/organizations"
+    assert client._http.get.call_args_list[0] == call("/api/v1/scope/resolve", params={})
     assert (
         client._http.get.call_args_list[1].args[0]
         == "/api/v1/organizations/organization-default/projects"
     )
+
+
+def test_project_discovery_returns_empty_when_default_scope_is_unavailable(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    client = ServiceClient(organization_id="")
+    client._http = MagicMock()
+    client._http.get.return_value = {}
+
+    assert client.list_projects("") == []
+    client._http.get.assert_called_once_with("/api/v1/scope/resolve", params={})
+
+
+def test_supported_models_use_selected_organization_and_traverse_pages() -> None:
+    client = ServiceClient(organization_id="organization-selected")
+    client._http = MagicMock()
+    client._http.get.side_effect = [
+        {
+            "items": [
+                {"name": "Public/Available", "status": "available"},
+                {"name": "Public/Unavailable", "status": "unavailable"},
+            ],
+            "pagination": {"total_count": 3},
+        },
+        {
+            "items": [{"name": "Internal/Developer", "visibility": "internal"}],
+            "pagination": {"total_count": 3},
+        },
+    ]
+
+    assert client.list_supported_models() == ["Public/Available", "Internal/Developer"]
+    assert client._http.get.call_args_list == [
+        call(
+            "/api/v1/supported-models",
+            params={"limit": 100, "offset": 0, "organization_id": "organization-selected"},
+        ),
+        call(
+            "/api/v1/supported-models",
+            params={"limit": 100, "offset": 2, "organization_id": "organization-selected"},
+        ),
+    ]
+
+
+def test_supported_model_config_can_be_found_after_first_page() -> None:
+    client = ServiceClient()
+    client._http = MagicMock()
+    client._http.get.side_effect = [
+        {
+            "items": [{"name": "First/Model", "config": {}}],
+            "pagination": {"total_count": 2},
+        },
+        {
+            "items": [{"name": "Target/Model", "config": {"resource": {}}}],
+            "pagination": {"total_count": 2},
+        },
+    ]
+
+    assert client.get_supported_model_config("Target/Model") == {
+        "name": "Target/Model",
+        "config": {"resource": {}},
+    }
 
 
 def test_training_client_logs_custom_metrics_and_exposes_training_run_id() -> None:
@@ -326,5 +389,71 @@ def test_async_named_scope_matches_sync_resolution(monkeypatch) -> None:
         payload = service._http.post.call_args.kwargs["json"]
         assert payload["organization_id"] == "organization-resolved"
         assert payload["project_id"] == "project-resolved"
+
+    asyncio.run(run())
+
+
+def test_async_project_discovery_uses_stable_default_scope(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+
+    async def run() -> None:
+        service = AsyncServiceClient(organization_id="")
+        service._http = MagicMock()
+        service._http.get = AsyncMock(
+            side_effect=[
+                {
+                    "organization": {"id": "organization-default"},
+                    "project": {"id": "project-default"},
+                },
+                [{"id": "project-default", "is_default": True}],
+            ]
+        )
+
+        projects = await service.list_projects("")
+
+        assert projects == [{"id": "project-default", "is_default": True}]
+        assert service._http.get.await_args_list[0] == call("/api/v1/scope/resolve", params={})
+        assert service._http.get.await_args_list[1].args[0] == (
+            "/api/v1/organizations/organization-default/projects"
+        )
+
+    asyncio.run(run())
+
+
+def test_async_supported_models_match_current_catalog_status_and_pagination() -> None:
+    async def run() -> None:
+        service = AsyncServiceClient()
+        service._session = {"organization_id": "organization-session"}
+        service._http = MagicMock()
+        service._http.get = AsyncMock(
+            side_effect=[
+                {
+                    "items": [
+                        {"name": "Legacy/Healthy", "status": "healthy"},
+                        {"name": "Catalog/Unavailable", "status": "unavailable"},
+                    ],
+                    "pagination": {"total_count": 3},
+                },
+                {
+                    "items": [{"name": "Catalog/Available", "status": "available"}],
+                    "pagination": {"total_count": 3},
+                },
+            ]
+        )
+
+        assert await service.list_supported_models() == [
+            "Legacy/Healthy",
+            "Catalog/Available",
+        ]
+        assert service._http.get.await_args_list == [
+            call(
+                "/api/v1/supported-models",
+                params={"limit": 100, "offset": 0, "organization_id": "organization-session"},
+            ),
+            call(
+                "/api/v1/supported-models",
+                params={"limit": 100, "offset": 2, "organization_id": "organization-session"},
+            ),
+        ]
 
     asyncio.run(run())

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -1,0 +1,109 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from weaver.async_service_client import AsyncServiceClient
+from weaver.async_training_client import AsyncTrainingClient
+from weaver.service_client import ServiceClient
+from weaver.training_client import TrainingClient
+
+
+def test_service_client_creates_session_in_project_with_constructor_metadata() -> None:
+    client = ServiceClient(project_id="project-1", user_metadata={"recipe": "grpo"})
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-1"}
+
+    client.ensure_session()
+
+    args, kwargs = client._http.post.call_args
+    assert args[0] == "/api/v1/sessions"
+    assert kwargs["json"]["project_id"] == "project-1"
+    assert kwargs["json"]["user_metadata"] == {"recipe": "grpo"}
+
+
+def test_training_client_logs_custom_metrics_and_exposes_training_run_id() -> None:
+    service = ServiceClient()
+    service._http = MagicMock()
+    client = TrainingClient(
+        service=service,
+        model_id="run-1",
+        base_model="test/model",
+        session_id="session-1",
+    )
+    occurred_at = datetime(2026, 8, 3, tzinfo=timezone.utc)
+
+    client.log_metrics(
+        {"eval/reward": 0.75, "eval/pass_rate": 0.5},
+        step=12,
+        occurred_at=occurred_at,
+        labels={"split": "eval"},
+    )
+
+    assert client.training_run_id == client.model_id == "run-1"
+    args, kwargs = service._http.post.call_args
+    assert args[0] == "/api/v1/sessions/session-1/metrics"
+    assert kwargs["json"]["metrics"][0] == {
+        "model_id": "run-1",
+        "name": "eval/reward",
+        "value": 0.75,
+        "step": 12,
+        "occurred_at": occurred_at.isoformat(),
+        "labels": {"split": "eval"},
+    }
+
+
+def test_training_client_rejects_non_finite_metrics() -> None:
+    service = ServiceClient()
+    service._http = MagicMock()
+    client = TrainingClient(
+        service=service,
+        model_id="run-1",
+        base_model="test/model",
+        session_id="session-1",
+    )
+    with pytest.raises(ValueError, match="must be finite"):
+        client.log_metrics({"train/loss": float("nan")}, step=1)
+    service._http.post.assert_not_called()
+
+
+def test_async_console_protocol_matches_sync_client() -> None:
+    async def run() -> None:
+        service = AsyncServiceClient(project_id="project-2", user_metadata={"recipe": "sft"})
+        service._http = MagicMock()
+        service._http.post = AsyncMock(return_value={"id": "session-2"})
+        await service.ensure_session()
+        _, session_kwargs = service._http.post.call_args
+        assert session_kwargs["json"]["project_id"] == "project-2"
+        assert session_kwargs["json"]["user_metadata"] == {"recipe": "sft"}
+
+        training = AsyncTrainingClient(
+            service=service,
+            model_id="run-2",
+            base_model="test/model",
+            session_id="session-2",
+        )
+        await training.log_metrics({"eval/reward": 0.8}, step=3)
+        assert training.training_run_id == "run-2"
+        args, metric_kwargs = service._http.post.call_args
+        assert args[0] == "/api/v1/sessions/session-2/metrics"
+        assert metric_kwargs["json"]["metrics"][0]["step"] == 3
+
+    asyncio.run(run())

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -72,6 +72,34 @@ def test_scope_ids_use_environment_when_constructor_values_are_absent(monkeypatc
     assert payload["project_id"] == "project-from-env"
 
 
+def test_scope_ids_are_omitted_when_parameter_and_environment_are_absent(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    monkeypatch.delenv("WEAVER_PROJECT_ID", raising=False)
+    client = ServiceClient()
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-default"}
+
+    client.ensure_session()
+
+    payload = client._http.post.call_args.kwargs["json"]
+    assert "organization_id" not in payload
+    assert "project_id" not in payload
+
+
+def test_project_only_scope_is_sent_for_server_side_organization_resolution(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    monkeypatch.delenv("WEAVER_PROJECT_ID", raising=False)
+    client = ServiceClient(project_id="project-1")
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-project"}
+
+    client.ensure_session()
+
+    payload = client._http.post.call_args.kwargs["json"]
+    assert payload["project_id"] == "project-1"
+    assert "organization_id" not in payload
+
+
 def test_project_discovery_falls_back_to_first_organization(monkeypatch) -> None:
     monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
     client = ServiceClient(organization_id="")
@@ -180,5 +208,23 @@ def test_async_empty_scope_ids_are_omitted(monkeypatch) -> None:
         payload = service._http.post.call_args.kwargs["json"]
         assert "organization_id" not in payload
         assert "project_id" not in payload
+
+    asyncio.run(run())
+
+
+def test_async_project_only_scope_is_sent(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    monkeypatch.delenv("WEAVER_PROJECT_ID", raising=False)
+
+    async def run() -> None:
+        service = AsyncServiceClient(project_id="project-async")
+        service._http = MagicMock()
+        service._http.post = AsyncMock(return_value={"id": "session-project"})
+
+        await service.ensure_session()
+
+        payload = service._http.post.call_args.kwargs["json"]
+        assert payload["project_id"] == "project-async"
+        assert "organization_id" not in payload
 
     asyncio.run(run())

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -44,6 +44,53 @@ def test_service_client_creates_session_in_project_with_constructor_metadata() -
     assert kwargs["json"]["user_metadata"] == {"recipe": "grpo"}
 
 
+def test_empty_scope_ids_are_omitted_so_server_fallback_applies(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_ORGANIZATION_ID", "organization-from-env")
+    monkeypatch.setenv("WEAVER_PROJECT_ID", "project-from-env")
+    client = ServiceClient(organization_id="  ", project_id="")
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-default"}
+
+    client.ensure_session()
+
+    payload = client._http.post.call_args.kwargs["json"]
+    assert "organization_id" not in payload
+    assert "project_id" not in payload
+
+
+def test_scope_ids_use_environment_when_constructor_values_are_absent(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_ORGANIZATION_ID", " organization-from-env ")
+    monkeypatch.setenv("WEAVER_PROJECT_ID", " project-from-env ")
+    client = ServiceClient()
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-env"}
+
+    client.ensure_session()
+
+    payload = client._http.post.call_args.kwargs["json"]
+    assert payload["organization_id"] == "organization-from-env"
+    assert payload["project_id"] == "project-from-env"
+
+
+def test_project_discovery_falls_back_to_first_organization(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    client = ServiceClient(organization_id="")
+    client._http = MagicMock()
+    client._http.get.side_effect = [
+        [{"id": "organization-default", "name": "Default"}],
+        [{"id": "project-default", "name": "Default Project", "is_default": True}],
+    ]
+
+    projects = client.list_projects("")
+
+    assert projects[0]["id"] == "project-default"
+    assert client._http.get.call_args_list[0].args[0] == "/api/v1/organizations"
+    assert (
+        client._http.get.call_args_list[1].args[0]
+        == "/api/v1/organizations/organization-default/projects"
+    )
+
+
 def test_training_client_logs_custom_metrics_and_exposes_training_run_id() -> None:
     service = ServiceClient()
     service._http = MagicMock()
@@ -115,5 +162,23 @@ def test_async_console_protocol_matches_sync_client() -> None:
         args, metric_kwargs = service._http.post.call_args
         assert args[0] == "/api/v1/sessions/session-2/metrics"
         assert metric_kwargs["json"]["metrics"][0]["step"] == 3
+
+    asyncio.run(run())
+
+
+def test_async_empty_scope_ids_are_omitted(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_ORGANIZATION_ID", "organization-from-env")
+    monkeypatch.setenv("WEAVER_PROJECT_ID", "project-from-env")
+
+    async def run() -> None:
+        service = AsyncServiceClient(organization_id=" ", project_id="")
+        service._http = MagicMock()
+        service._http.post = AsyncMock(return_value={"id": "session-default"})
+
+        await service.ensure_session()
+
+        payload = service._http.post.call_args.kwargs["json"]
+        assert "organization_id" not in payload
+        assert "project_id" not in payload
 
     asyncio.run(run())

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -27,7 +27,11 @@ from weaver.training_client import TrainingClient
 
 
 def test_service_client_creates_session_in_project_with_constructor_metadata() -> None:
-    client = ServiceClient(project_id="project-1", user_metadata={"recipe": "grpo"})
+    client = ServiceClient(
+        organization_id="organization-1",
+        project_id="project-1",
+        user_metadata={"recipe": "grpo"},
+    )
     client._http = MagicMock()
     client._http.post.return_value = {"id": "session-1"}
 
@@ -35,6 +39,7 @@ def test_service_client_creates_session_in_project_with_constructor_metadata() -
 
     args, kwargs = client._http.post.call_args
     assert args[0] == "/api/v1/sessions"
+    assert kwargs["json"]["organization_id"] == "organization-1"
     assert kwargs["json"]["project_id"] == "project-1"
     assert kwargs["json"]["user_metadata"] == {"recipe": "grpo"}
 
@@ -86,11 +91,16 @@ def test_training_client_rejects_non_finite_metrics() -> None:
 
 def test_async_console_protocol_matches_sync_client() -> None:
     async def run() -> None:
-        service = AsyncServiceClient(project_id="project-2", user_metadata={"recipe": "sft"})
+        service = AsyncServiceClient(
+            organization_id="organization-2",
+            project_id="project-2",
+            user_metadata={"recipe": "sft"},
+        )
         service._http = MagicMock()
         service._http.post = AsyncMock(return_value={"id": "session-2"})
         await service.ensure_session()
         _, session_kwargs = service._http.post.call_args
+        assert session_kwargs["json"]["organization_id"] == "organization-2"
         assert session_kwargs["json"]["project_id"] == "project-2"
         assert session_kwargs["json"]["user_metadata"] == {"recipe": "sft"}
 

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -100,6 +100,78 @@ def test_project_only_scope_is_sent_for_server_side_organization_resolution(monk
     assert "organization_id" not in payload
 
 
+def test_named_scope_is_resolved_to_canonical_ids_before_session_creation(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION", raising=False)
+    monkeypatch.delenv("WEAVER_PROJECT", raising=False)
+    client = ServiceClient(organization="research", project="Training")
+    client._http = MagicMock()
+    client._http.get.return_value = {
+        "organization": {"id": "organization-resolved", "slug": "research"},
+        "project": {"id": "project-resolved", "name": "Training"},
+    }
+    client._http.post.return_value = {"id": "session-named"}
+
+    client.ensure_session()
+
+    client._http.get.assert_called_once_with(
+        "/api/v1/scope/resolve",
+        params={"organization": "research", "project": "Training"},
+    )
+    payload = client._http.post.call_args.kwargs["json"]
+    assert payload["organization_id"] == "organization-resolved"
+    assert payload["project_id"] == "project-resolved"
+
+
+def test_named_scope_uses_environment_only_when_parameter_is_absent(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_ORGANIZATION", "environment-org")
+    monkeypatch.setenv("WEAVER_PROJECT", "environment-project")
+    client = ServiceClient(organization="explicit-org", project="explicit-project")
+    client._http = MagicMock()
+    client._http.get.return_value = {
+        "organization": {"id": "organization-resolved"},
+        "project": {"id": "project-resolved"},
+    }
+    client._http.post.return_value = {"id": "session-named"}
+
+    client.ensure_session()
+
+    assert client._http.get.call_args.kwargs["params"] == {
+        "organization": "explicit-org",
+        "project": "explicit-project",
+    }
+
+
+def test_canonical_ids_take_precedence_without_scope_resolution(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_ORGANIZATION", "ignored-org")
+    monkeypatch.setenv("WEAVER_PROJECT", "ignored-project")
+    client = ServiceClient(organization_id="org-id", project_id="project-id")
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-id"}
+
+    client.ensure_session()
+
+    client._http.get.assert_not_called()
+    payload = client._http.post.call_args.kwargs["json"]
+    assert payload["organization_id"] == "org-id"
+    assert payload["project_id"] == "project-id"
+
+
+def test_explicit_scope_resolution_does_not_inherit_unrelated_environment(monkeypatch) -> None:
+    monkeypatch.setenv("WEAVER_PROJECT", "environment-project")
+    client = ServiceClient()
+    client._http = MagicMock()
+    client._http.get.return_value = {
+        "organization": {"id": "org-id"},
+        "project": {"id": "default-project"},
+    }
+
+    client.resolve_scope("research", None)
+
+    client._http.get.assert_called_once_with(
+        "/api/v1/scope/resolve", params={"organization": "research"}
+    )
+
+
 def test_project_discovery_falls_back_to_first_organization(monkeypatch) -> None:
     monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
     client = ServiceClient(organization_id="")
@@ -226,5 +298,33 @@ def test_async_project_only_scope_is_sent(monkeypatch) -> None:
         payload = service._http.post.call_args.kwargs["json"]
         assert payload["project_id"] == "project-async"
         assert "organization_id" not in payload
+
+    asyncio.run(run())
+
+
+def test_async_named_scope_matches_sync_resolution(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION", raising=False)
+    monkeypatch.delenv("WEAVER_PROJECT", raising=False)
+
+    async def run() -> None:
+        service = AsyncServiceClient(organization="research", project="Training")
+        service._http = MagicMock()
+        service._http.get = AsyncMock(
+            return_value={
+                "organization": {"id": "organization-resolved"},
+                "project": {"id": "project-resolved"},
+            }
+        )
+        service._http.post = AsyncMock(return_value={"id": "session-project"})
+
+        await service.ensure_session()
+
+        service._http.get.assert_awaited_once_with(
+            "/api/v1/scope/resolve",
+            params={"organization": "research", "project": "Training"},
+        )
+        payload = service._http.post.call_args.kwargs["json"]
+        assert payload["organization_id"] == "organization-resolved"
+        assert payload["project_id"] == "project-resolved"
 
     asyncio.run(run())

--- a/tests/test_error_contract.py
+++ b/tests/test_error_contract.py
@@ -1,0 +1,121 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from weaver import WeaverAPIError as PublicWeaverAPIError
+from weaver._http import WeaverAPIError, raise_for_response
+from weaver.cli import cli
+
+
+def test_api_error_is_part_of_public_sdk_surface() -> None:
+    assert PublicWeaverAPIError is WeaverAPIError
+
+
+def test_error_contract_extracts_request_retry_and_quota_details() -> None:
+    response = httpx.Response(
+        402,
+        headers={"X-Request-ID": "req-header", "Retry-After": "17"},
+        json={
+            "error": "quota_exceeded",
+            "message": "insufficient quota",
+            "retryable": False,
+            "request_id": "req-body",
+            "details": {
+                "required_nanos": "2500000000",
+                "available_nanos": 1_000_000_000,
+                "required_usd": "2.5",
+                "available_usd": "1",
+            },
+        },
+    )
+
+    with pytest.raises(WeaverAPIError) as caught:
+        raise_for_response(response)
+
+    error = caught.value
+    assert error.status_code == 402
+    assert error.code == "quota_exceeded"
+    assert error.message == "insufficient quota"
+    assert error.retryable is False
+    assert error.request_id == "req-body"
+    assert error.retry_after == "17"
+    assert error.required_nanos == 2_500_000_000
+    assert error.available_nanos == 1_000_000_000
+    assert error.required_usd == "2.5"
+    assert error.available_usd == "1"
+
+
+def test_error_contract_uses_headers_and_top_level_legacy_details() -> None:
+    response = httpx.Response(
+        429,
+        headers={"X-Request-ID": "req-header", "Retry-After": "3"},
+        json={
+            "error": "rate_limited",
+            "message": "slow down",
+            "retryable": True,
+            "required_nanos": 9,
+            "available_nanos": 4,
+        },
+    )
+
+    with pytest.raises(WeaverAPIError) as caught:
+        raise_for_response(response)
+
+    assert caught.value.request_id == "req-header"
+    assert caught.value.retry_after == "3"
+    assert caught.value.required_nanos == 9
+    assert caught.value.available_nanos == 4
+    assert caught.value.required_usd == "0.000000009"
+    assert caught.value.available_usd == "0.000000004"
+
+
+@pytest.mark.parametrize(
+    ("status", "code", "expected"),
+    [
+        (402, "quota_exceeded", "Quota exceeded"),
+        (429, "rate_limited", "Rate limited"),
+        (503, "quota_unavailable", "Service temporarily unavailable"),
+    ],
+)
+def test_cli_renders_actionable_capacity_errors(monkeypatch, status, code, expected) -> None:
+    def fail(*_args, **_kwargs):
+        raise WeaverAPIError(
+            status,
+            code,
+            "capacity error",
+            retryable=status != 402,
+            request_id="request-123",
+            retry_after="11",
+            required_nanos=2_000_000_000,
+            available_nanos=500_000_000,
+            required_usd="2",
+            available_usd="0.5",
+        )
+
+    monkeypatch.setattr("weaver.service_client.ServiceClient.list_organizations", fail)
+    result = CliRunner().invoke(cli, ["organizations", "list", "--format", "json"])
+
+    assert result.exit_code == 1
+    assert expected in result.output
+    assert "request-123" in result.output
+    if status == 402:
+        assert "$2" in result.output
+        assert "$0.5" in result.output
+    if status == 429:
+        assert "11" in result.output

--- a/tests/test_quota_protocol.py
+++ b/tests/test_quota_protocol.py
@@ -1,0 +1,93 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from weaver.async_service_client import AsyncServiceClient
+from weaver.service_client import ServiceClient
+
+
+def test_sync_quota_uses_default_server_scope_when_org_is_absent(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    client = ServiceClient()
+    client._http = MagicMock()
+    client._http.get.return_value = {"available_nanos": 1_250_000_000, "available_usd": "1.25"}
+
+    result = client.get_quota_balance()
+
+    assert result["available_usd"] == "1.25"
+    client._http.get.assert_called_once_with("/api/v1/quota/balance")
+
+
+def test_sync_quota_uses_explicit_org_and_preserves_decimal_amount() -> None:
+    client = ServiceClient(organization_id="org-constructor")
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "request-1", "amount_usd": "0.000000001"}
+
+    result = client.request_quota("0.000000001", reason="one nano", organization_id="org-explicit")
+
+    assert result["id"] == "request-1"
+    client._http.post.assert_called_once_with(
+        "/api/v1/quota/requests",
+        json={"amount_usd": "0.000000001", "reason": "one nano"},
+        params={"org_id": "org-explicit"},
+        max_retries=1,
+    )
+
+
+def test_sync_list_quota_requests_preserves_pagination() -> None:
+    client = ServiceClient(organization_id="org-1")
+    client._http = MagicMock()
+    client._http.get.return_value = {"items": [], "pagination": {"total_count": 0}}
+
+    result = client.list_quota_requests(limit=10, offset=20)
+
+    assert result["items"] == []
+    client._http.get.assert_called_once_with(
+        "/api/v1/quota/requests",
+        params={"limit": 10, "offset": 20, "org_id": "org-1"},
+    )
+
+
+def test_async_quota_methods_match_sync_contract() -> None:
+    async def run() -> None:
+        client = AsyncServiceClient(organization_id="org-async")
+        client._http = MagicMock()
+        client._http.get = AsyncMock(
+            side_effect=[
+                {"available_nanos": 2_000_000_000, "available_usd": "2"},
+                {"items": [], "pagination": {"total_count": 0}},
+            ]
+        )
+        client._http.post = AsyncMock(return_value={"id": "request-async"})
+
+        balance = await client.get_quota_balance()
+        requests = await client.list_quota_requests(limit=5, offset=0)
+        created = await client.request_quota("3.5", reason="more training")
+
+        assert balance["available_nanos"] == 2_000_000_000
+        assert requests["items"] == []
+        assert created["id"] == "request-async"
+        client._http.get.assert_any_await("/api/v1/quota/balance", params={"org_id": "org-async"})
+        client._http.post.assert_awaited_once_with(
+            "/api/v1/quota/requests",
+            json={"amount_usd": "3.5", "reason": "more training"},
+            params={"org_id": "org-async"},
+            max_retries=1,
+        )
+
+    asyncio.run(run())

--- a/tests/test_scope_name_wire_contract.py
+++ b/tests/test_scope_name_wire_contract.py
@@ -1,0 +1,135 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end HTTP contract for UUID/slug/name scope resolution."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Iterator
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from weaver._http import WeaverAPIError
+from weaver.service_client import ServiceClient
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+PROJECT_ID = "22222222-2222-4222-8222-222222222222"
+
+
+@pytest.fixture()
+def scope_server() -> Iterator[tuple[str, list[dict[str, Any]]]]:
+    requests: list[dict[str, Any]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, _format: str, *_args: Any) -> None:
+            return
+
+        def reply(self, status: int, payload: dict[str, Any]) -> None:
+            encoded = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            query = parse_qs(parsed.query)
+            requests.append({"method": "GET", "path": parsed.path, "query": query})
+            if query.get("organization") == ["Shared"]:
+                self.reply(
+                    409,
+                    {
+                        "error": "ambiguous_scope_reference",
+                        "message": "scope reference is ambiguous",
+                        "retryable": False,
+                    },
+                )
+                return
+            self.reply(
+                200,
+                {
+                    "organization": {"id": ORG_ID, "slug": "research"},
+                    "project": {"id": PROJECT_ID, "slug": "training"},
+                },
+            )
+
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            length = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(length))
+            requests.append({"method": "POST", "path": parsed.path, "json": body})
+            self.reply(201, {"id": "session-1", **body})
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_name_scope_resolves_over_http_before_session_creation(
+    monkeypatch: pytest.MonkeyPatch,
+    scope_server: tuple[str, list[dict[str, Any]]],
+) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    monkeypatch.delenv("WEAVER_PROJECT_ID", raising=False)
+    monkeypatch.delenv("WEAVER_ORGANIZATION", raising=False)
+    monkeypatch.delenv("WEAVER_PROJECT", raising=False)
+    base_url, requests = scope_server
+    client = ServiceClient(
+        base_url=base_url,
+        api_key="sk-contract",
+        organization="research",
+        project="Training Run",
+    )
+    client.connect(ensure_session=False)
+    try:
+        client.ensure_session()
+    finally:
+        client.close()
+
+    assert requests[0] == {
+        "method": "GET",
+        "path": "/api/v1/scope/resolve",
+        "query": {"organization": ["research"], "project": ["Training Run"]},
+    }
+    assert requests[1]["json"]["organization_id"] == ORG_ID
+    assert requests[1]["json"]["project_id"] == PROJECT_ID
+
+
+def test_ambiguous_name_surfaces_structured_409(
+    scope_server: tuple[str, list[dict[str, Any]]],
+) -> None:
+    base_url, _requests = scope_server
+    client = ServiceClient(base_url=base_url, api_key="sk-contract")
+    client.connect(ensure_session=False)
+    try:
+        with pytest.raises(WeaverAPIError) as caught:
+            client.resolve_scope("Shared")
+    finally:
+        client.close()
+
+    assert caught.value.status_code == 409
+    assert caught.value.code == "ambiguous_scope_reference"
+    assert caught.value.retryable is False

--- a/tests/test_server_v1141_contract.py
+++ b/tests/test_server_v1141_contract.py
@@ -1,0 +1,422 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HTTP wire-contract tests matching weaver-server v1.14.1.
+
+The response bodies and route/query names in this fixture mirror the public
+Gin handlers at the v1.14.1 tag. Unlike the narrow MagicMock tests, these tests
+exercise URL encoding, JSON serialization, headers and the real httpx layer.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Iterator
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from click.testing import CliRunner
+
+from weaver._http import APIClient, WeaverAPIError
+from weaver.cli import cli
+from weaver.config import WeaverConfig
+from weaver.service_client import ServiceClient
+
+ORG_ID = "11111111-1111-4111-8111-111111111111"
+PROJECT_ID = "22222222-2222-4222-8222-222222222222"
+SESSION_ID = "33333333-3333-4333-8333-333333333333"
+
+
+class ServerV1141Fixture:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.error_response: tuple[int, dict[str, Any], dict[str, str]] | None = None
+        self.server: ThreadingHTTPServer | None = None
+        self.thread: threading.Thread | None = None
+
+    @property
+    def base_url(self) -> str:
+        assert self.server is not None
+        host = str(self.server.server_address[0])
+        port = int(self.server.server_address[1])
+        return f"http://{host}:{port}"
+
+    def start(self) -> None:
+        fixture = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: Any) -> None:
+                return
+
+            def _request_body(self) -> dict[str, Any] | None:
+                length = int(self.headers.get("Content-Length", "0"))
+                if length == 0:
+                    return None
+                return json.loads(self.rfile.read(length))
+
+            def _reply(
+                self,
+                status: int,
+                payload: dict[str, Any] | list[dict[str, Any]],
+                headers: dict[str, str] | None = None,
+            ) -> None:
+                encoded = json.dumps(payload).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                for name, value in (headers or {}).items():
+                    self.send_header(name, value)
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            def _record(
+                self, body: dict[str, Any] | None = None
+            ) -> tuple[str, dict[str, list[str]]]:
+                parsed = urlparse(self.path)
+                fixture.requests.append(
+                    {
+                        "method": self.command,
+                        "path": parsed.path,
+                        "query": parse_qs(parsed.query),
+                        "json": body,
+                        "api_key": self.headers.get("X-WEAVER-API-KEY"),
+                    }
+                )
+                return parsed.path, parse_qs(parsed.query)
+
+            def do_GET(self) -> None:  # noqa: N802
+                path, _query = self._record()
+                if fixture.error_response is not None:
+                    status, payload, headers = fixture.error_response
+                    self._reply(status, payload, headers)
+                    return
+                if path == "/api/v1/organizations":
+                    self._reply(
+                        200,
+                        [
+                            {
+                                "id": ORG_ID,
+                                "name": "Research",
+                                "slug": "research",
+                                "current_user_role": "admin",
+                                "created_at": "2026-08-04T00:00:00Z",
+                                "updated_at": "2026-08-04T00:00:00Z",
+                            }
+                        ],
+                    )
+                    return
+                if path == f"/api/v1/organizations/{ORG_ID}/projects":
+                    self._reply(
+                        200,
+                        [
+                            {
+                                "id": PROJECT_ID,
+                                "organization_id": ORG_ID,
+                                "name": "Default Project",
+                                "slug": "default",
+                                "is_default": True,
+                                "read_only": False,
+                                "current_user_role": "manager",
+                                "created_at": "2026-08-04T00:00:00Z",
+                                "updated_at": "2026-08-04T00:00:00Z",
+                            }
+                        ],
+                    )
+                    return
+                if path == "/api/v1/quota/balance":
+                    self._reply(
+                        200,
+                        {
+                            "organization_id": ORG_ID,
+                            "currency": "USD",
+                            "granted_nanos": 5_000_000_000,
+                            "reserved_nanos": 1_000_000_000,
+                            "settled_nanos": 500_000_000,
+                            "available_nanos": 3_500_000_000,
+                            "granted_usd": "5",
+                            "reserved_usd": "1",
+                            "settled_usd": "0.5",
+                            "available_usd": "3.5",
+                        },
+                    )
+                    return
+                if path == "/api/v1/quota/requests":
+                    self._reply(
+                        200,
+                        {
+                            "items": [],
+                            "pagination": {"total_count": 0, "limit": 10, "offset": 20},
+                        },
+                    )
+                    return
+                self._reply(404, {"error": "not_found", "message": "not found", "retryable": False})
+
+            def do_POST(self) -> None:  # noqa: N802
+                body = self._request_body()
+                path, _query = self._record(body)
+                if path == "/api/v1/sessions":
+                    self._reply(
+                        201,
+                        {
+                            "id": SESSION_ID,
+                            "organization_id": ORG_ID,
+                            "project_id": PROJECT_ID,
+                            "tags": body["tags"] if body else [],
+                            "user_metadata": body["user_metadata"] if body else {},
+                            "sdk_version": body["sdk_version"] if body else "",
+                            "created_at": "2026-08-04T00:00:00Z",
+                            "updated_at": "2026-08-04T00:00:00Z",
+                        },
+                    )
+                    return
+                if path == "/api/v1/quota/requests":
+                    self._reply(
+                        201,
+                        {
+                            "id": "44444444-4444-4444-8444-444444444444",
+                            "organization_id": ORG_ID,
+                            "email": "user@example.com",
+                            "amount_nanos": 1,
+                            "amount_usd": "0.000000001",
+                            "currency": "USD",
+                            "reason": body["reason"] if body else "",
+                            "status": "pending",
+                        },
+                    )
+                    return
+                self._reply(404, {"error": "not_found", "message": "not found", "retryable": False})
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def close(self) -> None:
+        if self.server is not None:
+            self.server.shutdown()
+            self.server.server_close()
+        if self.thread is not None:
+            self.thread.join(timeout=5)
+
+
+@pytest.fixture()
+def server_v1141() -> Iterator[ServerV1141Fixture]:
+    fixture = ServerV1141Fixture()
+    fixture.start()
+    try:
+        yield fixture
+    finally:
+        fixture.close()
+
+
+def test_cli_org_and_project_discovery_matches_v1141_wire_contract(
+    server_v1141: ServerV1141Fixture,
+) -> None:
+    runner = CliRunner()
+    organizations = runner.invoke(
+        cli,
+        [
+            "organizations",
+            "list",
+            "--format",
+            "json",
+            "--base-url",
+            server_v1141.base_url,
+            "--api-key",
+            "sk-contract",
+        ],
+    )
+    projects = runner.invoke(
+        cli,
+        [
+            "projects",
+            "list",
+            "--organization-id",
+            ORG_ID,
+            "--format",
+            "json",
+            "--base-url",
+            server_v1141.base_url,
+            "--api-key",
+            "sk-contract",
+        ],
+    )
+
+    assert organizations.exit_code == 0
+    assert json.loads(organizations.output) == [{"id": ORG_ID, "name": "Research", "role": "admin"}]
+    assert projects.exit_code == 0
+    assert json.loads(projects.output) == [
+        {"id": PROJECT_ID, "name": "Default Project", "role": "manager"}
+    ]
+    assert all(item["api_key"] == "sk-contract" for item in server_v1141.requests)
+
+
+@pytest.mark.parametrize(
+    ("project_id", "expected_scope"),
+    [(None, {}), (PROJECT_ID, {"project_id": PROJECT_ID})],
+)
+def test_session_default_and_project_only_fallback_match_v1141_wire_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    server_v1141: ServerV1141Fixture,
+    project_id: str | None,
+    expected_scope: dict[str, str],
+) -> None:
+    monkeypatch.delenv("WEAVER_ORGANIZATION_ID", raising=False)
+    monkeypatch.delenv("WEAVER_PROJECT_ID", raising=False)
+    client = ServiceClient(
+        base_url=server_v1141.base_url,
+        api_key="sk-contract",
+        project_id=project_id,
+    )
+    client.connect(ensure_session=False)
+    try:
+        created = client.ensure_session()
+    finally:
+        client.close()
+
+    assert created["id"] == SESSION_ID
+    request = server_v1141.requests[-1]
+    assert request["path"] == "/api/v1/sessions"
+    assert {key: request["json"][key] for key in expected_scope} == expected_scope
+    for key in {"organization_id", "project_id"} - expected_scope.keys():
+        assert key not in request["json"]
+
+
+def test_user_quota_methods_match_v1141_paths_queries_and_decimal_body(
+    server_v1141: ServerV1141Fixture,
+) -> None:
+    client = ServiceClient(
+        base_url=server_v1141.base_url,
+        api_key="sk-contract",
+        organization_id=ORG_ID,
+    )
+    client.connect(ensure_session=False)
+    try:
+        balance = client.get_quota_balance()
+        listed = client.list_quota_requests(limit=10, offset=20)
+        created = client.request_quota("0.000000001", reason="one nano")
+    finally:
+        client.close()
+
+    assert balance["available_nanos"] == 3_500_000_000
+    assert listed["pagination"] == {"total_count": 0, "limit": 10, "offset": 20}
+    assert created["amount_nanos"] == 1
+    assert server_v1141.requests[-3]["query"] == {"org_id": [ORG_ID]}
+    assert server_v1141.requests[-2]["query"] == {
+        "org_id": [ORG_ID],
+        "limit": ["10"],
+        "offset": ["20"],
+    }
+    assert server_v1141.requests[-1]["query"] == {"org_id": [ORG_ID]}
+    assert server_v1141.requests[-1]["json"] == {
+        "amount_usd": "0.000000001",
+        "reason": "one nano",
+    }
+
+
+@pytest.mark.parametrize(
+    ("status", "payload", "headers", "expected"),
+    [
+        (
+            402,
+            {
+                "error": "quota_exceeded",
+                "message": "insufficient quota",
+                "retryable": False,
+                "details": {
+                    "required_nanos": 2_500_000_000,
+                    "available_nanos": 1_000_000_000,
+                    "required_usd": "2.5",
+                    "available_usd": "1",
+                },
+            },
+            {},
+            {
+                "code": "quota_exceeded",
+                "retryable": False,
+                "required_nanos": 2_500_000_000,
+                "available_nanos": 1_000_000_000,
+                "required_usd": "2.5",
+                "available_usd": "1",
+                "retry_after": None,
+            },
+        ),
+        (
+            429,
+            {
+                "error": "rate_limited",
+                "message": "rate limit exceeded",
+                "retryable": True,
+                "details": {
+                    "retry_after_seconds": 2,
+                    "retry_after_milliseconds": 1_500,
+                },
+            },
+            {"Retry-After": "2"},
+            {
+                "code": "rate_limited",
+                "retryable": True,
+                "required_nanos": None,
+                "available_nanos": None,
+                "required_usd": None,
+                "available_usd": None,
+                "retry_after": "2",
+            },
+        ),
+        (
+            503,
+            {
+                "error": "quota_pricing_unavailable",
+                "message": "quota pricing unavailable",
+                "retryable": True,
+            },
+            {},
+            {
+                "code": "quota_pricing_unavailable",
+                "retryable": True,
+                "required_nanos": None,
+                "available_nanos": None,
+                "required_usd": None,
+                "available_usd": None,
+                "retry_after": None,
+            },
+        ),
+    ],
+)
+def test_capacity_errors_match_v1141_wire_contract(
+    server_v1141: ServerV1141Fixture,
+    status: int,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    expected: dict[str, Any],
+) -> None:
+    server_v1141.error_response = (status, payload, headers)
+    client = APIClient(
+        WeaverConfig(base_url=server_v1141.base_url, api_key="sk-contract"),
+        max_retries=1,
+    )
+    try:
+        with pytest.raises(WeaverAPIError) as caught:
+            client.get("/api/v1/quota/balance")
+    finally:
+        client.close()
+
+    error = caught.value
+    assert error.status_code == status
+    for field, value in expected.items():
+        assert getattr(error, field) == value
+    assert error.details == payload.get("details", {})
+    # v1.14.1 has no request-id response middleware yet; SDK leaves it absent.
+    assert error.request_id is None

--- a/weaver/__init__.py
+++ b/weaver/__init__.py
@@ -24,6 +24,7 @@ except Exception:
     __version__ = "0.3.0"
 
 from . import types  # noqa: F401
+from ._http import WeaverAPIError  # noqa: F401
 from .async_sampling_client import AsyncSamplingClient  # noqa: F401
 from .async_service_client import AsyncServiceClient  # noqa: F401
 from .async_training_client import AsyncTrainingClient  # noqa: F401
@@ -37,6 +38,7 @@ __all__ = [
     "AsyncTrainingClient",
     "AsyncSamplingClient",
     "AsyncOperationHandle",
+    "WeaverAPIError",
     "types",
     "__version__",
 ]

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -110,8 +110,15 @@ class AsyncAPIClient:
     async def get(self, path: str, *, params: Mapping[str, Any] | None = None) -> Any:
         return await self._request("GET", path, params=params)
 
-    async def post(self, path: str, *, json: Any = None, max_retries: int | None = None) -> Any:
-        return await self._request("POST", path, json=json, max_retries=max_retries)
+    async def post(
+        self,
+        path: str,
+        *,
+        json: Any = None,
+        params: Mapping[str, Any] | None = None,
+        max_retries: int | None = None,
+    ) -> Any:
+        return await self._request("POST", path, params=params, json=json, max_retries=max_retries)
 
     async def patch(self, path: str, *, json: Any) -> Any:
         return await self._request("PATCH", path, json=json)

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -74,12 +74,67 @@ def _is_connection_error(exc: BaseException) -> bool:
 
 
 class WeaverAPIError(RuntimeError):
-    def __init__(self, status_code: int, code: str, message: str, retryable: bool):
+    """Structured error returned by the Weaver API.
+
+    Optional capacity fields intentionally use integer nano-USD values and
+    decimal USD strings. This avoids losing very small charges to binary
+    floating-point rounding while still giving CLI users readable amounts.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        code: str,
+        message: str,
+        retryable: bool,
+        *,
+        request_id: str | None = None,
+        retry_after: str | None = None,
+        required_nanos: int | None = None,
+        available_nanos: int | None = None,
+        required_usd: str | None = None,
+        available_usd: str | None = None,
+        details: Mapping[str, Any] | None = None,
+    ):
         super().__init__(f"[{status_code}] {code}: {message}")
         self.status_code = status_code
         self.code = code
         self.message = message
         self.retryable = retryable
+        self.request_id = request_id
+        self.retry_after = retry_after
+        self.required_nanos = required_nanos
+        self.available_nanos = available_nanos
+        self.required_usd = required_usd
+        self.available_usd = available_usd
+        self.details = dict(details or {})
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _usd_from_nanos(value: int | None) -> str | None:
+    if value is None:
+        return None
+    sign = "-" if value < 0 else ""
+    absolute = abs(value)
+    whole, fractional = divmod(absolute, 1_000_000_000)
+    if fractional == 0:
+        return f"{sign}{whole}"
+    return f"{sign}{whole}.{fractional:09d}".rstrip("0")
 
 
 def extract_model_id_from_path(path: str) -> str | None:
@@ -104,11 +159,32 @@ def raise_for_response(response: httpx.Response) -> None:
         payload = response.json()
     except ValueError:
         payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    raw_details = payload.get("details")
+    details = raw_details if isinstance(raw_details, dict) else {}
+
+    def detail(name: str) -> Any:
+        # Accept the canonical nested contract and the early top-level shape so
+        # SDK upgrades do not have to be synchronized exactly with a server deploy.
+        return details.get(name, payload.get(name))
+
+    required_nanos = _optional_int(detail("required_nanos"))
+    available_nanos = _optional_int(detail("available_nanos"))
     raise WeaverAPIError(
         response.status_code,
         code=payload.get("error", "unknown_error"),
         message=payload.get("message", response.text),
         retryable=bool(payload.get("retryable", False)),
+        request_id=_optional_string(payload.get("request_id"))
+        or _optional_string(response.headers.get("X-Request-ID")),
+        retry_after=_optional_string(payload.get("retry_after"))
+        or _optional_string(response.headers.get("Retry-After")),
+        required_nanos=required_nanos,
+        available_nanos=available_nanos,
+        required_usd=_optional_string(detail("required_usd")) or _usd_from_nanos(required_nanos),
+        available_usd=_optional_string(detail("available_usd")) or _usd_from_nanos(available_nanos),
+        details=details,
     )
 
 
@@ -206,8 +282,15 @@ class APIClient:
     def get(self, path: str, *, params: Mapping[str, Any] | None = None) -> Any:
         return self._request("GET", path, params=params)
 
-    def post(self, path: str, *, json: Any = None, max_retries: int | None = None) -> Any:
-        return self._request("POST", path, json=json, max_retries=max_retries)
+    def post(
+        self,
+        path: str,
+        *,
+        json: Any = None,
+        params: Mapping[str, Any] | None = None,
+        max_retries: int | None = None,
+    ) -> Any:
+        return self._request("POST", path, params=params, json=json, max_retries=max_retries)
 
     def patch(self, path: str, *, json: Any) -> Any:
         return self._request("PATCH", path, json=json)

--- a/weaver/_utils.py
+++ b/weaver/_utils.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict
 
 
@@ -45,6 +46,21 @@ UNSET = _UnsetType()
 # shared storage. Callers can pass an explicit ``ttl_seconds`` (including
 # ``None`` for permanent retention) to override it.
 DEFAULT_SAMPLER_TTL_SECONDS = 3600  # 1 hour
+
+
+def optional_scope_id(value: str | None, env_var: str) -> str | None:
+    """Resolve and normalize an optional organization/project identifier.
+
+    ``None`` allows the environment variable to provide a default. An
+    explicitly empty value is normalized to ``None`` so session creation can
+    rely on the server's default-organization/default-project fallback.
+    """
+
+    candidate = os.getenv(env_var) if value is None else value
+    if candidate is None:
+        return None
+    normalized = candidate.strip()
+    return normalized or None
 
 
 def lookup_case_insensitive(payload: Dict[str, Any], name: str) -> Any:

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -101,6 +101,8 @@ class AsyncServiceClient:
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
     ) -> None:
         """Initialize AsyncServiceClient.
@@ -110,11 +112,15 @@ class AsyncServiceClient:
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            project_id: Optional Project used for a newly created session
+            user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
         """
         self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._project_id = project_id
+        self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
         self._http: AsyncAPIClient | None = None
@@ -261,9 +267,13 @@ class AsyncServiceClient:
             return self._session
         payload = {
             "tags": list(tags or self._default_tags),
-            "user_metadata": user_metadata or {},
+            "user_metadata": (
+                user_metadata if user_metadata is not None else self._session_user_metadata
+            ),
             "sdk_version": __version__,
         }
+        if self._project_id:
+            payload["project_id"] = self._project_id
         session = await self.http.post("/api/v1/sessions", json=payload)
         self._session_id = extract_id(session)
         self._session = session
@@ -302,6 +312,7 @@ class AsyncServiceClient:
         training_mode: Optional[str] = None,
         lora_config: Union[LoraConfig, Dict[str, Any]] = DEFAULT_LORA_CONFIG,
         user_metadata: Optional[Dict[str, Any]] = None,
+        performance_tier: Optional[str] = None,
     ) -> "AsyncTrainingClient":
         """Create a training model with LoRA or FullFT configuration.
 
@@ -322,6 +333,8 @@ class AsyncServiceClient:
             )
         if user_metadata is not None:
             payload["user_metadata"] = user_metadata
+        if performance_tier is not None:
+            payload["performance_tier"] = performance_tier
 
         response = await self.http.post(
             f"/api/v1/sessions/{self.session_id}/models",
@@ -351,6 +364,14 @@ class AsyncServiceClient:
             tokenizer_path=tokenizer_path,
             debug_info=debug_info,
         )
+
+    async def create_training_client(self, **kwargs: Any) -> "AsyncTrainingClient":
+        """Create a Training Run client; compatibility alias for create_model."""
+
+        # The required base_model is supplied through kwargs by this compatibility
+        # alias; create_model performs the normal runtime validation.
+        # pylint: disable-next=missing-kwoa
+        return await self.create_model(**kwargs)
 
     def _next_model_seq(self) -> int:
         value = self._model_seq_counter

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -103,6 +103,8 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         session_id: Optional[str] = None,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
+        organization: Optional[str] = None,
+        project: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
     ) -> None:
@@ -115,6 +117,8 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
             session_id: Optional existing session ID to reuse
             organization_id: Optional Organization that owns a newly created session
             project_id: Optional Project used for a newly created session
+            organization: Optional organization UUID, globally unique slug, or display name
+            project: Optional project UUID, organization-local slug, or display name
             user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
         """
@@ -123,6 +127,8 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         self._session_id = session_id
         self._organization_id = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
         self._project_id = optional_scope_id(project_id, "WEAVER_PROJECT_ID")
+        self._organization_reference = optional_scope_id(organization, "WEAVER_ORGANIZATION")
+        self._project_reference = optional_scope_id(project, "WEAVER_PROJECT")
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
@@ -271,6 +277,26 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
     ) -> Dict[str, Any]:
         if self._session is not None:
             return self._session
+        organization_id = self._organization_id
+        project_id = self._project_id
+        if (organization_id is None and self._organization_reference) or (
+            project_id is None and self._project_reference
+        ):
+            resolved = await self.resolve_scope(
+                organization_id or self._organization_reference,
+                project_id or self._project_reference,
+            )
+            if organization_id is None:
+                organization = resolved.get("organization")
+                if not isinstance(organization, dict):
+                    raise ValueError("Scope response missing organization")
+                organization_id = extract_id(organization)
+            if project_id is None:
+                project = resolved.get("project")
+                if not isinstance(project, dict):
+                    raise ValueError("Scope response missing project")
+                project_id = extract_id(project)
+
         payload = {
             "tags": list(tags or self._default_tags),
             "user_metadata": (
@@ -278,10 +304,10 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
             ),
             "sdk_version": __version__,
         }
-        if self._organization_id:
-            payload["organization_id"] = self._organization_id
-        if self._project_id:
-            payload["project_id"] = self._project_id
+        if organization_id:
+            payload["organization_id"] = organization_id
+        if project_id:
+            payload["project_id"] = project_id
         session = await self.http.post("/api/v1/sessions", json=payload)
         self._session_id = extract_id(session)
         self._session = session
@@ -533,6 +559,23 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         if not isinstance(payload, list):
             return []
         return [item for item in payload if isinstance(item, dict)]
+
+    async def resolve_scope(
+        self,
+        organization: Optional[str] = None,
+        project: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Resolve UUID/slug/name references to canonical scope IDs."""
+
+        params: Dict[str, str] = {}
+        organization_ref = organization.strip() if organization else None
+        project_ref = project.strip() if project else None
+        if organization_ref:
+            params["organization"] = organization_ref
+        if project_ref:
+            params["project"] = project_ref
+        payload = await self.http.get("/api/v1/scope/resolve", params=params)
+        return payload if isinstance(payload, dict) else {}
 
     async def list_projects(self, organization_id: Optional[str] = None) -> List[Dict[str, Any]]:
         """List projects, falling back to the user's first organization."""

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -517,39 +517,73 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         response = await self.http.post(path, json=payload, max_retries=1)
         return build_async_operation_handle(self.http, response)
 
+    async def _supported_model_scope_params(self) -> Dict[str, str]:
+        organization_id = self._organization_id
+        if organization_id is None and isinstance(self._session, dict):
+            raw_id = lookup_case_insensitive(self._session, "organization_id")
+            organization_id = str(raw_id).strip() if raw_id else None
+        if organization_id is None and (
+            self._organization_reference or self._project_id or self._project_reference
+        ):
+            scope = await self.resolve_scope(
+                self._organization_reference,
+                self._project_id or self._project_reference,
+            )
+            organization = scope.get("organization")
+            if isinstance(organization, dict):
+                raw_id = lookup_case_insensitive(organization, "id")
+                organization_id = str(raw_id).strip() if raw_id else None
+        return {"organization_id": organization_id} if organization_id else {}
+
+    async def _list_supported_model_records(self) -> List[Dict[str, Any]]:
+        """Traverse the role-filtered supported-model collection."""
+
+        records: List[Dict[str, Any]] = []
+        limit = 100
+        offset = 0
+        scope = await self._supported_model_scope_params()
+        while True:
+            params: Dict[str, Any] = {"limit": limit, "offset": offset, **scope}
+            payload = await self.http.get("/api/v1/supported-models", params=params)
+            if not isinstance(payload, dict):
+                break
+            items = payload.get("items")
+            if not isinstance(items, list):
+                break
+            page = [item for item in items if isinstance(item, dict)]
+            records.extend(page)
+            pagination = payload.get("pagination")
+            if not isinstance(pagination, dict):
+                break
+            total = pagination.get("total_count")
+            try:
+                total_count = int(str(total))
+            except (TypeError, ValueError):
+                break
+            offset += len(items)
+            if not items or offset >= total_count:
+                break
+        return records
+
     async def get_supported_model_config(self, base_model: str) -> Optional[Dict[str, Any]]:
         """Get configuration for a specific supported model."""
-        payload = await self.http.get("/api/v1/supported-models")
-        if not isinstance(payload, dict):
-            return None
-        items = payload.get("items")
-        if not isinstance(items, list):
-            return None
-        for item in items:
-            if not isinstance(item, dict):
-                continue
+        for item in await self._list_supported_model_records():
             name = lookup_case_insensitive(item, "name")
             if name and str(name) == base_model:
                 return item
         return None
 
     async def list_supported_models(self) -> List[str]:
-        """Return supported model names exposed by the server."""
-        payload = await self.http.get("/api/v1/supported-models")
-        if not isinstance(payload, dict):
-            return []
-        items = payload.get("items")
+        """Return usable model names exposed to the authenticated role."""
+
         names: List[str] = []
-        if isinstance(items, list):
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                name = lookup_case_insensitive(item, "name")
-                status = lookup_case_insensitive(item, "status")
-                if status and str(status).lower() != "healthy":
-                    continue
-                if name:
-                    names.append(str(name))
+        for item in await self._list_supported_model_records():
+            name = lookup_case_insensitive(item, "name")
+            status = lookup_case_insensitive(item, "status")
+            if status and str(status).lower() not in {"healthy", "available"}:
+                continue
+            if name:
+                names.append(str(name))
         return names
 
     async def list_organizations(self) -> List[Dict[str, Any]]:
@@ -578,16 +612,17 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         return payload if isinstance(payload, dict) else {}
 
     async def list_projects(self, organization_id: Optional[str] = None) -> List[Dict[str, Any]]:
-        """List projects, falling back to the user's first organization."""
+        """List projects, falling back to the user's stable default organization."""
 
         resolved = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
         if resolved is None:
             resolved = self._organization_id
         if resolved is None:
-            organizations = await self.list_organizations()
-            if not organizations:
+            scope = await self.resolve_scope()
+            organization = scope.get("organization")
+            if not isinstance(organization, dict):
                 return []
-            resolved = str(organizations[0].get("id", "")).strip() or None
+            resolved = str(organization.get("id", "")).strip() or None
         if resolved is None:
             return []
         payload = await self.http.get(f"/api/v1/organizations/{resolved}/projects")

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -101,6 +101,7 @@ class AsyncServiceClient:
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
@@ -112,6 +113,7 @@ class AsyncServiceClient:
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            organization_id: Optional Organization that owns a newly created session
             project_id: Optional Project used for a newly created session
             user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
@@ -119,6 +121,7 @@ class AsyncServiceClient:
         self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._organization_id = organization_id
         self._project_id = project_id
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
@@ -272,6 +275,8 @@ class AsyncServiceClient:
             ),
             "sdk_version": __version__,
         }
+        if self._organization_id:
+            payload["organization_id"] = self._organization_id
         if self._project_id:
             payload["project_id"] = self._project_id
         session = await self.http.post("/api/v1/sessions", json=payload)

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -77,7 +77,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from . import __version__
 from ._async_http import AsyncAPIClient
-from ._utils import extract_id, lookup_case_insensitive
+from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import AsyncOperationHandle, build_async_operation_handle
 from .types import LoraConfig
@@ -121,8 +121,8 @@ class AsyncServiceClient:
         self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
-        self._organization_id = organization_id
-        self._project_id = project_id
+        self._organization_id = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        self._project_id = optional_scope_id(project_id, "WEAVER_PROJECT_ID")
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
@@ -149,10 +149,13 @@ class AsyncServiceClient:
             raise RuntimeError("AsyncServiceClient is not connected")
         return self._http
 
-    async def connect(self) -> None:
-        if self._http is not None:
+    async def connect(self, *, ensure_session: bool = True) -> None:
+        """Connect, optionally without creating or fetching a Session."""
+
+        if self._http is None:
+            self._http = AsyncAPIClient(self._config)
+        if not ensure_session or self._session is not None:
             return
-        self._http = AsyncAPIClient(self._config)
         if self._session_id:
             await self._fetch_session(self._session_id)
         else:
@@ -161,7 +164,7 @@ class AsyncServiceClient:
         self._register_atexit()
 
     async def _ensure_connected(self) -> None:
-        if self._http is None:
+        if self._http is None or self._session is None:
             await self.connect()
 
     async def terminate_model(
@@ -522,6 +525,32 @@ class AsyncServiceClient:
                 if name:
                     names.append(str(name))
         return names
+
+    async def list_organizations(self) -> List[Dict[str, Any]]:
+        """List organizations available to the authenticated user."""
+
+        payload = await self.http.get("/api/v1/organizations")
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
+
+    async def list_projects(self, organization_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List projects, falling back to the user's first organization."""
+
+        resolved = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        if resolved is None:
+            resolved = self._organization_id
+        if resolved is None:
+            organizations = await self.list_organizations()
+            if not organizations:
+                return []
+            resolved = str(organizations[0].get("id", "")).strip() or None
+        if resolved is None:
+            return []
+        payload = await self.http.get(f"/api/v1/organizations/{resolved}/projects")
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
 
     async def list_training_runs(self, *, limit: int = 25, offset: int = 0) -> Dict[str, Any]:
         """List training runs with pagination."""

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -93,7 +93,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_LORA_CONFIG = LoraConfig(rank=32)
 
 
-class AsyncServiceClient:
+class AsyncServiceClient:  # pylint: disable=too-many-public-methods
     def __init__(
         self,
         *,
@@ -551,6 +551,53 @@ class AsyncServiceClient:
         if not isinstance(payload, list):
             return []
         return [item for item in payload if isinstance(item, dict)]
+
+    def _quota_scope_params(self, organization_id: Optional[str]) -> Dict[str, str]:
+        resolved = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        if resolved is None:
+            resolved = self._organization_id
+        return {"org_id": resolved} if resolved is not None else {}
+
+    async def get_quota_balance(self, organization_id: Optional[str] = None) -> Dict[str, Any]:
+        """Return the caller's nano-USD quota balance."""
+
+        scope = self._quota_scope_params(organization_id)
+        if scope:
+            payload = await self.http.get("/api/v1/quota/balance", params=scope)
+        else:
+            payload = await self.http.get("/api/v1/quota/balance")
+        return payload if isinstance(payload, dict) else {}
+
+    async def list_quota_requests(
+        self,
+        organization_id: Optional[str] = None,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """List quota requests submitted by the current user."""
+
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        params.update(self._quota_scope_params(organization_id))
+        payload = await self.http.get("/api/v1/quota/requests", params=params)
+        return payload if isinstance(payload, dict) else {}
+
+    async def request_quota(
+        self,
+        amount_usd: str,
+        *,
+        reason: str,
+        organization_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Request additional USD quota without losing nano-USD precision."""
+
+        payload = await self.http.post(
+            "/api/v1/quota/requests",
+            json={"amount_usd": str(amount_usd), "reason": reason},
+            params=self._quota_scope_params(organization_id) or None,
+            max_retries=1,
+        )
+        return payload if isinstance(payload, dict) else {}
 
     async def list_training_runs(self, *, limit: int = 25, offset: int = 0) -> Dict[str, Any]:
         """List training runs with pagination."""

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -27,6 +27,8 @@ later, which lets several server-side operations overlap::
 from __future__ import annotations
 
 import logging
+import math
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
 from ._payloads import (
@@ -71,6 +73,52 @@ class AsyncTrainingClient:
         self.tokenizer_path = tokenizer_path
         self.debug_info = debug_info
         self._tokenizer: Any = None
+
+    @property
+    def training_run_id(self) -> str:
+        """Canonical identifier for this Training Run; model_id is retained."""
+
+        return self.model_id
+
+    async def log_metrics(
+        self,
+        metrics: Mapping[str, float],
+        *,
+        step: int,
+        occurred_at: datetime | None = None,
+        labels: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist application-side scalar metrics in Weaver."""
+
+        if step < 0:
+            raise ValueError("step must be non-negative")
+        if len(metrics) > 1000:
+            raise ValueError("at most 1000 metrics may be logged per call")
+        at = occurred_at or datetime.now(timezone.utc)
+        if at.tzinfo is None:
+            at = at.replace(tzinfo=timezone.utc)
+        points = []
+        for name, raw_value in metrics.items():
+            metric_name = str(name).strip()
+            if not metric_name:
+                raise ValueError("metric names must not be empty")
+            value = float(raw_value)
+            if not math.isfinite(value):
+                raise ValueError(f"metric {metric_name!r} must be finite")
+            points.append(
+                {
+                    "model_id": self.model_id,
+                    "name": metric_name,
+                    "value": value,
+                    "step": step,
+                    "occurred_at": at.isoformat(),
+                    "labels": dict(labels or {}),
+                }
+            )
+        if points:
+            await self._service.http.post(
+                f"/api/v1/sessions/{self.session_id}/metrics", json={"metrics": points}
+            )
 
     def _next_seq(self) -> int:
         return self._service.next_operation_seq(self.model_id)

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -315,6 +315,11 @@ def projects_group():
     """Discover projects available to the current user."""
 
 
+@cli.group("scope")
+def scope_group():
+    """Resolve organization and project references."""
+
+
 def _run_list_organizations(
     output_format: str, base_url: Optional[str], api_key: Optional[str]
 ) -> None:
@@ -335,19 +340,45 @@ def _run_list_organizations(
 
 def _run_list_projects(
     org_id: Optional[str],
+    org_reference: Optional[str],
     output_format: str,
     base_url: Optional[str],
     api_key: Optional[str],
 ) -> None:
+    if org_id and org_reference:
+        raise click.UsageError("Use either --organization-id or --organization, not both")
     client = ServiceClient(base_url=base_url, api_key=api_key, organization_id=org_id)
     try:
         client.connect(ensure_session=False)
-        items = scope_selection_rows(client.list_projects(org_id))
+        resolved_org_id = org_id
+        if org_reference:
+            scope = client.resolve_scope(org_reference, None)
+            organization = scope.get("organization")
+            if not isinstance(organization, dict) or not organization.get("id"):
+                raise ValueError("Scope response missing organization id")
+            resolved_org_id = str(organization["id"])
+        items = scope_selection_rows(client.list_projects(resolved_org_id))
         if output_format == "json":
             format_json_output(items)
         else:
             console.print(create_projects_table(items))
             console.print(f"\n{len(items)} projects")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+def _run_resolve_scope(
+    organization: Optional[str],
+    project: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> None:
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        format_json_output(client.resolve_scope(organization, project))
     except Exception as e:
         handle_error(e)
     finally:
@@ -399,6 +430,12 @@ def organizations_list_cmd(
     help="Organization ID; defaults to the first available organization",
 )
 @click.option(
+    "--organization",
+    "org_reference",
+    envvar="WEAVER_ORGANIZATION",
+    help="Organization UUID, globally unique slug, or display name",
+)
+@click.option(
     "--format",
     "-f",
     "output_format",
@@ -409,11 +446,15 @@ def organizations_list_cmd(
 @click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
 @click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
 def list_projects_cmd(
-    org_id: Optional[str], output_format: str, base_url: Optional[str], api_key: Optional[str]
+    org_id: Optional[str],
+    org_reference: Optional[str],
+    output_format: str,
+    base_url: Optional[str],
+    api_key: Optional[str],
 ):
     """List projects in an organization."""
 
-    _run_list_projects(org_id, output_format, base_url, api_key)
+    _run_list_projects(org_id, org_reference, output_format, base_url, api_key)
 
 
 @projects_group.command("list")
@@ -423,6 +464,12 @@ def list_projects_cmd(
     "org_id",
     envvar="WEAVER_ORGANIZATION_ID",
     help="Organization ID; defaults to the user's default organization",
+)
+@click.option(
+    "--organization",
+    "org_reference",
+    envvar="WEAVER_ORGANIZATION",
+    help="Organization UUID, globally unique slug, or display name",
 )
 @click.option(
     "--format",
@@ -435,11 +482,39 @@ def list_projects_cmd(
 @click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
 @click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
 def projects_list_cmd(
-    org_id: Optional[str], output_format: str, base_url: Optional[str], api_key: Optional[str]
+    org_id: Optional[str],
+    org_reference: Optional[str],
+    output_format: str,
+    base_url: Optional[str],
+    api_key: Optional[str],
 ) -> None:
     """List projects in an organization."""
 
-    _run_list_projects(org_id, output_format, base_url, api_key)
+    _run_list_projects(org_id, org_reference, output_format, base_url, api_key)
+
+
+@scope_group.command("resolve")
+@click.option(
+    "--organization",
+    envvar="WEAVER_ORGANIZATION",
+    help="Organization UUID, globally unique slug, or display name",
+)
+@click.option(
+    "--project",
+    envvar="WEAVER_PROJECT",
+    help="Project UUID, organization-local slug, or display name",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def resolve_scope_cmd(
+    organization: Optional[str],
+    project: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> None:
+    """Resolve references to canonical organization and project IDs."""
+
+    _run_resolve_scope(organization, project, base_url, api_key)
 
 
 @list.command("training-runs")

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -146,6 +146,40 @@ def create_models_table(items: List[Dict[str, Any]]) -> Table:
     return table
 
 
+def create_organizations_table(items: List[Dict[str, Any]]) -> Table:
+    """Create a copy-friendly organization table."""
+
+    table = Table(title="Organizations", box=box.ROUNDED)
+    table.add_column("Organization ID", style="cyan", no_wrap=True)
+    table.add_column("Name", style="green")
+    table.add_column("Slug", style="blue")
+    for item in items:
+        table.add_row(
+            str(item.get("id", "")),
+            str(item.get("name", "")),
+            str(item.get("slug", "")),
+        )
+    return table
+
+
+def create_projects_table(items: List[Dict[str, Any]]) -> Table:
+    """Create a copy-friendly project table."""
+
+    table = Table(title="Projects", box=box.ROUNDED)
+    table.add_column("Project ID", style="cyan", no_wrap=True)
+    table.add_column("Name", style="green")
+    table.add_column("Slug", style="blue")
+    table.add_column("Default", justify="center")
+    for item in items:
+        table.add_row(
+            str(item.get("id", "")),
+            str(item.get("name", "")),
+            str(item.get("slug", "")),
+            "yes" if item.get("is_default") else "",
+        )
+    return table
+
+
 def display_training_run_detail(data: Dict[str, Any]) -> None:
     """Display detailed training run information."""
     console.print("\n[bold cyan]Training Run Details[/bold cyan]\n")
@@ -243,6 +277,73 @@ def show():
 @cli.group()
 def checkpoint():
     """Manage checkpoints."""
+
+
+@list.command("organizations")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def list_organizations_cmd(output_format: str, base_url: Optional[str], api_key: Optional[str]):
+    """List organizations available to the current user."""
+
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        items = client.list_organizations()
+        if output_format == "json":
+            format_json_output(items)
+        else:
+            console.print(create_organizations_table(items))
+            console.print(f"\n{len(items)} organizations")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+@list.command("projects")
+@click.option(
+    "--organization-id",
+    "--org-id",
+    "org_id",
+    envvar="WEAVER_ORGANIZATION_ID",
+    help="Organization ID; defaults to the first available organization",
+)
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def list_projects_cmd(
+    org_id: Optional[str], output_format: str, base_url: Optional[str], api_key: Optional[str]
+):
+    """List projects in an organization."""
+
+    client = ServiceClient(base_url=base_url, api_key=api_key, organization_id=org_id)
+    try:
+        client.connect(ensure_session=False)
+        items = client.list_projects(org_id)
+        if output_format == "json":
+            format_json_output(items)
+        else:
+            console.print(create_projects_table(items))
+            console.print(f"\n{len(items)} projects")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
 
 
 @list.command("training-runs")

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -427,7 +427,7 @@ def organizations_list_cmd(
     "--org-id",
     "org_id",
     envvar="WEAVER_ORGANIZATION_ID",
-    help="Organization ID; defaults to the first available organization",
+    help="Organization ID; defaults to the user's stable default organization",
 )
 @click.option(
     "--organization",

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -88,9 +88,24 @@ def format_training_mode(
 def handle_error(e: Exception) -> None:
     """Handle and display errors gracefully."""
     if isinstance(e, WeaverAPIError):
-        console.print(f"[red]API Error ({e.status_code}):[/red] {e.message}")
+        if e.status_code == 402:
+            console.print(f"[red]Quota exceeded:[/red] {e.message}")
+            if e.required_usd is not None or e.available_usd is not None:
+                required = f"${e.required_usd}" if e.required_usd is not None else "unknown"
+                available = f"${e.available_usd}" if e.available_usd is not None else "unknown"
+                console.print(f"Required: {required}; available: {available}")
+        elif e.status_code == 429:
+            console.print(f"[red]Rate limited:[/red] {e.message}")
+            if e.retry_after:
+                console.print(f"Retry after: {e.retry_after} seconds")
+        elif e.status_code == 503:
+            console.print(f"[red]Service temporarily unavailable:[/red] {e.message}")
+        else:
+            console.print(f"[red]API Error ({e.status_code}):[/red] {e.message}")
         if e.status_code == 401:
             console.print("[yellow]Tip:[/yellow] Check your API key configuration")
+        if e.request_id:
+            console.print(f"Request ID: {e.request_id}")
     else:
         console.print(f"[red]Error:[/red] {str(e)}")
     sys.exit(1)
@@ -152,12 +167,12 @@ def create_organizations_table(items: List[Dict[str, Any]]) -> Table:
     table = Table(title="Organizations", box=box.ROUNDED)
     table.add_column("Organization ID", style="cyan", no_wrap=True)
     table.add_column("Name", style="green")
-    table.add_column("Slug", style="blue")
+    table.add_column("Role", style="blue")
     for item in items:
         table.add_row(
             str(item.get("id", "")),
             str(item.get("name", "")),
-            str(item.get("slug", "")),
+            str(item.get("role") or item.get("current_user_role", "")),
         )
     return table
 
@@ -168,16 +183,27 @@ def create_projects_table(items: List[Dict[str, Any]]) -> Table:
     table = Table(title="Projects", box=box.ROUNDED)
     table.add_column("Project ID", style="cyan", no_wrap=True)
     table.add_column("Name", style="green")
-    table.add_column("Slug", style="blue")
-    table.add_column("Default", justify="center")
+    table.add_column("Role", style="blue")
     for item in items:
         table.add_row(
             str(item.get("id", "")),
             str(item.get("name", "")),
-            str(item.get("slug", "")),
-            "yes" if item.get("is_default") else "",
+            str(item.get("role") or item.get("current_user_role", "")),
         )
     return table
+
+
+def scope_selection_rows(items: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Return the stable, public fields needed to select an org/project."""
+
+    return [
+        {
+            "id": str(item.get("id", "")),
+            "name": str(item.get("name", "")),
+            "role": str(item.get("role") or item.get("current_user_role", "")),
+        }
+        for item in items
+    ]
 
 
 def display_training_run_detail(data: Dict[str, Any]) -> None:
@@ -279,6 +305,55 @@ def checkpoint():
     """Manage checkpoints."""
 
 
+@cli.group("organizations")
+def organizations_group():
+    """Discover organizations available to the current user."""
+
+
+@cli.group("projects")
+def projects_group():
+    """Discover projects available to the current user."""
+
+
+def _run_list_organizations(
+    output_format: str, base_url: Optional[str], api_key: Optional[str]
+) -> None:
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        items = scope_selection_rows(client.list_organizations())
+        if output_format == "json":
+            format_json_output(items)
+        else:
+            console.print(create_organizations_table(items))
+            console.print(f"\n{len(items)} organizations")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+def _run_list_projects(
+    org_id: Optional[str],
+    output_format: str,
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> None:
+    client = ServiceClient(base_url=base_url, api_key=api_key, organization_id=org_id)
+    try:
+        client.connect(ensure_session=False)
+        items = scope_selection_rows(client.list_projects(org_id))
+        if output_format == "json":
+            format_json_output(items)
+        else:
+            console.print(create_projects_table(items))
+            console.print(f"\n{len(items)} projects")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
 @list.command("organizations")
 @click.option(
     "--format",
@@ -293,19 +368,26 @@ def checkpoint():
 def list_organizations_cmd(output_format: str, base_url: Optional[str], api_key: Optional[str]):
     """List organizations available to the current user."""
 
-    client = ServiceClient(base_url=base_url, api_key=api_key)
-    try:
-        client.connect(ensure_session=False)
-        items = client.list_organizations()
-        if output_format == "json":
-            format_json_output(items)
-        else:
-            console.print(create_organizations_table(items))
-            console.print(f"\n{len(items)} organizations")
-    except Exception as e:
-        handle_error(e)
-    finally:
-        client.close()
+    _run_list_organizations(output_format, base_url, api_key)
+
+
+@organizations_group.command("list")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def organizations_list_cmd(
+    output_format: str, base_url: Optional[str], api_key: Optional[str]
+) -> None:
+    """List organizations available to the current user."""
+
+    _run_list_organizations(output_format, base_url, api_key)
 
 
 @list.command("projects")
@@ -331,19 +413,33 @@ def list_projects_cmd(
 ):
     """List projects in an organization."""
 
-    client = ServiceClient(base_url=base_url, api_key=api_key, organization_id=org_id)
-    try:
-        client.connect(ensure_session=False)
-        items = client.list_projects(org_id)
-        if output_format == "json":
-            format_json_output(items)
-        else:
-            console.print(create_projects_table(items))
-            console.print(f"\n{len(items)} projects")
-    except Exception as e:
-        handle_error(e)
-    finally:
-        client.close()
+    _run_list_projects(org_id, output_format, base_url, api_key)
+
+
+@projects_group.command("list")
+@click.option(
+    "--organization-id",
+    "--org-id",
+    "org_id",
+    envvar="WEAVER_ORGANIZATION_ID",
+    help="Organization ID; defaults to the user's default organization",
+)
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def projects_list_cmd(
+    org_id: Optional[str], output_format: str, base_url: Optional[str], api_key: Optional[str]
+) -> None:
+    """List projects in an organization."""
+
+    _run_list_projects(org_id, output_format, base_url, api_key)
 
 
 @list.command("training-runs")

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from . import __version__
 from ._http import APIClient
-from ._utils import extract_id, lookup_case_insensitive
+from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import OperationHandle, build_operation_handle
 from .types import LoraConfig
@@ -72,8 +72,8 @@ class ServiceClient:
         )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
-        self._organization_id = organization_id
-        self._project_id = project_id
+        self._organization_id = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        self._project_id = optional_scope_id(project_id, "WEAVER_PROJECT_ID")
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
@@ -100,16 +100,19 @@ class ServiceClient:
             raise RuntimeError("ServiceClient is not connected")
         return self._http
 
-    def connect(self) -> None:
-        if self._http is not None:
+    def connect(self, *, ensure_session: bool = True) -> None:
+        """Connect, optionally without creating or fetching a Session."""
+
+        if self._http is None:
+            self._http = APIClient(self._config)
+            atexit.register(self.close)
+        if not ensure_session or self._session is not None:
             return
-        self._http = APIClient(self._config)
         if self._session_id:
             self._fetch_session(self._session_id)
         else:
             self.ensure_session()
         self._start_heartbeat()
-        atexit.register(self.close)
 
     def terminate_model(
         self,
@@ -461,7 +464,6 @@ class ServiceClient:
     def list_supported_models(self) -> List[str]:
         """Return supported model names exposed by the server."""
         payload = self.http.get("/api/v1/supported-models")
-        print(f"payload: {payload}")
         if not isinstance(payload, dict):
             return []
         items = payload.get("items")
@@ -477,6 +479,32 @@ class ServiceClient:
                 if name:
                     names.append(str(name))
         return names
+
+    def list_organizations(self) -> List[Dict[str, Any]]:
+        """List organizations available to the authenticated user."""
+
+        payload = self.http.get("/api/v1/organizations")
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
+
+    def list_projects(self, organization_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List projects, falling back to the user's first organization."""
+
+        resolved = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        if resolved is None:
+            resolved = self._organization_id
+        if resolved is None:
+            organizations = self.list_organizations()
+            if not organizations:
+                return []
+            resolved = str(organizations[0].get("id", "")).strip() or None
+        if resolved is None:
+            return []
+        payload = self.http.get(f"/api/v1/organizations/{resolved}/projects")
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
 
     def get_supported_model_config(self, base_model: str) -> Optional[Dict[str, Any]]:
         """Get configuration for a specific supported model.

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -487,23 +487,65 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         response = self.http.post(path, json=payload, max_retries=1)
         return build_operation_handle(self.http, response)
 
+    def _supported_model_scope_params(self) -> Dict[str, str]:
+        organization_id = self._organization_id
+        if organization_id is None and isinstance(self._session, dict):
+            raw_id = lookup_case_insensitive(self._session, "organization_id")
+            organization_id = str(raw_id).strip() if raw_id else None
+        if organization_id is None and (
+            self._organization_reference or self._project_id or self._project_reference
+        ):
+            scope = self.resolve_scope(
+                self._organization_reference,
+                self._project_id or self._project_reference,
+            )
+            organization = scope.get("organization")
+            if isinstance(organization, dict):
+                raw_id = lookup_case_insensitive(organization, "id")
+                organization_id = str(raw_id).strip() if raw_id else None
+        return {"organization_id": organization_id} if organization_id else {}
+
+    def _list_supported_model_records(self) -> List[Dict[str, Any]]:
+        """Traverse the role-filtered supported-model collection."""
+
+        records: List[Dict[str, Any]] = []
+        limit = 100
+        offset = 0
+        scope = self._supported_model_scope_params()
+        while True:
+            params: Dict[str, Any] = {"limit": limit, "offset": offset, **scope}
+            payload = self.http.get("/api/v1/supported-models", params=params)
+            if not isinstance(payload, dict):
+                break
+            items = payload.get("items")
+            if not isinstance(items, list):
+                break
+            page = [item for item in items if isinstance(item, dict)]
+            records.extend(page)
+            pagination = payload.get("pagination")
+            if not isinstance(pagination, dict):
+                break
+            total = pagination.get("total_count")
+            try:
+                total_count = int(str(total))
+            except (TypeError, ValueError):
+                break
+            offset += len(items)
+            if not items or offset >= total_count:
+                break
+        return records
+
     def list_supported_models(self) -> List[str]:
-        """Return supported model names exposed by the server."""
-        payload = self.http.get("/api/v1/supported-models")
-        if not isinstance(payload, dict):
-            return []
-        items = payload.get("items")
+        """Return usable model names exposed to the authenticated role."""
+
         names: List[str] = []
-        if isinstance(items, list):
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                name = lookup_case_insensitive(item, "name")
-                status = lookup_case_insensitive(item, "status")
-                if status and str(status).lower() != "healthy":
-                    continue
-                if name:
-                    names.append(str(name))
+        for item in self._list_supported_model_records():
+            name = lookup_case_insensitive(item, "name")
+            status = lookup_case_insensitive(item, "status")
+            if status and str(status).lower() not in {"healthy", "available"}:
+                continue
+            if name:
+                names.append(str(name))
         return names
 
     def list_organizations(self) -> List[Dict[str, Any]]:
@@ -537,16 +579,17 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         return payload if isinstance(payload, dict) else {}
 
     def list_projects(self, organization_id: Optional[str] = None) -> List[Dict[str, Any]]:
-        """List projects, falling back to the user's first organization."""
+        """List projects, falling back to the user's stable default organization."""
 
         resolved = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
         if resolved is None:
             resolved = self._organization_id
         if resolved is None:
-            organizations = self.list_organizations()
-            if not organizations:
+            scope = self.resolve_scope()
+            organization = scope.get("organization")
+            if not isinstance(organization, dict):
                 return []
-            resolved = str(organizations[0].get("id", "")).strip() or None
+            resolved = str(organization.get("id", "")).strip() or None
         if resolved is None:
             return []
         payload = self.http.get(f"/api/v1/organizations/{resolved}/projects")
@@ -619,16 +662,7 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         Returns:
             Model configuration dict if found, None otherwise
         """
-        payload = self.http.get("/api/v1/supported-models")
-        if not isinstance(payload, dict):
-            return None
-        items = payload.get("items")
-        if not isinstance(items, list):
-            return None
-
-        for item in items:
-            if not isinstance(item, dict):
-                continue
+        for item in self._list_supported_model_records():
             name = lookup_case_insensitive(item, "name")
             if name and str(name) == base_model:
                 return item

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_LORA_CONFIG = LoraConfig(rank=32)
 
 
-class ServiceClient:
+class ServiceClient:  # pylint: disable=too-many-public-methods
     def __init__(
         self,
         *,
@@ -505,6 +505,62 @@ class ServiceClient:
         if not isinstance(payload, list):
             return []
         return [item for item in payload if isinstance(item, dict)]
+
+    def _quota_scope_params(self, organization_id: Optional[str]) -> Dict[str, str]:
+        resolved = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
+        if resolved is None:
+            resolved = self._organization_id
+        return {"org_id": resolved} if resolved is not None else {}
+
+    def get_quota_balance(self, organization_id: Optional[str] = None) -> Dict[str, Any]:
+        """Return the caller's nano-USD quota balance.
+
+        When no organization is supplied by parameter, constructor, or
+        environment, the unscoped endpoint lets the server select the user's
+        default organization.
+        """
+
+        scope = self._quota_scope_params(organization_id)
+        if scope:
+            payload = self.http.get("/api/v1/quota/balance", params=scope)
+        else:
+            payload = self.http.get("/api/v1/quota/balance")
+        return payload if isinstance(payload, dict) else {}
+
+    def list_quota_requests(
+        self,
+        organization_id: Optional[str] = None,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """List quota requests submitted by the current user."""
+
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        params.update(self._quota_scope_params(organization_id))
+        payload = self.http.get("/api/v1/quota/requests", params=params)
+        return payload if isinstance(payload, dict) else {}
+
+    def request_quota(
+        self,
+        amount_usd: str,
+        *,
+        reason: str,
+        organization_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Request additional USD quota for the current user.
+
+        ``amount_usd`` is sent as a decimal string; callers should not convert
+        it to ``float`` because the server accepts up to nano-USD precision.
+        """
+
+        payload = self.http.post(
+            "/api/v1/quota/requests",
+            json={"amount_usd": str(amount_usd), "reason": reason},
+            params=self._quota_scope_params(organization_id) or None,
+            max_retries=1,
+        )
+        return payload if isinstance(payload, dict) else {}
 
     def get_supported_model_config(self, base_model: str) -> Optional[Dict[str, Any]]:
         """Get configuration for a specific supported model.

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -51,6 +51,8 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         session_id: Optional[str] = None,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
+        organization: Optional[str] = None,
+        project: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
     ) -> None:
@@ -63,6 +65,8 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             session_id: Optional existing session ID to reuse
             organization_id: Optional Organization that owns a newly created session
             project_id: Optional Project used for a newly created session
+            organization: Optional organization UUID, globally unique slug, or display name
+            project: Optional project UUID, organization-local slug, or display name
             user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
         """
@@ -74,6 +78,8 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         self._session_id = session_id
         self._organization_id = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
         self._project_id = optional_scope_id(project_id, "WEAVER_PROJECT_ID")
+        self._organization_reference = optional_scope_id(organization, "WEAVER_ORGANIZATION")
+        self._project_reference = optional_scope_id(project, "WEAVER_PROJECT")
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
@@ -166,6 +172,26 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
     ) -> Dict[str, Any]:
         if self._session is not None:
             return self._session
+        organization_id = self._organization_id
+        project_id = self._project_id
+        if (organization_id is None and self._organization_reference) or (
+            project_id is None and self._project_reference
+        ):
+            resolved = self.resolve_scope(
+                organization_id or self._organization_reference,
+                project_id or self._project_reference,
+            )
+            if organization_id is None:
+                organization = resolved.get("organization")
+                if not isinstance(organization, dict):
+                    raise ValueError("Scope response missing organization")
+                organization_id = extract_id(organization)
+            if project_id is None:
+                project = resolved.get("project")
+                if not isinstance(project, dict):
+                    raise ValueError("Scope response missing project")
+                project_id = extract_id(project)
+
         payload = {
             "tags": list(tags or self._default_tags),
             "user_metadata": (
@@ -173,10 +199,10 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             ),
             "sdk_version": __version__,
         }
-        if self._organization_id:
-            payload["organization_id"] = self._organization_id
-        if self._project_id:
-            payload["project_id"] = self._project_id
+        if organization_id:
+            payload["organization_id"] = organization_id
+        if project_id:
+            payload["project_id"] = project_id
         session = self.http.post("/api/v1/sessions", json=payload)
         self._session_id = extract_id(session)
         self._session = session
@@ -487,6 +513,28 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         if not isinstance(payload, list):
             return []
         return [item for item in payload if isinstance(item, dict)]
+
+    def resolve_scope(
+        self,
+        organization: Optional[str] = None,
+        project: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Resolve UUID/slug/name references to canonical organization/project IDs.
+
+        Empty references are omitted, preserving the server's stable personal
+        organization and default-project fallback. Ambiguous display names are
+        surfaced as the server's 409 ``ambiguous_scope_reference`` error.
+        """
+
+        params: Dict[str, str] = {}
+        organization_ref = organization.strip() if organization else None
+        project_ref = project.strip() if project else None
+        if organization_ref:
+            params["organization"] = organization_ref
+        if project_ref:
+            params["project"] = project_ref
+        payload = self.http.get("/api/v1/scope/resolve", params=params)
+        return payload if isinstance(payload, dict) else {}
 
     def list_projects(self, organization_id: Optional[str] = None) -> List[Dict[str, Any]]:
         """List projects, falling back to the user's first organization."""

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -49,6 +49,8 @@ class ServiceClient:
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
     ) -> None:
         """Initialize ServiceClient.
@@ -58,6 +60,8 @@ class ServiceClient:
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            project_id: Optional Project used for a newly created session
+            user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
         """
         self._config = WeaverConfig.from_env(
@@ -66,6 +70,8 @@ class ServiceClient:
         )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._project_id = project_id
+        self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
 
         self._http: APIClient | None = None
@@ -156,9 +162,13 @@ class ServiceClient:
             return self._session
         payload = {
             "tags": list(tags or self._default_tags),
-            "user_metadata": user_metadata or {},
+            "user_metadata": (
+                user_metadata if user_metadata is not None else self._session_user_metadata
+            ),
             "sdk_version": __version__,
         }
+        if self._project_id:
+            payload["project_id"] = self._project_id
         session = self.http.post("/api/v1/sessions", json=payload)
         self._session_id = extract_id(session)
         self._session = session
@@ -303,6 +313,15 @@ class ServiceClient:
             tokenizer_path=tokenizer_path,
             debug_info=debug_info,
         )
+
+    def create_training_client(self, **kwargs: Any) -> "TrainingClient":
+        """Create a Training Run client.
+
+        This is the canonical product name for :meth:`create_model`. The old
+        method remains supported for compatibility with existing recipes.
+        """
+
+        return self.create_model(**kwargs)
 
     def _next_model_seq(self) -> int:
         value = self._model_seq_counter

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -49,6 +49,7 @@ class ServiceClient:
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
         heartbeat_interval: float = 30.0,
@@ -60,6 +61,7 @@ class ServiceClient:
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            organization_id: Optional Organization that owns a newly created session
             project_id: Optional Project used for a newly created session
             user_metadata: Metadata attached when a new session is created
             heartbeat_interval: Interval in seconds for session heartbeat
@@ -70,6 +72,7 @@ class ServiceClient:
         )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._organization_id = organization_id
         self._project_id = project_id
         self._session_user_metadata = dict(user_metadata or {})
         self._heartbeat_interval = heartbeat_interval
@@ -167,6 +170,8 @@ class ServiceClient:
             ),
             "sdk_version": __version__,
         }
+        if self._organization_id:
+            payload["organization_id"] = self._organization_id
         if self._project_id:
             payload["project_id"] = self._project_id
         session = self.http.post("/api/v1/sessions", json=payload)

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import logging
+import math
+from datetime import datetime, timezone
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
@@ -62,6 +64,60 @@ class TrainingClient:
         self.session_id = session_id
         self.tokenizer_path = tokenizer_path
         self.debug_info = debug_info
+
+    @property
+    def training_run_id(self) -> str:
+        """Canonical identifier for this Training Run.
+
+        ``model_id`` remains available as a compatibility alias.
+        """
+
+        return self.model_id
+
+    def log_metrics(
+        self,
+        metrics: Mapping[str, float],
+        *,
+        step: int,
+        occurred_at: datetime | None = None,
+        labels: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist user-defined scalar metrics in Weaver.
+
+        Trainer-produced loss and optimizer metrics are captured by the server
+        completion protocol automatically; this method is for application-side
+        metrics such as rewards and evaluation scores.
+        """
+
+        if step < 0:
+            raise ValueError("step must be non-negative")
+        if len(metrics) > 1000:
+            raise ValueError("at most 1000 metrics may be logged per call")
+        at = occurred_at or datetime.now(timezone.utc)
+        if at.tzinfo is None:
+            at = at.replace(tzinfo=timezone.utc)
+        points = []
+        for name, raw_value in metrics.items():
+            metric_name = str(name).strip()
+            if not metric_name:
+                raise ValueError("metric names must not be empty")
+            value = float(raw_value)
+            if not math.isfinite(value):
+                raise ValueError(f"metric {metric_name!r} must be finite")
+            points.append(
+                {
+                    "model_id": self.model_id,
+                    "name": metric_name,
+                    "value": value,
+                    "step": step,
+                    "occurred_at": at.isoformat(),
+                    "labels": dict(labels or {}),
+                }
+            )
+        if points:
+            self._service.http.post(
+                f"/api/v1/sessions/{self.session_id}/metrics", json={"metrics": points}
+            )
 
     def _next_seq(self) -> int:
         return self._service.next_operation_seq(self.model_id)


### PR DESCRIPTION
## Summary
- add organization/project discovery and CLI list commands
- allow sync and async clients to select organization/project by UUID, slug, or name
- expose a scope resolver command with structured 409 ambiguity errors
- propagate canonical organization and project IDs with safe server fallback when either reference is omitted or empty
- expose typed quota balance, request, and error protocol
- keep the trainer wire protocol unchanged

## Validation
- 224 SDK tests passed, including real local HTTP wire-contract tests
- black, isort, pylint, mypy, and repository pre-commit hooks passed

## Integration
Pairs with Weaver Server PR #462 for name resolution and the staged quota/control-plane changes. No SDK release is included.