### PR TITLE
Add Session experiment metadata to SDK clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,21 @@ if __name__ == "__main__":
     main()
 ```
 
-Select a scope by human-readable references, or discover and resolve available scopes:
+Give a new Session an optional experiment name and searchable string labels while
+selecting its scope by human-readable references:
 
 ```python
-with ServiceClient(organization="research", project="alignment") as client:
+with ServiceClient(
+    organization="research",
+    project="alignment",
+    name="PPO baseline",
+    labels={"dataset": "math", "environment": "staging"},
+) as client:
     client.ensure_session()
 ```
+
+Empty `name`/`labels` are omitted from the create request, preserving compatibility
+with legacy servers and existing call sites.
 
 ```bash
 weaver organizations list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.10.0"
+version = "1.11.0"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [

--- a/tests/test_console_protocol.py
+++ b/tests/test_console_protocol.py
@@ -30,6 +30,8 @@ def test_service_client_creates_session_in_project_with_constructor_metadata() -
     client = ServiceClient(
         organization_id="organization-1",
         project_id="project-1",
+        name="  PPO baseline  ",
+        labels={"environment": "staging", "owner": "research"},
         user_metadata={"recipe": "grpo"},
     )
     client._http = MagicMock()
@@ -41,7 +43,33 @@ def test_service_client_creates_session_in_project_with_constructor_metadata() -
     assert args[0] == "/api/v1/sessions"
     assert kwargs["json"]["organization_id"] == "organization-1"
     assert kwargs["json"]["project_id"] == "project-1"
+    assert kwargs["json"]["name"] == "PPO baseline"
+    assert kwargs["json"]["labels"] == {"environment": "staging", "owner": "research"}
     assert kwargs["json"]["user_metadata"] == {"recipe": "grpo"}
+
+
+def test_empty_experiment_metadata_is_omitted_for_legacy_servers() -> None:
+    client = ServiceClient(name="  ", labels={})
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-legacy"}
+
+    client.ensure_session()
+
+    payload = client._http.post.call_args.kwargs["json"]
+    assert "name" not in payload
+    assert "labels" not in payload
+
+
+def test_constructor_copies_experiment_labels() -> None:
+    labels = {"environment": "staging"}
+    client = ServiceClient(labels=labels)
+    labels["environment"] = "mutated"
+    client._http = MagicMock()
+    client._http.post.return_value = {"id": "session-copied-labels"}
+
+    client.ensure_session()
+
+    assert client._http.post.call_args.kwargs["json"]["labels"] == {"environment": "staging"}
 
 
 def test_empty_scope_ids_are_omitted_so_server_fallback_applies(monkeypatch) -> None:
@@ -304,6 +332,8 @@ def test_async_console_protocol_matches_sync_client() -> None:
         service = AsyncServiceClient(
             organization_id="organization-2",
             project_id="project-2",
+            name="Async SFT",
+            labels={"dataset": "math"},
             user_metadata={"recipe": "sft"},
         )
         service._http = MagicMock()
@@ -312,6 +342,8 @@ def test_async_console_protocol_matches_sync_client() -> None:
         _, session_kwargs = service._http.post.call_args
         assert session_kwargs["json"]["organization_id"] == "organization-2"
         assert session_kwargs["json"]["project_id"] == "project-2"
+        assert session_kwargs["json"]["name"] == "Async SFT"
+        assert session_kwargs["json"]["labels"] == {"dataset": "math"}
         assert session_kwargs["json"]["user_metadata"] == {"recipe": "sft"}
 
         training = AsyncTrainingClient(

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -73,7 +73,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from . import __version__
 from ._async_http import AsyncAPIClient
@@ -101,6 +101,8 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        name: Optional[str] = None,
+        labels: Optional[Mapping[str, str]] = None,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         organization: Optional[str] = None,
@@ -115,6 +117,8 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            name: Optional experiment display name for a newly created Session
+            labels: Optional searchable string metadata for a newly created Session
             organization_id: Optional Organization that owns a newly created session
             project_id: Optional Project used for a newly created session
             organization: Optional organization UUID, globally unique slug, or display name
@@ -125,6 +129,8 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         self._config = WeaverConfig.from_env(base_url=base_url, api_key=api_key)
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._session_name = name.strip() if name and name.strip() else None
+        self._session_labels = dict(labels or {})
         self._organization_id = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
         self._project_id = optional_scope_id(project_id, "WEAVER_PROJECT_ID")
         self._organization_reference = optional_scope_id(organization, "WEAVER_ORGANIZATION")
@@ -272,6 +278,8 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
     async def ensure_session(
         self,
         *,
+        name: Optional[str] = None,
+        labels: Optional[Mapping[str, str]] = None,
         tags: Optional[Sequence[str]] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
@@ -304,6 +312,12 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
             ),
             "sdk_version": __version__,
         }
+        session_name = self._session_name if name is None else name.strip()
+        session_labels = self._session_labels if labels is None else dict(labels)
+        if session_name:
+            payload["name"] = session_name
+        if session_labels:
+            payload["labels"] = dict(session_labels)
         if organization_id:
             payload["organization_id"] = organization_id
         if project_id:

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -20,7 +20,7 @@ import atexit
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from . import __version__
 from ._http import APIClient
@@ -49,6 +49,8 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         api_key: Optional[str] = None,
         default_tags: Optional[Sequence[str]] = None,
         session_id: Optional[str] = None,
+        name: Optional[str] = None,
+        labels: Optional[Mapping[str, str]] = None,
         organization_id: Optional[str] = None,
         project_id: Optional[str] = None,
         organization: Optional[str] = None,
@@ -63,6 +65,8 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             api_key: API key for authentication (starts with 'sk-'). Get from admin UI at /api-keys
             default_tags: Default tags for sessions
             session_id: Optional existing session ID to reuse
+            name: Optional experiment display name for a newly created Session
+            labels: Optional searchable string metadata for a newly created Session
             organization_id: Optional Organization that owns a newly created session
             project_id: Optional Project used for a newly created session
             organization: Optional organization UUID, globally unique slug, or display name
@@ -76,6 +80,8 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         )
         self._default_tags = list(default_tags or ["weaver-sdk"])
         self._session_id = session_id
