### PR TITLE
fix(training): keep token batching trainer-agnostic

### DIFF
--- a/examples/streaming_sft.py
+++ b/examples/streaming_sft.py
@@ -20,11 +20,14 @@ corpus is never preprocessed in memory. While the trainer runs that request, a
 worker thread prepares the next one.
 
 The batcher only estimates request size. The trainer performs the actual packing.
+It may submit more than ``global_batch_size`` source records to target that many
+packed sequences. To submit exactly ``global_batch_size`` source records instead,
+skip ``TokenBudgetBatcher`` and batch the source iterator by count.
 
 Example:
     python examples/streaming_sft.py data.jsonl \
         --base-model Qwen/Qwen3-8B --global-batch-size 128 \
-        --max-tokens-per-gpu 262144
+        --max-sequence-length 262144
 """
 
 from __future__ import annotations
@@ -172,7 +175,7 @@ async def run(args: argparse.Namespace) -> None:
                 iter_tokenized_examples(args.data, tokenizer),
                 length_fn=lambda example: len(example.input_tokens),
                 global_batch_size=args.global_batch_size,
-                max_tokens_per_gpu=args.max_tokens_per_gpu,
+                max_sequence_length=args.max_sequence_length,
             )
         )
         prepared = asyncio.create_task(asyncio.to_thread(prepare_next, batches))
@@ -217,7 +220,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base-model", default="Qwen/Qwen3-8B")
     parser.add_argument("--training-mode", choices=("full_ft", "lora"), default="full_ft")
     parser.add_argument("--global-batch-size", type=int, required=True)
-    parser.add_argument("--max-tokens-per-gpu", type=int, required=True)
+    parser.add_argument("--max-sequence-length", type=int, required=True)
     parser.add_argument("--steps", type=int, default=10)
     parser.add_argument("--submit-ahead", type=int, default=1)
     parser.add_argument("--learning-rate", type=float, default=1e-4)

--- a/examples/streaming_sft.py
+++ b/examples/streaming_sft.py
@@ -15,16 +15,16 @@
 """Streaming, packed SFT with bounded preparation and submission lookahead.
 
 Input is JSONL with ``{"prompt": "...", "response": "..."}`` records. The
-source is read and tokenized only until one full trainer request is known; the
+source is read and tokenized only until one token-budgeted request is known; the
 corpus is never preprocessed in memory. While the trainer runs that request, a
 worker thread prepares the next one.
 
-The batcher's DP size and token budget must match the registered trainer.
+The batcher only estimates request size. The trainer performs the actual packing.
 
 Example:
     python examples/streaming_sft.py data.jsonl \
         --base-model Qwen/Qwen3-8B --global-batch-size 128 \
