### PR TITLE
feat(sampling): guard generation control to full fine-tuning and pair it with a context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,34 @@ For a complete runnable script, see [`examples/pig_latin.py`](examples/pig_latin
 For large packed datasets, [`examples/streaming_sft.py`](examples/streaming_sft.py)
 shows bounded token-budget batching and submit-ahead.
 
+### Generation control (full fine-tuning only)
+
+RL weight swaps need in-flight generation to stop before new weights land. A sampling
+client can freeze its inference engine and resume it afterwards:
+
+```python
+with sampling_client.paused(mode=PauseMode.ABORT):
+    path = training_client.save_weights_for_sampler(name="step-42")
+    new_client = service.create_sampling_client(
+        model_path=path, model_id=model_id, base_model=base_model
+    )
+```
+
+Two things to know before using it:
+
+- **The pause is engine-wide, not per sampling session.** It freezes *every* in-flight
+  request on the engine serving that model, including ones issued through an earlier
+  sampling session. That is what makes it usable for weight swaps — the requests you
+  want to abort belong to the previous weight epoch — but it also means a pause is never
+  scoped to "just my requests".
+- **Full fine-tuning only.** Those models get a dedicated engine. LoRA adapters are
+  served from one shared engine per base model, where a pause would abort generation for
+  unrelated tenants, so the call is rejected before any request is sent.
+
+Prefer `paused()` over calling `pause_generation()` / `continue_generation()` directly:
+a pause that never reaches its resume leaves the engine frozen indefinitely, and there is
+no server-side auto-resume. The async client mirrors this as `async with`.
+
 ## Ecosystem
 
 [NexRL](https://github.com/nex-agi/NexRL) is the companion RL training framework.

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,6 +58,25 @@ weaver scope resolve --organization research --project alignment
 
 完整可运行脚本参见 [`examples/pig_latin.py`](examples/pig_latin.py)。
 
+### 生成控制（仅限全量微调）
+
+RL 权重热切需要在新权重落地前让正在进行的生成停下来。采样客户端可以冻结所在的推理引擎，并在之后恢复：
+
+```python
+with sampling_client.paused(mode=PauseMode.ABORT):
+    path = training_client.save_weights_for_sampler(name="step-42")
+    new_client = service.create_sampling_client(
+        model_path=path, model_id=model_id, base_model=base_model
+    )
+```
+
+使用前需要知道两件事：
+
+- **暂停作用于整个引擎，而不是单个 sampling session。** 它会冻结该模型引擎上*所有*正在进行的请求，包括通过更早的 sampling session 发出的那些。这正是它能用于权重热切的原因——需要打断的恰恰是上一个权重版本的请求——但也意味着暂停永远不可能只影响"我自己的请求"。
+- **仅支持全量微调。** 全量微调模型拥有独占的引擎；LoRA adapter 则共用同一个底模引擎，在那里暂停会打断其他租户的生成，因此这类调用在发出请求之前就会被拒绝。
+
+建议使用 `paused()` 而不是直接调用 `pause_generation()` / `continue_generation()`：暂停之后如果没有走到恢复那一步，引擎会一直冻结下去，服务端不会自动恢复。异步客户端对应的形式是 `async with`。
+
 ## 生态
 
 [NexRL](https://github.com/nex-agi/NexRL) 是配套的 RL 训练框架。在其 **training-service** 模式下，NexRL 负责编排完整的 RL 流程（rollout、轨迹收集、策略更新），Weaver 提供底层的训练和推理服务。

--- a/tests/test_sampling_control.py
+++ b/tests/test_sampling_control.py
@@ -29,26 +29,36 @@ from weaver.async_sampling_client import AsyncSamplingClient
 from weaver.sampling_client import SamplingClient
 from weaver.types import ModelInput, PauseMode
 
+MODEL_ID = "11111111-2222-3333-4444-555555555555"
 
-def _make_sync_client() -> tuple[SamplingClient, MagicMock]:
+
+def _make_sync_client(
+    training_mode: str = "full_ft", **overrides
+) -> tuple[SamplingClient, MagicMock]:
     mock_service = MagicMock()
-    client = SamplingClient(
-        service=mock_service,
-        sampling_session_id="sess-001",
-        base_model="Qwen/Qwen3-8B",
-    )
-    return client, mock_service
+    mock_service.get_model.return_value = {"training_mode": training_mode}
+    kwargs = {
+        "sampling_session_id": "sess-001",
+        "base_model": "Qwen/Qwen3-8B",
+        "model_id": MODEL_ID,
+    }
+    kwargs.update(overrides)
+    return SamplingClient(service=mock_service, **kwargs), mock_service
 
 
-def _make_async_client() -> tuple[AsyncSamplingClient, MagicMock]:
+def _make_async_client(
+    training_mode: str = "full_ft", **overrides
+) -> tuple[AsyncSamplingClient, MagicMock]:
     mock_service = MagicMock()
     mock_service.http.post = AsyncMock()
-    client = AsyncSamplingClient(
-        service=mock_service,
-        sampling_session_id="sess-001",
-        base_model="Qwen/Qwen3-8B",
-    )
-    return client, mock_service
+    mock_service.get_model = AsyncMock(return_value={"training_mode": training_mode})
+    kwargs = {
+        "sampling_session_id": "sess-001",
+        "base_model": "Qwen/Qwen3-8B",
+        "model_id": MODEL_ID,
+    }
+    kwargs.update(overrides)
+    return AsyncSamplingClient(service=mock_service, **kwargs), mock_service
 
 
 # --------------------------------------------------------------------------- #
@@ -115,6 +125,79 @@ class TestSyncClient:
         )
         assert result == {"ok": True}
 
+    def test_paused_resumes_on_success(self):
+        client, mock_service = _make_sync_client()
+        mock_service.http.post.return_value = {"ok": True}
+
+        with client.paused() as result:
+            assert result == {"ok": True}
+
+        paths = [call[0][0] for call in mock_service.http.post.call_args_list]
+        assert paths == [
+            "/api/v1/sampling-sessions/sess-001/pause-generation",
+            "/api/v1/sampling-sessions/sess-001/continue-generation",
+        ]
+
+    def test_paused_resumes_on_exception(self):
+        """The whole point of the context manager: a frozen engine must not
+        survive an error inside the block, since nothing auto-resumes it."""
+        client, mock_service = _make_sync_client()
+        mock_service.http.post.return_value = {}
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with client.paused():
+                raise RuntimeError("boom")
+
+        paths = [call[0][0] for call in mock_service.http.post.call_args_list]
+        assert paths[-1] == "/api/v1/sampling-sessions/sess-001/continue-generation"
+
+
+class TestSyncFullFTRestriction:
+    def test_lora_model_is_rejected_without_calling_the_server(self):
+        client, mock_service = _make_sync_client(training_mode="lora")
+
+        with pytest.raises(ValueError, match="full fine-tuning"):
+            client.pause_generation()
+
+        mock_service.http.post.assert_not_called()
+
+    def test_continue_is_restricted_too(self):
+        client, mock_service = _make_sync_client(training_mode="lora")
+        with pytest.raises(ValueError, match="full fine-tuning"):
+            client.continue_generation()
+        mock_service.http.post.assert_not_called()
+
+    def test_unbound_client_is_rejected_without_any_request(self):
+        """No model_id and a model_path that carries none: a bare base-model or
+        shared-pool client, which has no engine of its own to freeze."""
+        client, mock_service = _make_sync_client(model_id=None, model_path=None)
+
+        with pytest.raises(ValueError, match="not bound"):
+            client.pause_generation()
+
+        mock_service.get_model.assert_not_called()
+        mock_service.http.post.assert_not_called()
+
+    def test_model_id_recovered_from_checkpoint_path(self):
+        client, mock_service = _make_sync_client(
+            model_id=None, model_path=f"weaver://{MODEL_ID}/checkpoints/step-42"
+        )
+        mock_service.http.post.return_value = {}
+
+        client.pause_generation()
+
+        mock_service.get_model.assert_called_once_with(MODEL_ID)
+
+    def test_eligibility_is_checked_once(self):
+        client, mock_service = _make_sync_client()
+        mock_service.http.post.return_value = {}
+
+        client.pause_generation()
+        client.continue_generation()
+        client.pause_generation()
+
+        assert mock_service.get_model.call_count == 1
+
 
 # --------------------------------------------------------------------------- #
 # Async client                                                                 #
@@ -148,6 +231,91 @@ class TestAsyncClient:
         client, _ = _make_async_client()
         with pytest.raises(ValueError):
             asyncio.run(client.pause_generation(mode="freeze"))
+
+    def test_paused_resumes_on_success(self):
+        client, mock_service = _make_async_client()
+        mock_service.http.post.return_value = {"ok": True}
+
+        async def _run():
+            async with client.paused() as result:
+                assert result == {"ok": True}
+
+        asyncio.run(_run())
+
+        paths = [call[0][0] for call in mock_service.http.post.call_args_list]
+        assert paths == [
+            "/api/v1/sampling-sessions/sess-001/pause-generation",
+            "/api/v1/sampling-sessions/sess-001/continue-generation",
+        ]
+
+    def test_paused_resumes_on_exception(self):
+        client, mock_service = _make_async_client()
+        mock_service.http.post.return_value = {}
+
+        async def _run():
+            async with client.paused():
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            asyncio.run(_run())
+
+        paths = [call[0][0] for call in mock_service.http.post.call_args_list]
+        assert paths[-1] == "/api/v1/sampling-sessions/sess-001/continue-generation"
+
+
+class TestAsyncFullFTRestriction:
+    def test_lora_model_is_rejected_without_calling_the_server(self):
+        client, mock_service = _make_async_client(training_mode="lora")
+
+        with pytest.raises(ValueError, match="full fine-tuning"):
+            asyncio.run(client.pause_generation())
+
+        mock_service.http.post.assert_not_called()
+
+    def test_unbound_client_is_rejected_without_any_request(self):
+        client, mock_service = _make_async_client(model_id=None, model_path=None)
+
+        with pytest.raises(ValueError, match="not bound"):
+            asyncio.run(client.continue_generation())
+
+        mock_service.get_model.assert_not_called()
+        mock_service.http.post.assert_not_called()
+
+    def test_eligibility_is_checked_once(self):
+        client, mock_service = _make_async_client()
+        mock_service.http.post.return_value = {}
+
+        async def _run():
+            await client.pause_generation()
+            await client.continue_generation()
+
+        asyncio.run(_run())
+        assert mock_service.get_model.call_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers                                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestWeaverPathParsing:
+    def test_extracts_model_id(self):
+        assert (
+            _su.parse_model_id_from_weaver_path(f"weaver://{MODEL_ID}/checkpoints/step-42")
+            == MODEL_ID
+        )
+
+    def test_returns_none_for_non_weaver_paths(self):
+        assert _su.parse_model_id_from_weaver_path(None) is None
+        assert _su.parse_model_id_from_weaver_path("") is None
+        assert _su.parse_model_id_from_weaver_path("/gpfs/checkpoints/step-42") is None
+        assert _su.parse_model_id_from_weaver_path("weaver://") is None
+
+    def test_ensure_full_ft_rejects_other_modes(self):
+        _su.ensure_full_ft_for_control("full_ft", model_id=MODEL_ID)
+        for mode in ("lora", "", None):
+            with pytest.raises(ValueError, match="full fine-tuning"):
+                _su.ensure_full_ft_for_control(mode, model_id=MODEL_ID)
 
 
 # --------------------------------------------------------------------------- #

--- a/weaver/_sampling_utils.py
+++ b/weaver/_sampling_utils.py
@@ -21,6 +21,7 @@ owning one. The callable is invoked lazily, only when decoding is required.
 
 from __future__ import annotations
 
+import re
 from typing import Any, Callable, Dict, List, Optional
 
 from transformers.tokenization_utils import PreTrainedTokenizer
@@ -70,6 +71,61 @@ def build_logprobs_body(
 def build_pause_generation_body(mode: "PauseMode | str") -> Dict[str, Any]:
     """Build the ``pause-generation`` request body, validating ``mode``."""
     return {"mode": coerce_pause_mode(mode)}
+
+
+# Checkpoint URIs are ``weaver://<model-id>/checkpoints/<name>``; the model id is
+# always the first path segment.
+_WEAVER_PATH_RE = re.compile(r"^weaver://([^/]+)/")
+
+
+def parse_model_id_from_weaver_path(path: str | None) -> str | None:
+    """Extract the model id embedded in a ``weaver://`` checkpoint URI.
+
+    A sampling client created from a checkpoint path alone still knows which
+    model produced it, because the id is part of the URI. This recovers it so
+    the client does not have to round-trip to the server for something it is
+    already holding.
+
+    Note this is *not* :func:`weaver._http.extract_model_id_from_path`, which
+    parses API request paths (``/api/v1/models/<id>/...``), not storage URIs.
+
+    Args:
+        path: A ``weaver://<model-id>/checkpoints/<name>`` URI, or None.
+
+    Returns:
+        The model id, or None if ``path`` is absent or not a weaver URI.
+    """
+    if not path:
+        return None
+    match = _WEAVER_PATH_RE.match(path.strip())
+    if not match:
+        return None
+    return match.group(1) or None
+
+
+def ensure_full_ft_for_control(training_mode: Any, *, model_id: str | None) -> None:
+    """Reject generation control against anything but a full fine-tuning model.
+
+    pause/continue act on a whole inference engine, not on one sampling session.
+    Full fine-tuning is the only mode with a dedicated engine; LoRA adapters are
+    served from a single shared engine per base model, so pausing there would
+    abort in-flight generation for every other tenant on that base model.
+
+    Args:
+        training_mode: The model's ``training_mode`` as reported by the server.
+        model_id: The model the control primitive resolved to, for the message.
+
+    Raises:
+        ValueError: If ``training_mode`` is not ``"full_ft"``.
+    """
+    if training_mode == "full_ft":
+        return
+    raise ValueError(
+        f"generation control is only supported for full fine-tuning models, but model "
+        f"{model_id} has training_mode={training_mode!r}. LoRA adapters share one "
+        f"inference engine per base model, so pausing it would abort in-flight "
+        f"generation for unrelated tenants."
+    )
 
 
 def sanitize_tokens(value: Any) -> List[int]:

--- a/weaver/async_sampling_client.py
+++ b/weaver/async_sampling_client.py
@@ -16,7 +16,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, overload
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, overload
 
 from transformers.tokenization_utils import PreTrainedTokenizer
 
@@ -48,6 +49,9 @@ class AsyncSamplingClient:
         self.model_id = model_id
         self.tokenizer_path = tokenizer_path
         self._tokenizer: PreTrainedTokenizer | None = None
+        # Cached result of the generation-control eligibility check; a model's
+        # training mode is fixed at creation, so one confirmation is enough.
+        self._is_full_ft = False
 
     @overload
     async def sample(
@@ -140,12 +144,35 @@ class AsyncSamplingClient:
             "return_rollout_token_expert_data": result.get("return_rollout_token_expert_data"),
         }
 
-    async def pause_generation(self, *, mode: PauseMode | str = PauseMode.ABORT) -> Dict[str, Any]:
-        """Pause in-flight generation on the engines behind this session.
+    async def _ensure_full_ft(self) -> None:
+        """Verify this client's model is full fine-tuning, once, then cache it.
 
-        See :meth:`weaver.sampling_client.SamplingClient.pause_generation`.
+        See :meth:`weaver.sampling_client.SamplingClient._ensure_full_ft`.
+        """
+        if self._is_full_ft:
+            return
+        model_id = self.model_id or _su.parse_model_id_from_weaver_path(self.model_path)
+        if not model_id:
+            raise ValueError(
+                "generation control requires a full fine-tuning model, but this sampling "
+                "client is not bound to one (no model_id, and model_path carries no model "
+                "id). Sampling against a bare base model or a LoRA adapter on the shared "
+                "base-model pool cannot be paused: the engine is shared with other tenants."
+            )
+        model = await self._service.get_model(model_id)
+        _su.ensure_full_ft_for_control(
+            lookup_case_insensitive(model, "training_mode"), model_id=model_id
+        )
+        self._is_full_ft = True
+
+    async def pause_generation(self, *, mode: PauseMode | str = PauseMode.ABORT) -> Dict[str, Any]:
+        """Pause in-flight generation on the engine serving this model.
+
+        Engine-wide and full-fine-tuning-only. See
+        :meth:`weaver.sampling_client.SamplingClient.pause_generation`.
         """
         body = _su.build_pause_generation_body(mode)
+        await self._ensure_full_ft()
         return await self._service.http.post(
             f"/api/v1/sampling-sessions/{self.sampling_session_id}/pause-generation",
             json=body,
@@ -156,9 +183,28 @@ class AsyncSamplingClient:
 
         See :meth:`weaver.sampling_client.SamplingClient.continue_generation`.
         """
+        await self._ensure_full_ft()
         return await self._service.http.post(
             f"/api/v1/sampling-sessions/{self.sampling_session_id}/continue-generation",
         )
+
+    @asynccontextmanager
+    async def paused(
+        self, *, mode: PauseMode | str = PauseMode.ABORT
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Pause the engine for the duration of the block, then always resume.
+
+        See :meth:`weaver.sampling_client.SamplingClient.paused`.
+
+        Example:
+            >>> async with sampling_client.paused(mode=PauseMode.ABORT):
+            ...     path = await training_client.save_weights_for_sampler(name="step-42")
+        """
+        result = await self.pause_generation(mode=mode)
+        try:
+            yield result
+        finally:
+            await self.continue_generation()
 
     async def _ensure_tokenizer_source(self) -> None:
         """Make sure a tokenizer path or base_model is known (may fetch the session)."""

--- a/weaver/sampling_client.py
+++ b/weaver/sampling_client.py
@@ -16,7 +16,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List
 
 from transformers.tokenization_utils import PreTrainedTokenizer
 
@@ -45,6 +46,9 @@ class SamplingClient:
         self.model_id = model_id
         self.tokenizer_path = tokenizer_path
         self._tokenizer: PreTrainedTokenizer | None = None
+        # Cached result of the generation-control eligibility check; a model's
+        # training mode is fixed at creation, so one confirmation is enough.
+        self._is_full_ft = False
 
     def sample(
         self,
@@ -119,8 +123,34 @@ class SamplingClient:
             "return_rollout_token_expert_data": result.get("return_rollout_token_expert_data"),
         }
 
+    def _ensure_full_ft(self) -> None:
+        """Verify this client's model is full fine-tuning, once, then cache it.
+
+        The check runs client-side so an unsupported call fails immediately and
+        with a precise message, instead of travelling to the server to be
+        rejected there. The server enforces the same rule independently.
+
+        Raises:
+            ValueError: If the client is not bound to a full fine-tuning model.
+        """
+        if self._is_full_ft:
+            return
+        model_id = self.model_id or _su.parse_model_id_from_weaver_path(self.model_path)
+        if not model_id:
+            raise ValueError(
+                "generation control requires a full fine-tuning model, but this sampling "
+                "client is not bound to one (no model_id, and model_path carries no model "
+                "id). Sampling against a bare base model or a LoRA adapter on the shared "
+                "base-model pool cannot be paused: the engine is shared with other tenants."
+            )
+        model = self._service.get_model(model_id)
+        _su.ensure_full_ft_for_control(
+            lookup_case_insensitive(model, "training_mode"), model_id=model_id
+        )
+        self._is_full_ft = True
+
     def pause_generation(self, *, mode: PauseMode | str = PauseMode.ABORT) -> Dict[str, Any]:
-        """Pause in-flight generation on the engines behind this session.
+        """Pause in-flight generation on the engine serving this model.
 
         This is a stateless control primitive: it freezes the engine until
         :meth:`continue_generation` is called. With the default
@@ -130,17 +160,35 @@ class SamplingClient:
         partial/async rollout weight swaps
         (abort -> drain -> sync_weights -> continue).
 
+        **Scope**: the pause is engine-wide, not scoped to this sampling
+        session. It freezes every in-flight request on the engine, including
+        ones issued through an earlier sampling session of the same model —
+        which is exactly what a weight swap needs, since the requests to abort
+        are the ones belonging to the previous weight epoch.
+
+        **Full fine-tuning only.** A LoRA adapter is served from one shared
+        engine per base model, so pausing it would abort generation for
+        unrelated tenants; such a call is rejected before any request is sent.
+
+        Prefer :meth:`paused` over calling this directly: a pause that is never
+        continued leaves the engine frozen indefinitely, and there is no
+        server-side auto-resume.
+
         Args:
             mode: How to treat in-flight requests. One of :class:`PauseMode`
                 (``abort`` / ``retract`` / ``in_place``) or its string value.
 
         Returns:
-            The server response payload.
+            An acknowledgement, ``{"ok": True, "status": "paused", "mode": ...}``.
+            The engine's own reply is deliberately not surfaced: it carries
+            replica topology and backend details, and varies by engine version.
 
         Raises:
-            ValueError: If ``mode`` is not a supported pause mode.
+            ValueError: If ``mode`` is not a supported pause mode, or this
+                client is not bound to a full fine-tuning model.
         """
         body = _su.build_pause_generation_body(mode)
+        self._ensure_full_ft()
         return self._service.http.post(
             f"/api/v1/sampling-sessions/{self.sampling_session_id}/pause-generation",
             json=body,
@@ -149,12 +197,53 @@ class SamplingClient:
     def continue_generation(self) -> Dict[str, Any]:
         """Resume generation after a :meth:`pause_generation` call.
 
+        Engine-wide and full-fine-tuning-only, like :meth:`pause_generation`.
+
         Returns:
-            The server response payload.
+            An acknowledgement, ``{"ok": True, "status": "running"}``.
+
+        Raises:
+            ValueError: If this client is not bound to a full fine-tuning model.
         """
+        self._ensure_full_ft()
         return self._service.http.post(
             f"/api/v1/sampling-sessions/{self.sampling_session_id}/continue-generation",
         )
+
+    @contextmanager
+    def paused(self, *, mode: PauseMode | str = PauseMode.ABORT) -> Iterator[Dict[str, Any]]:
+        """Pause the engine for the duration of the block, then always resume.
+
+        A bare :meth:`pause_generation` that never reaches its
+        :meth:`continue_generation` — because the block raised, or the caller
+        returned early — leaves the engine frozen for good: nothing on the
+        server auto-resumes it. This pairs the two so the resume survives errors.
+
+        The resume is issued on *this* client even if the block replaced it with
+        a new one, which is correct: both address the same engine.
+
+        Example:
+            >>> with sampling_client.paused(mode=PauseMode.ABORT):
+            ...     path = training_client.save_weights_for_sampler(name="step-42")
+            ...     new_client = service.create_sampling_client(
+            ...         model_path=path, model_id=model_id, base_model=base_model
+            ...     )
+
+        Args:
+            mode: How to treat in-flight requests, as in :meth:`pause_generation`.
+
+        Yields:
+            The :meth:`pause_generation` response.
+
+        Raises:
+            ValueError: If ``mode`` is invalid or this client is not bound to a
+                full fine-tuning model. Nothing is paused in that case.
+        """
+        result = self.pause_generation(mode=mode)
+        try:
+            yield result
+        finally:
+            self.continue_generation()
 
     def _normalize_sample_result(self, payload: Any) -> Any:
         return _su.normalize_sample_result(payload, self._ensure_tokenizer)

--- a/weaver/types/sampling_control.py
+++ b/weaver/types/sampling_control.py
@@ -33,6 +33,17 @@ class PauseMode(str, Enum):
       resume from scratch after ``continue``.
     - ``IN_PLACE``: freeze requests where they are and resume them in place
       after ``continue``.
+
+    Scope, in all modes: the pause acts on a whole **inference engine**, not on
+    one sampling session. Every in-flight request on that engine is affected,
+    including requests issued through an earlier sampling session of the same
+    model — which is what makes it usable for weight swaps, where the requests
+    to abort belong to the previous weight epoch.
+
+    That scope is also why generation control is restricted to **full
+    fine-tuning** models: those get a dedicated engine, while LoRA adapters are
+    served from one shared engine per base model, where a pause would abort
+    generation for unrelated tenants.
     """
 
     ABORT = "abort"


### PR DESCRIPTION
## Problem

`pause_generation` / `continue_generation` act on a whole **inference engine**, not on one sampling session: the engine freezes and aborts every in-flight request on it.

Only full fine-tuning models get a dedicated engine. LoRA adapters are served from one shared engine per base model — so pausing there aborts generation for unrelated tenants. Nothing stopped that.

Separately, the RL weight-swap loop is `pause(old) → sync_weights → continue(new)`, which spans two sampling clients. That made the pairing awkward to write, and easy to leave unpaired: a pause that never reaches its continue leaves the engine frozen for good, since nothing auto-resumes it.

## Changes

**Full-fine-tuning guard, client-side.** Rejected before any request goes out, so the failure is immediate and explains itself. The server enforces the same rule independently.

Eligibility resolves from what the client already holds: `model_id`, or the id embedded in a `weaver://<model-id>/checkpoints/<name>` path. A client with neither is not bound to a model at all (bare base-model sampling, or a LoRA adapter on the shared pool) and is refused without a round trip. The `get_model` lookup is cached — a model's training mode is fixed at creation.

**`paused()` / `async with paused()`.** Puts pause and continue in one scope that survives errors. It also settles the weight-swap awkwardness: the resume is issued on the *same* client that paused, even though the block replaces that client with one for the new weights — both address the same engine, so that is correct.

```python
with sampling_client.paused(mode=PauseMode.ABORT):
    path = training_client.save_weights_for_sampler(name="step-42")
    new_client = service.create_sampling_client(
        model_path=path, model_id=model_id, base_model=base_model
    )
```

**Docs.** `PauseMode`, both client docstrings, and a README / README_zh section spell out the engine-wide scope: the pause reaches requests issued through earlier sampling sessions of the same model, which is exactly what a weight swap needs, since the requests to abort belong to the previous weight epoch.

URLs and public signatures are unchanged. Shared logic lives in `_sampling_utils.py`; sync and async clients are updated in lockstep per the async-compatibility rule.

Needs the matching server-side guard to be deployed for the restriction to hold against direct API callers; the client-side check is for a fast, self-explaining failure, not for enforcement.

## Tests

New coverage on both stacks: LoRA rejected with no HTTP issued, unbound client rejected without even a `get_model`, model id recovered from a checkpoint path, eligibility checked exactly once, and `paused()` resuming both on success and when the block raises. Plus unit tests for the two new shared helpers.

`pytest tests/` — 260 passed. black / isort clean.