+        self._session_name = name.strip() if name and name.strip() else None
+        self._session_labels = dict(labels or {})
         self._organization_id = optional_scope_id(organization_id, "WEAVER_ORGANIZATION_ID")
         self._project_id = optional_scope_id(project_id, "WEAVER_PROJECT_ID")
         self._organization_reference = optional_scope_id(organization, "WEAVER_ORGANIZATION")
@@ -167,6 +173,8 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
     def ensure_session(
         self,
         *,
+        name: Optional[str] = None,
+        labels: Optional[Mapping[str, str]] = None,
         tags: Optional[Sequence[str]] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
@@ -199,6 +207,12 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             ),
             "sdk_version": __version__,
         }
+        session_name = self._session_name if name is None else name.strip()
+        session_labels = self._session_labels if labels is None else dict(labels)
+        if session_name:
+            payload["name"] = session_name
+        if session_labels:
+            payload["labels"] = dict(session_labels)
         if organization_id:
             payload["organization_id"] = organization_id
         if project_id:


### PR DESCRIPTION
## What changed

- add optional `name` and searchable string `labels` to sync and async `ServiceClient` constructors
- allow the same metadata as `ensure_session` overrides
- copy caller mappings and omit empty metadata from the create request
- document the API and add sync/async compatibility coverage

## Why

Weaver experiments need durable human-readable metadata that can flow into
server-side Session search and multi-Session comparison. Keeping the fields on
Session creation avoids duplicating experiment metadata in TrainingClient,
SamplingClient, or trainer task protocols.

## Compatibility

The constructor remains keyword-only. Existing call sites and reused
`session_id` behavior are unchanged. Empty names and labels are omitted,
preserving the legacy request shape for older servers and the published SDK
contract.

## Validation

- `python -m pytest -q` — 245 passed
- `black --check weaver/ tests/`
- `isort --check-only weaver/ tests/`
- repository commit hooks: black, isort, license headers, pylint, and mypy all passed
- cross-repository real Gin/SQLite gate created and searched sync/async named and labeled Sessions with this branch

Companion server/Console PR: https://github.com/china-qijizhifeng/weaver-server/pull/523