-        --dp-size 8 --max-tokens-per-gpu 262144
+        --max-tokens-per-gpu 262144
 """
 
 from __future__ import annotations
@@ -75,7 +75,6 @@ class PreparedRequest:
     data: list[types.Datum]
     samples: int
     tokens: int
-    packed_microbatches: int
     prepare_seconds: float
 
 
@@ -119,9 +118,8 @@ def prepare_next(
         return None
     return PreparedRequest(
         data=[example.to_datum() for example in batch.items],
-        samples=batch.shape.samples,
-        tokens=batch.shape.tokens,
-        packed_microbatches=batch.shape.global_microbatches,
+        samples=len(batch.items),
+        tokens=batch.tokens,
         prepare_seconds=time.perf_counter() - started,
     )
 
@@ -171,12 +169,9 @@ async def run(args: argparse.Namespace) -> None:
         tokenizer = await asyncio.to_thread(training.get_tokenizer)
         batches = iter(
             TokenBudgetBatcher(
-                # Requires Megatron Bridge balanced packing: TRAINER_MICRO_BATCH_SIZE=0,
-                # matching DP/token budget, and router replay disabled.
                 iter_tokenized_examples(args.data, tokenizer),
                 length_fn=lambda example: len(example.input_tokens),
                 global_batch_size=args.global_batch_size,
-                dp_size=args.dp_size,
                 max_tokens_per_gpu=args.max_tokens_per_gpu,
             )
         )
@@ -193,8 +188,7 @@ async def run(args: argparse.Namespace) -> None:
                 await queue.submit(step, request.data, optimizer)
                 print(
                     f"submitted step={step} samples={request.samples} "
-                    f"tokens={request.tokens} packed={request.packed_microbatches} "
-                    f"prepare_s={request.prepare_seconds:.3f}",
+                    f"tokens={request.tokens} prepare_s={request.prepare_seconds:.3f}",
                     flush=True,
                 )
 
@@ -223,7 +217,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base-model", default="Qwen/Qwen3-8B")
     parser.add_argument("--training-mode", choices=("full_ft", "lora"), default="full_ft")
     parser.add_argument("--global-batch-size", type=int, required=True)
-    parser.add_argument("--dp-size", type=int, required=True)
     parser.add_argument("--max-tokens-per-gpu", type=int, required=True)
     parser.add_argument("--steps", type=int, default=10)
     parser.add_argument("--submit-ahead", type=int, default=1)

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -28,7 +28,7 @@ def test_token_budget_batcher_fills_without_crossing_target():
             range(13),
             length_fn=lambda _: 6,
             global_batch_size=4,
-            max_tokens_per_gpu=10,
+            max_sequence_length=10,
         )
     )
 
@@ -52,7 +52,7 @@ def test_token_budget_batcher_reads_only_through_next_boundary():
             source(),
             length_fn=lambda _: 6,
             global_batch_size=4,
-            max_tokens_per_gpu=10,
+            max_sequence_length=10,
         )
     )
 
@@ -79,7 +79,7 @@ def test_token_budget_batcher_emits_exact_target_without_lookahead():
                 source(),
                 length_fn=lambda _: 5,
                 global_batch_size=4,
-                max_tokens_per_gpu=10,
+                max_sequence_length=10,
             )
         )
     )
@@ -95,7 +95,7 @@ def test_token_budget_batcher_can_emit_incomplete_final_request():
             range(4),
             length_fn=lambda _: 6,
             global_batch_size=2,
-            max_tokens_per_gpu=10,
+            max_sequence_length=10,
             drop_last=False,
         )
     )
@@ -110,11 +110,11 @@ def test_token_budget_batcher_rejects_sample_over_budget():
             [11],
             length_fn=lambda value: value,
             global_batch_size=2,
-            max_tokens_per_gpu=10,
+            max_sequence_length=10,
         )
     )
 
-    with pytest.raises(ValueError, match="exceeds max_tokens_per_gpu"):
+    with pytest.raises(ValueError, match="exceeds max_sequence_length"):
         next(batches)
 
 

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -18,56 +18,23 @@ import asyncio
 
 import pytest
 
-import weaver.training_pipeline as training_pipeline
 from weaver import types
-from weaver.training_pipeline import (
-    SubmitAheadQueue,
-    TokenBudgetBatcher,
-    predict_packed_batch_shape,
-)
+from weaver.training_pipeline import SubmitAheadQueue, TokenBudgetBatcher
 
 
-def test_predict_packed_batch_shape_balances_dp_and_microbatches():
-    shape = predict_packed_batch_shape(
-        [8, 7, 6, 5],
-        dp_size=2,
-        max_tokens_per_gpu=10,
-    )
-
-    assert shape.samples == 4
-    assert shape.tokens == 26
-    assert shape.tokens_per_dp == (13, 13)
-    assert shape.samples_per_dp == (2, 2)
-    assert shape.microbatches_per_dp == 2
-    assert shape.max_microbatch_tokens == 8
-    assert shape.global_microbatches == 4
-    assert shape.dp_safe
-
-
-def test_predict_packed_batch_shape_detects_second_stage_overflow():
-    shape = predict_packed_batch_shape(
-        [6, 6, 6],
-        dp_size=1,
-        max_tokens_per_gpu=10,
-    )
-
-    assert shape.microbatches_per_dp == 2
-    assert shape.max_microbatch_tokens == 12
-
-
-def test_token_budget_batcher_carries_second_stage_overflow():
+def test_token_budget_batcher_fills_without_crossing_target():
     batches = list(
         TokenBudgetBatcher(
-            range(4),
+            range(13),
             length_fn=lambda _: 6,
-            global_batch_size=2,
-            dp_size=1,
+            global_batch_size=4,
             max_tokens_per_gpu=10,
         )
     )
 
-    assert [batch.items for batch in batches] == [(0, 1), (2, 3)]
-    assert all(batch.shape.max_microbatch_tokens <= 10 for batch in batches)
+    assert [batch.items for batch in batches] == [tuple(range(6)), tuple(range(6, 12))]
+    assert [batch.tokens for batch in batches] == [36, 36]
+    assert all(30 < batch.tokens <= 40 for batch in batches)
 
 
 def test_token_budget_batcher_reads_only_through_next_boundary():
@@ -83,62 +50,58 @@ def test_token_budget_batcher_reads_only_through_next_boundary():
     batches = iter(
         TokenBudgetBatcher(
             source(),
-            length_fn=lambda _: 5,
+            length_fn=lambda _: 6,
             global_batch_size=4,
-            dp_size=2,
             max_tokens_per_gpu=10,
         )
     )
 
     first = next(batches)
 
-    assert first.items == tuple(range(8))
-    assert first.shape.global_microbatches == 4
-    assert reads == list(range(9))
+    assert first.items == tuple(range(6))
+    assert first.tokens == 36
+    assert reads == list(range(7))
 
 
-def test_token_budget_batcher_carries_overflow_into_next_request():
-    batches = iter(
-        TokenBudgetBatcher(
-            range(17),
-            length_fn=lambda _: 5,
-            global_batch_size=4,
-            dp_size=2,
-            max_tokens_per_gpu=10,
-        )
-    )
+def test_token_budget_batcher_emits_exact_target_without_lookahead():
+    reads: list[int] = []
 
-    assert next(batches).items == tuple(range(8))
-    assert next(batches).items == tuple(range(8, 16))
-    with pytest.raises(StopIteration):
-        next(batches)
+    def source():
+        index = 0
+        while True:
+            reads.append(index)
+            yield index
+            index += 1
 
-
-def test_token_budget_batcher_avoids_repartitioning_every_short_sample(monkeypatch):
-    calls = 0
-    original = training_pipeline.predict_packed_batch_shape
-
-    def counted(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        return original(*args, **kwargs)
-
-    monkeypatch.setattr(training_pipeline, "predict_packed_batch_shape", counted)
     batch = next(
         iter(
             TokenBudgetBatcher(
-                range(1281),
-                length_fn=lambda _: 1,
-                global_batch_size=128,
-                dp_size=8,
+                source(),
+                length_fn=lambda _: 5,
+                global_batch_size=4,
                 max_tokens_per_gpu=10,
             )
         )
     )
 
-    assert batch.shape.global_microbatches == 128
-    assert batch.shape.tokens >= 1280 * 0.98
-    assert calls <= 2
+    assert batch.items == tuple(range(8))
+    assert batch.tokens == 40
+    assert reads == list(range(8))
+
+
+def test_token_budget_batcher_can_emit_incomplete_final_request():
+    batches = list(
+        TokenBudgetBatcher(
+            range(4),
+            length_fn=lambda _: 6,
+            global_batch_size=2,
+            max_tokens_per_gpu=10,
+            drop_last=False,
+        )
+    )
+
+    assert [batch.items for batch in batches] == [(0, 1, 2), (3,)]
+    assert [batch.tokens for batch in batches] == [18, 6]
 
 
 def test_token_budget_batcher_rejects_sample_over_budget():
@@ -147,7 +110,6 @@ def test_token_budget_batcher_rejects_sample_over_budget():
             [11],
             length_fn=lambda value: value,
             global_batch_size=2,
-            dp_size=1,
             max_tokens_per_gpu=10,
         )
     )

--- a/weaver/training_pipeline.py
+++ b/weaver/training_pipeline.py
@@ -60,7 +60,7 @@ class TokenBudgetBatch(Generic[T]):
 class TokenBudgetBatcher(Generic[T]):
     """Build best-effort token-budgeted requests with bounded memory.
 
-    The target request size is ``global_batch_size * max_tokens_per_gpu``.
+    The target request size is ``global_batch_size * max_sequence_length``.
     The trainer remains responsible for actual packing. An item that would
     cross the target starts the next request, so the corpus is never planned or
     tokenized up front.
@@ -68,8 +68,8 @@ class TokenBudgetBatcher(Generic[T]):
     Args:
         source: Stream of already rendered or tokenized source samples.
         length_fn: Returns the valid-token length of one sample.
-        global_batch_size: Multiplier for the target request token budget.
-        max_tokens_per_gpu: Token-budget unit and maximum source-sample length.
+        global_batch_size: Desired number of packed sequences per request.
+        max_sequence_length: Target packed length and maximum source-sample length.
         drop_last: Drop an incomplete final request when the source ends.
     """
 
@@ -79,21 +79,21 @@ class TokenBudgetBatcher(Generic[T]):
         *,
         length_fn: Callable[[T], int],
         global_batch_size: int,
-        max_tokens_per_gpu: int,
+        max_sequence_length: int,
         drop_last: bool = True,
     ) -> None:
         if global_batch_size <= 0:
             raise ValueError("global_batch_size must be positive")
-        if max_tokens_per_gpu <= 0:
-            raise ValueError("max_tokens_per_gpu must be positive")
+        if max_sequence_length <= 0:
+            raise ValueError("max_sequence_length must be positive")
         self._source = source
         self._length_fn = length_fn
         self._global_batch_size = global_batch_size
-        self._max_tokens_per_gpu = max_tokens_per_gpu
+        self._max_sequence_length = max_sequence_length
         self._drop_last = drop_last
 
     def __iter__(self) -> Iterator[TokenBudgetBatch[T]]:
-        target_tokens = self._global_batch_size * self._max_tokens_per_gpu
+        target_tokens = self._global_batch_size * self._max_sequence_length
         items: list[T] = []
         total_tokens = 0
 
@@ -101,10 +101,10 @@ class TokenBudgetBatcher(Generic[T]):
             length = int(self._length_fn(item))
             if length <= 0:
                 raise ValueError("sample token lengths must be positive")
-            if length > self._max_tokens_per_gpu:
+            if length > self._max_sequence_length:
                 raise ValueError(
-                    f"sample length {length} exceeds max_tokens_per_gpu="
-                    f"{self._max_tokens_per_gpu}"
+                    f"sample length {length} exceeds max_sequence_length="
+                    f"{self._max_sequence_length}"
                 )
 
             if items and total_tokens + length > target_tokens:

--- a/weaver/training_pipeline.py
+++ b/weaver/training_pipeline.py
@@ -17,8 +17,6 @@
 from __future__ import annotations
 
 import asyncio
-import heapq
-import math
 from collections import deque
 from dataclasses import dataclass
 from typing import (
@@ -39,8 +37,6 @@ if TYPE_CHECKING:
     from .types import AdamParams, Datum
 
 T = TypeVar("T")
-_MAX_BOUNDARY_PROBES = 32
-_MIN_SAFE_FILL_PERCENT = 98
 
 
 class _AsyncTrainingClient(Protocol):
@@ -54,175 +50,26 @@ class _AsyncTrainingClient(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
-class PackedBatchShape:
-    """Predicted shape after Weaver's balanced DP partition.
-
-    Attributes:
-        samples: Number of source samples in the request.
-        tokens: Total source tokens in the request.
-        microbatches_per_dp: Synchronized microbatch count on each DP rank.
-        samples_per_dp: Source-sample counts assigned to each DP rank.
-        tokens_per_dp: Token counts assigned to each DP rank.
-        max_microbatch_tokens: Largest predicted packed microbatch.
-    """
-
-    samples: int
-    tokens: int
-    microbatches_per_dp: int
-    samples_per_dp: tuple[int, ...]
-    tokens_per_dp: tuple[int, ...]
-    max_microbatch_tokens: int = 0
-
-    @property
-    def global_microbatches(self) -> int:
-        """Return the predicted global packed microbatch count."""
-
-        return self.microbatches_per_dp * len(self.tokens_per_dp)
-
-    @property
-    def dp_safe(self) -> bool:
-        """Return whether every DP rank has enough samples to form the shape."""
-
-        return bool(self.microbatches_per_dp) and self.microbatches_per_dp <= min(
-            self.samples_per_dp, default=0
-        )
-
-
-@dataclass(frozen=True, slots=True)
 class TokenBudgetBatch(Generic[T]):
-    """One source request selected from a streaming iterator."""
+    """One token-budgeted request selected from a streaming iterator."""
 
     items: tuple[T, ...]
-    shape: PackedBatchShape
-
-
-class _Partition:
-    __slots__ = ("items", "total")
-
-    def __init__(self) -> None:
-        self.items: list[tuple[int, int]] = []
-        self.total = 0
-
-    def add(self, index: int, value: int) -> None:
-        self.items.append((index, value))
-        self.total += value
-
-    def merge(self, other: "_Partition") -> None:
-        self.items.extend(other.items)
-        self.total += other.total
-
-    def __lt__(self, other: "_Partition") -> bool:
-        return (self.total, len(self.items), self.items) < (
-            other.total,
-            len(other.items),
-            other.items,
-        )
-
-
-class _PartitionState:
-    __slots__ = ("partitions", "width")
-
-    def __init__(self, items: Sequence[tuple[int, int]], width: int) -> None:
-        self.width = width
-        self.partitions = [_Partition() for _ in range(width)]
-        for partition, (index, value) in zip(self.partitions, items, strict=False):
-            partition.add(index, value)
-        self.partitions.sort(reverse=True)
-
-    @property
-    def spread(self) -> int:
-        return self.partitions[0].total - self.partitions[-1].total
-
-    def merge(self, other: "_PartitionState") -> None:
-        for index in range(self.width):
-            self.partitions[index].merge(other.partitions[self.width - 1 - index])
-        self.partitions.sort(reverse=True)
-
-    def __lt__(self, other: "_PartitionState") -> bool:
-        if self.spread != other.spread:
-            return self.spread > other.spread
-        return self.partitions[0] > other.partitions[0]
-
-
-def _balanced_partitions(lengths: Sequence[int], count: int) -> list[list[int]]:
-    """Match Weaver trainer's balanced DP partition for length-only planning."""
-
-    if len(lengths) < count:
-        return [list(range(rank, len(lengths), count)) for rank in range(count)]
-
-    states: list[_PartitionState] = []
-    for length, index in sorted((length, index) for index, length in enumerate(lengths)):
-        heapq.heappush(states, _PartitionState([(index, length)], count))
-    while len(states) > 1:
-        first = heapq.heappop(states)
-        second = heapq.heappop(states)
-        first.merge(second)
-        heapq.heappush(states, first)
-    return [sorted(index for index, _ in part.items) for part in states[0].partitions]
-
-
-def predict_packed_batch_shape(
-    lengths: Sequence[int], *, dp_size: int, max_tokens_per_gpu: int
-) -> PackedBatchShape:
-    """Predict the current balanced trainer's request shape from token lengths.
-
-    Args:
-        lengths: Valid-token length of each source sample.
-        dp_size: Data-parallel world size.
-        max_tokens_per_gpu: Trainer token budget for one packed microbatch.
-
-    Returns:
-        The predicted DP assignment and synchronized microbatch count.
-
-    Raises:
-        ValueError: If a size is invalid or a source sample exceeds the budget.
-    """
-
-    if dp_size <= 0:
-        raise ValueError("dp_size must be positive")
-    if max_tokens_per_gpu <= 0:
-        raise ValueError("max_tokens_per_gpu must be positive")
-    if any(length <= 0 for length in lengths):
-        raise ValueError("sample token lengths must be positive")
-    if lengths and max(lengths) > max_tokens_per_gpu:
-        raise ValueError(
-            f"sample length {max(lengths)} exceeds max_tokens_per_gpu=" f"{max_tokens_per_gpu}"
-        )
-    if not lengths:
-        return PackedBatchShape(0, 0, 0, (0,) * dp_size, (0,) * dp_size)
-
-    partitions = _balanced_partitions(lengths, dp_size)
-    tokens_per_dp = tuple(sum(lengths[index] for index in part) for part in partitions)
-    samples_per_dp = tuple(len(part) for part in partitions)
-    microbatches = max(math.ceil(tokens / max_tokens_per_gpu) for tokens in tokens_per_dp)
-    microbatch_tokens: list[int] = []
-    for part in partitions:
-        rank_lengths = [lengths[index] for index in part]
-        for microbatch in _balanced_partitions(rank_lengths, microbatches):
-            microbatch_tokens.append(sum(rank_lengths[index] for index in microbatch))
-    return PackedBatchShape(
-        samples=len(lengths),
-        tokens=sum(lengths),
-        microbatches_per_dp=microbatches,
-        samples_per_dp=samples_per_dp,
-        tokens_per_dp=tokens_per_dp,
-        max_microbatch_tokens=max(microbatch_tokens, default=0),
-    )
+    tokens: int
 
 
 class TokenBudgetBatcher(Generic[T]):
-    """Build full packed requests from a source stream with bounded memory.
+    """Build best-effort token-budgeted requests with bounded memory.
 
-    The batcher reads only until one DP-safe full request boundary is known.
-    Any item read past that boundary is carried into the next request; the
-    corpus is never planned or tokenized up front.
+    The target request size is ``global_batch_size * max_tokens_per_gpu``.
+    The trainer remains responsible for actual packing. An item that would
+    cross the target starts the next request, so the corpus is never planned or
+    tokenized up front.
 
     Args:
         source: Stream of already rendered or tokenized source samples.
         length_fn: Returns the valid-token length of one sample.
-        global_batch_size: Desired global number of packed microbatches.
-        dp_size: Data-parallel world size used by the registered model.
-        max_tokens_per_gpu: Trainer token budget for one packed microbatch.
+        global_batch_size: Multiplier for the target request token budget.
+        max_tokens_per_gpu: Token-budget unit and maximum source-sample length.
         drop_last: Drop an incomplete final request when the source ends.
     """
 
@@ -232,32 +79,23 @@ class TokenBudgetBatcher(Generic[T]):
         *,
         length_fn: Callable[[T], int],
         global_batch_size: int,
-        dp_size: int,
         max_tokens_per_gpu: int,
         drop_last: bool = True,
     ) -> None:
         if global_batch_size <= 0:
             raise ValueError("global_batch_size must be positive")
-        if dp_size <= 0 or global_batch_size % dp_size:
-            raise ValueError("global_batch_size must be divisible by dp_size")
         if max_tokens_per_gpu <= 0:
             raise ValueError("max_tokens_per_gpu must be positive")
         self._source = source
         self._length_fn = length_fn
         self._global_batch_size = global_batch_size
-        self._dp_size = dp_size
         self._max_tokens_per_gpu = max_tokens_per_gpu
         self._drop_last = drop_last
 
     def __iter__(self) -> Iterator[TokenBudgetBatch[T]]:
-        target = self._global_batch_size // self._dp_size
+        target_tokens = self._global_batch_size * self._max_tokens_per_gpu
         items: list[T] = []
-        lengths: list[int] = []
-        shape: PackedBatchShape | None = None
         total_tokens = 0
-        max_length = 0
-        probing_boundary = False
-        boundary_probes = 0
 
         for item in self._source:
             length = int(self._length_fn(item))
@@ -268,110 +106,21 @@ class TokenBudgetBatcher(Generic[T]):
                     f"sample length {length} exceeds max_tokens_per_gpu="
                     f"{self._max_tokens_per_gpu}"
                 )
+
+            if items and total_tokens + length > target_tokens:
+                yield TokenBudgetBatch(tuple(items), total_tokens)
+                items = []
+                total_tokens = 0
+
             items.append(item)
-            lengths.append(length)
             total_tokens += length
-            max_length = max(max_length, length)
+            if total_tokens == target_tokens:
+                yield TokenBudgetBatch(tuple(items), total_tokens)
+                items = []
+                total_tokens = 0
 
-            if not probing_boundary:
-                # Karmarkar-Karp's final partition spread is no larger than the
-                # longest sample. Until this bound crosses the per-DP capacity,
-                # the exact O(n log n) partition cannot overflow the target.
-                average_ceiling = math.ceil(total_tokens / self._dp_size)
-                partition_upper_bound = average_ceiling + max_length
-                if partition_upper_bound <= target * self._max_tokens_per_gpu:
-                    continue
-                probing_boundary = True
-                if len(items) > 1:
-                    previous = predict_packed_batch_shape(
-                        lengths[:-1],
-                        dp_size=self._dp_size,
-                        max_tokens_per_gpu=self._max_tokens_per_gpu,
-                    )
-                    if (
-                        previous.microbatches_per_dp == target
-                        and previous.dp_safe
-                        and previous.max_microbatch_tokens <= self._max_tokens_per_gpu
-                    ):
-                        global_capacity = self._global_batch_size * self._max_tokens_per_gpu
-                        if previous.tokens * 100 >= global_capacity * _MIN_SAFE_FILL_PERCENT:
-                            yield TokenBudgetBatch(tuple(items[:-1]), previous)
-                            items = [item]
-                            lengths = [length]
-                            shape = None
-                            total_tokens = length
-                            max_length = length
-                            probing_boundary = False
-                            boundary_probes = 0
-                            continue
-                        shape = previous
-
-            candidate = predict_packed_batch_shape(
-                lengths,
-                dp_size=self._dp_size,
-                max_tokens_per_gpu=self._max_tokens_per_gpu,
-            )
-            boundary_probes += 1
-            if candidate.microbatches_per_dp <= target:
-                if (
-                    candidate.microbatches_per_dp == target
-                    and candidate.dp_safe
-                    and candidate.max_microbatch_tokens <= self._max_tokens_per_gpu
-                ):
-                    shape = candidate
-                    if boundary_probes >= _MAX_BOUNDARY_PROBES:
-                        yield TokenBudgetBatch(tuple(items), shape)
-                        items = []
-                        lengths = []
-                        shape = None
-                        total_tokens = 0
-                        max_length = 0
-                        probing_boundary = False
-                        boundary_probes = 0
-                    continue
-                if shape is None:
-                    continue
-
-            overflow_item = items.pop()
-            overflow_length = lengths.pop()
-            if shape is None:
-                raise ValueError(
-                    "source stream crossed the packed batch boundary before a "
-                    "DP-safe full request was formed"
-                )
-            yield TokenBudgetBatch(tuple(items), shape)
-            items = [overflow_item]
-            lengths = [overflow_length]
-            shape = None
-            total_tokens = overflow_length
-            max_length = overflow_length
-            probing_boundary = False
-            boundary_probes = 0
-
-        final_shape = (
-            predict_packed_batch_shape(
-                lengths,
-                dp_size=self._dp_size,
-                max_tokens_per_gpu=self._max_tokens_per_gpu,
-            )
-            if items
-            else None
-        )
-        if (
-            items
-            and final_shape is not None
-            and final_shape.microbatches_per_dp == target
-            and final_shape.dp_safe
-            and final_shape.max_microbatch_tokens <= self._max_tokens_per_gpu
-        ):
-            yield TokenBudgetBatch(tuple(items), final_shape)
-        elif items and not self._drop_last:
-            assert final_shape is not None
-            if not final_shape.dp_safe:
-                raise ValueError("incomplete final request is not DP-safe")
-            if final_shape.max_microbatch_tokens > self._max_tokens_per_gpu:
-                raise ValueError("incomplete final request exceeds max_tokens_per_gpu")
-            yield TokenBudgetBatch(tuple(items), final_shape)
+        if items and not self._drop_last:
+            yield TokenBudgetBatch(tuple(items), total_tokens)
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary
- make `TokenBudgetBatcher` a best-effort streaming pre-look over `global_batch_size * max_tokens_per_gpu`
- remove DP topology, packed-shape prediction, and trainer partitioning logic from the SDK and example
- preserve overflow carry, bounded memory, optional final-batch dropping, and submit-ahead behavior

The trainer remains authoritative for actual packing and microbatch formation. This follows up on #97 and #99.

## Testing
- `python -m pytest -q` — 243 passed
- Black, isort, mypy, pylint, license, and diff checks passed
- replayed six requests from the SFT sample-length manifest at 99.59%–99.99% of the `128 × 262144` token target
