### PR TITLE
feat(checkpoints): export and download HuggingFace weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,37 @@ Prefer `paused()` over calling `pause_generation()` / `continue_generation()` di
 a pause that never reaches its resume leaves the engine frozen indefinitely, and there is
 no server-side auto-resume. The async client mirrors this as `async with`.
 
+### HuggingFace weights export
+
+Checkpoints are stored in the trainer's native distributed format. `export_weights()`
+converts one into a HuggingFace directory — a full model for full fine-tuning, a PEFT
+adapter for LoRA — and `download_weights()` fetches it to disk:
+
+```python
+artifact = training_client.export_weights()          # save current weights + export
+artifact = training_client.export_weights(checkpoint=ckpt)  # export an existing checkpoint
+
+service.download_weights(artifact, "./hf-weights")
+```
+
+```bash
+weaver checkpoint export weaver://<model>/checkpoints/step-42
+weaver checkpoint download weaver://<model>/checkpoints/step-42 -o ./hf-weights
+```
+
+Three things to know:
+
+- **Export is explicit, download never triggers one.** Converting a full model is minutes
+  of compute and tens of GB of storage, so `download_weights()` fails with a "run
+  export_weights first" error rather than silently starting a conversion.
+- **Artifacts expire independently of their checkpoint** (7 days by default, `ttl_seconds`
+  to change). Deleting the source checkpoint does not delete the artifact, and vice versa.
+- **LoRA exports an adapter by default.** Pass `merge_adapter=True` to fold it into the
+  base model and get a full HF model instead; it is rejected for full fine-tuning models.
+
+Downloads run in parallel, resume interrupted files, refresh expired URLs, and verify each
+file's sha256 before publishing it. Both methods have `Async*` twins.
+
 ## Ecosystem
 
 [NexRL](https://github.com/nex-agi/NexRL) is the companion RL training framework.

--- a/README_zh.md
+++ b/README_zh.md
@@ -77,6 +77,30 @@ with sampling_client.paused(mode=PauseMode.ABORT):
 
 建议使用 `paused()` 而不是直接调用 `pause_generation()` / `continue_generation()`：暂停之后如果没有走到恢复那一步，引擎会一直冻结下去，服务端不会自动恢复。异步客户端对应的形式是 `async with`。
 
+### HuggingFace 权重导出
+
+checkpoint 以 trainer 原生的分布式格式保存。`export_weights()` 会把它转换成 HuggingFace 目录——全量微调得到完整模型，LoRA 得到 PEFT adapter——再用 `download_weights()` 下载到本地：
+
+```python
+artifact = training_client.export_weights()          # 保存当前权重并导出
+artifact = training_client.export_weights(checkpoint=ckpt)  # 导出已有的 checkpoint
+
+service.download_weights(artifact, "./hf-weights")
+```
+
+```bash
+weaver checkpoint export weaver://<model>/checkpoints/step-42
+weaver checkpoint download weaver://<model>/checkpoints/step-42 -o ./hf-weights
+```
+
+需要知道三件事：
+
+- **导出必须显式发起，下载不会隐式触发导出。** 转换一个完整模型是分钟级的算力开销和几十 GB 的存储，因此在没有已完成产物时 `download_weights()` 会直接报错提示先执行 `export_weights`，而不是悄悄启动一次转换。
+- **产物的过期时间独立于源 checkpoint**（默认 7 天，可用 `ttl_seconds` 调整）。删除源 checkpoint 不会连带删除产物，反之亦然。
+- **LoRA 默认导出 adapter。** 传 `merge_adapter=True` 可以把它合并进底模、导出完整的 HF 模型；全量微调模型传这个参数会被拒绝。
+
+下载是并行的，支持断点续传、过期 URL 自动刷新，并在落盘前校验每个文件的 sha256。两个方法都有对应的 `Async*` 版本。
+
 ## 生态
 
 [NexRL](https://github.com/nex-agi/NexRL) 是配套的 RL 训练框架。在其 **training-service** 模式下，NexRL 负责编排完整的 RL 流程（rollout、轨迹收集、策略更新），Weaver 提供底层的训练和推理服务。

--- a/tests/test_hf_download.py
+++ b/tests/test_hf_download.py
@@ -1,0 +1,681 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for HF weights download: descriptor plumbing and download_weights."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from weaver import _async_http, _http, async_service_client, service_client
+from weaver._artifacts import (
+    descriptor_files,
+    parse_download_target,
+    select_artifact_payload,
+)
+from weaver._http import DownloadURLExpiredError, stream_download_to_file
+from weaver.async_service_client import AsyncServiceClient
+from weaver.cli import cli
+from weaver.service_client import ServiceClient
+from weaver.types.weights_artifact import WeightsArtifact
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+FILES: Dict[str, bytes] = {
+    "adapter_config.json": b'{"r": 32}',
+    "adapter_model.safetensors": b"\x00" * 4096 + b"tensor-bytes",
+    "sub/tokenizer.json": b'{"vocab": {}}',
+}
+
+# Single-file artifact: lets resume/retry tests assert on one request stream
+# without interleaving from the other shards.
+SINGLE_FILE: Dict[str, bytes] = {"shard.bin": bytes(range(256)) * 8}
+
+CHECKPOINT_URI = "weaver://mdl-123/checkpoints/step-5"
+ADAPTER_ARTIFACT = {
+    "id": "art-1",
+    "checkpoint_id": "ckpt-1",
+    "model_id": "mdl-123",
+    "kind": "hf_adapter",
+    "status": "completed",
+    "uri": f"{CHECKPOINT_URI}/artifacts/hf_adapter",
+}
+MODEL_ARTIFACT = {
+    "id": "art-2",
+    "checkpoint_id": "ckpt-1",
+    "model_id": "mdl-123",
+    "kind": "hf_model",
+    "status": "completed",
+    "uri": f"{CHECKPOINT_URI}/artifacts/hf_model",
+}
+
+
+def _sha(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _descriptor(
+    files: Dict[str, bytes],
+    *,
+    sig: str = "ok",
+    sha_overrides: Dict[str, str] | None = None,
+) -> Dict[str, Any]:
+    overrides = sha_overrides or {}
+    return {
+        "artifact_id": "art-1",
+        "kind": "hf_adapter",
+        "total_bytes": sum(len(content) for content in files.values()),
+        "files": [
+            {
+                "name": name,
+                "size": len(content),
+                "sha256": overrides.get(name, _sha(content)),
+                "url": f"https://tos.example.com/files/{name}?sig={sig}",
+                "url_expires_at": "2026-08-12T00:15:00Z",
+            }
+            for name, content in files.items()
+        ],
+    }
+
+
+def _presigned_handler(files: Dict[str, bytes], calls: list | None = None):
+    """MockTransport handler emulating presigned object-storage URLs."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if calls is not None:
+            calls.append(request)
+        assert "X-WEAVER-API-KEY" not in request.headers  # bare client only
+        if request.url.params.get("sig") == "expired":
+            return httpx.Response(403, text="<Error>expired</Error>")
+        name = request.url.path[len("/files/") :]
+        content = files[name]
+        range_header = request.headers.get("Range")
+        if range_header:
+            start = int(range_header.split("=", 1)[1].split("-", 1)[0])
+            if start >= len(content):
+                return httpx.Response(416)
+            return httpx.Response(206, content=content[start:])
+        return httpx.Response(200, content=content)
+
+    return handler
+
+
+def _make_sync_client(api_get_side_effect) -> ServiceClient:
+    client = ServiceClient(base_url="https://test.example.com", api_key="sk-test")
+    client._http = MagicMock()
+    client._http.get.side_effect = api_get_side_effect
+    return client
+
+
+def _make_async_client(api_get_side_effect) -> AsyncServiceClient:
+    client = AsyncServiceClient(base_url="https://test.example.com", api_key="sk-test")
+    client._http = MagicMock()
+    client._http.get = AsyncMock(side_effect=api_get_side_effect)
+    return client
+
+
+def _api_routes(descriptor: Dict[str, Any], artifacts: list | None = None):
+    """Standard API GET routing for resolution + descriptor fetch."""
+
+    routes = {
+        "/api/v1/models/mdl-123/checkpoints": {
+            "items": [{"id": "ckpt-1", "path": CHECKPOINT_URI, "type": "weight"}]
+        },
+        "/api/v1/checkpoints/ckpt-1/artifacts": {
+            "items": artifacts if artifacts is not None else [dict(ADAPTER_ARTIFACT)]
+        },
+        "/api/v1/artifacts/art-1/download": descriptor,
+        "/api/v1/artifacts/art-2/download": descriptor,
+    }
+
+    def side_effect(path, **_kwargs):
+        return routes[path]
+
+    return side_effect
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParseDownloadTarget:
+    def test_artifact_uri(self):
+        parsed = parse_download_target(f"{CHECKPOINT_URI}/artifacts/hf_adapter")
+        assert parsed.model_id == "mdl-123"
+        assert parsed.checkpoint_path == CHECKPOINT_URI
+        assert parsed.kind == "hf_adapter"
+        assert parsed.artifact_id is None
+
+    def test_checkpoint_uri(self):
+        parsed = parse_download_target(CHECKPOINT_URI)
+        assert parsed.checkpoint_path == CHECKPOINT_URI
+        assert parsed.kind is None
+
+    def test_raw_artifact_id(self):
+        parsed = parse_download_target("art-1")
+        assert parsed.artifact_id == "art-1"
+
+    def test_unknown_kind_rejected(self):
+        with pytest.raises(ValueError, match="Unknown artifact kind"):
+            parse_download_target(f"{CHECKPOINT_URI}/artifacts/onnx")
+
+    def test_malformed_weaver_uri_rejected(self):
+        with pytest.raises(ValueError, match="Unrecognized weaver URI"):
+            parse_download_target("weaver://mdl-123/weights/step-5")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            parse_download_target("  ")
+
+
+class TestSelectArtifactPayload:
+    def test_single_completed(self):
+        selected = select_artifact_payload([dict(ADAPTER_ARTIFACT)], None, context="t")
+        assert selected["id"] == "art-1"
+
+    def test_kind_filter(self):
+        items = [dict(ADAPTER_ARTIFACT), dict(MODEL_ARTIFACT)]
+        selected = select_artifact_payload(items, "hf_model", context="t")
+        assert selected["id"] == "art-2"
+
+    def test_no_completed_tells_user_to_export(self):
+        items = [{**ADAPTER_ARTIFACT, "status": "pending"}]
+        with pytest.raises(RuntimeError, match="export_weights"):
+            select_artifact_payload(items, None, context="t")
+
+    def test_ambiguous_kinds_require_kind(self):
+        items = [dict(ADAPTER_ARTIFACT), dict(MODEL_ARTIFACT)]
+        with pytest.raises(ValueError, match="disambiguate"):
+            select_artifact_payload(items, None, context="t")
+
+
+class TestDescriptorFiles:
+    def test_normalizes_entries(self):
+        files = descriptor_files(_descriptor(FILES))
+        assert [entry.name for entry in files] == list(FILES)
+        assert files[0].size == len(FILES["adapter_config.json"])
+        assert files[0].sha256 == _sha(FILES["adapter_config.json"])
+        assert files[0].url.startswith("https://tos.example.com/")
+
+    def test_rejects_traversal_names(self):
+        bad = _descriptor({"../evil.bin": b"x"})
+        with pytest.raises(ValueError, match="unsafe file name"):
+            descriptor_files(bad)
+
+    def test_rejects_absolute_names(self):
+        bad = _descriptor({"/etc/passwd": b"x"})
+        with pytest.raises(ValueError, match="unsafe file name"):
+            descriptor_files(bad)
+
+    def test_rejects_empty_descriptor(self):
+        with pytest.raises(ValueError, match="no files"):
+            descriptor_files({"files": []})
+
+
+# ---------------------------------------------------------------------------
+# stream_download_to_file (sync + async low-level helper)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamDownload:
+    def test_full_download(self, tmp_path):
+        content = FILES["adapter_model.safetensors"]
+        transport = httpx.MockTransport(_presigned_handler(FILES))
+        dest = tmp_path / "shard.bin"
+        with httpx.Client(transport=transport) as client:
+            written = stream_download_to_file(
+                "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
+                dest,
+                client=client,
+            )
+        assert written == len(content)
+        assert dest.read_bytes() == content
+
+    def test_resume_appends_via_range(self, tmp_path):
+        content = FILES["adapter_model.safetensors"]
+        transport = httpx.MockTransport(_presigned_handler(FILES))
+        dest = tmp_path / "shard.bin"
+        dest.write_bytes(content[:100])
+        with httpx.Client(transport=transport) as client:
+            written = stream_download_to_file(
+                "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
+                dest,
+                client=client,
+                resume_from=100,
+            )
+        assert written == len(content)
+        assert dest.read_bytes() == content
+
+    def test_restart_when_server_ignores_range(self, tmp_path):
+        content = b"full-content"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=content)  # no Range support
+
+        dest = tmp_path / "f.bin"
+        dest.write_bytes(b"stale-partial")
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            written = stream_download_to_file(
+                "https://tos.example.com/f", dest, client=client, resume_from=13
+            )
+        assert written == len(content)
+        assert dest.read_bytes() == content
+
+    def test_expired_url_raises_dedicated_error(self, tmp_path):
+        transport = httpx.MockTransport(_presigned_handler(FILES))
+        with httpx.Client(transport=transport) as client:
+            with pytest.raises(DownloadURLExpiredError):
+                stream_download_to_file(
+                    "https://tos.example.com/files/adapter_config.json?sig=expired",
+                    tmp_path / "f.bin",
+                    client=client,
+                )
+
+    def test_async_twin_full_download(self, tmp_path):
+        content = FILES["adapter_model.safetensors"]
+        transport = httpx.MockTransport(_presigned_handler(FILES))
+        dest = tmp_path / "shard.bin"
+
+        async def run():
+            async with httpx.AsyncClient(transport=transport) as client:
+                return await _async_http.async_stream_download_to_file(
+                    "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
+                    dest,
+                    client=client,
+                )
+
+        written = asyncio.run(run())
+        assert written == len(content)
+        assert dest.read_bytes() == content
+
+
+# ---------------------------------------------------------------------------
+# ServiceClient.download_weights (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadWeights:
+    def _patch_transport(self, monkeypatch, handler):
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+
+    def test_parallel_download_by_artifact_id(self, tmp_path, monkeypatch):
+        calls: list = []
+        self._patch_transport(monkeypatch, _presigned_handler(FILES, calls))
+        client = _make_sync_client(_api_routes(_descriptor(FILES)))
+
+        dest = client.download_weights("art-1", tmp_path / "out")
+
+        assert dest == tmp_path / "out"
+        for name, content in FILES.items():
+            assert (dest / name).read_bytes() == content
+        assert not list(dest.rglob("*.part"))
+        assert len(calls) == len(FILES)
+        # Only the descriptor endpoint is hit for a raw artifact id.
+        client.http.get.assert_called_once_with("/api/v1/artifacts/art-1/download")
+
+    def test_checkpoint_uri_resolution_flow(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        client = _make_sync_client(_api_routes(_descriptor(FILES)))
+
+        client.download_weights(CHECKPOINT_URI, tmp_path / "out")
+
+        paths = [call.args[0] for call in client.http.get.call_args_list]
+        assert paths == [
+            "/api/v1/models/mdl-123/checkpoints",
+            "/api/v1/checkpoints/ckpt-1/artifacts",
+            "/api/v1/artifacts/art-1/download",
+        ]
+
+    def test_artifact_uri_selects_kind(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        artifacts = [dict(ADAPTER_ARTIFACT), dict(MODEL_ARTIFACT)]
+        client = _make_sync_client(_api_routes(_descriptor(FILES), artifacts=artifacts))
+
+        client.download_weights(f"{CHECKPOINT_URI}/artifacts/hf_model", tmp_path / "out")
+
+        paths = [call.args[0] for call in client.http.get.call_args_list]
+        assert paths[-1] == "/api/v1/artifacts/art-2/download"
+
+    def test_weights_artifact_object_target(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        client = _make_sync_client(_api_routes(_descriptor(FILES)))
+
+        artifact = WeightsArtifact.from_payload(ADAPTER_ARTIFACT)
+        client.download_weights(artifact, tmp_path / "out")
+
+        client.http.get.assert_called_once_with("/api/v1/artifacts/art-1/download")
+
+    def test_no_completed_artifact_never_exports_implicitly(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        pending = [{**ADAPTER_ARTIFACT, "status": "pending"}]
+        client = _make_sync_client(_api_routes(_descriptor(FILES), artifacts=pending))
+
+        with pytest.raises(RuntimeError, match="export_weights"):
+            client.download_weights(CHECKPOINT_URI, tmp_path / "out")
+        client.http.post.assert_not_called()
+
+    def test_ambiguous_artifacts_require_kind(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        artifacts = [dict(ADAPTER_ARTIFACT), dict(MODEL_ARTIFACT)]
+        client = _make_sync_client(_api_routes(_descriptor(FILES), artifacts=artifacts))
+
+        with pytest.raises(ValueError, match="disambiguate"):
+            client.download_weights(CHECKPOINT_URI, tmp_path / "out")
+
+    def test_kind_conflicting_with_artifact_uri_rejected(self, tmp_path, monkeypatch):
+        client = _make_sync_client(_api_routes(_descriptor(FILES)))
+        with pytest.raises(ValueError, match="conflicts"):
+            client.download_weights(
+                f"{CHECKPOINT_URI}/artifacts/hf_adapter", tmp_path / "out", kind="hf_model"
+            )
+
+    def test_invalid_kind_rejected(self, tmp_path):
+        client = _make_sync_client(_api_routes(_descriptor(FILES)))
+        with pytest.raises(ValueError, match="kind must be one of"):
+            client.download_weights("art-1", tmp_path / "out", kind="onnx")
+
+    def test_sha256_mismatch_raises_and_removes_file(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        descriptor = _descriptor(FILES, sha_overrides={"adapter_config.json": "0" * 64})
+        client = _make_sync_client(_api_routes(descriptor))
+
+        with pytest.raises(RuntimeError, match="sha256 mismatch"):
+            client.download_weights("art-1", tmp_path / "out")
+        assert not (tmp_path / "out" / "adapter_config.json").exists()
+        assert not (tmp_path / "out" / "adapter_config.json.part").exists()
+
+    def test_sha256_mismatch_ignored_when_verify_false(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        descriptor = _descriptor(FILES, sha_overrides={"adapter_config.json": "0" * 64})
+        client = _make_sync_client(_api_routes(descriptor))
+
+        dest = client.download_weights("art-1", tmp_path / "out", verify=False)
+
+        assert (dest / "adapter_config.json").read_bytes() == FILES["adapter_config.json"]
+
+    def test_expired_url_refreshes_descriptor(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        descriptor_calls = {"count": 0}
+
+        def api_get(path, **_kwargs):
+            if path == "/api/v1/artifacts/art-1/download":
+                descriptor_calls["count"] += 1
+                # First descriptor hands out already-expired URLs; the re-fetch
+                # (triggered by the 403) returns working ones.
+                sig = "expired" if descriptor_calls["count"] == 1 else "ok"
+                return _descriptor(FILES, sig=sig)
+            raise AssertionError(f"unexpected API GET {path}")
+
+        client = _make_sync_client(api_get)
+        dest = client.download_weights("art-1", tmp_path / "out")
+
+        assert descriptor_calls["count"] >= 2
+        for name, content in FILES.items():
+            assert (dest / name).read_bytes() == content
+
+    def test_completed_files_are_skipped_on_rerun(self, tmp_path, monkeypatch):
+        calls: list = []
+        self._patch_transport(monkeypatch, _presigned_handler(FILES, calls))
+        client = _make_sync_client(_api_routes(_descriptor(FILES)))
+        dest = tmp_path / "out"
+        (dest / "sub").mkdir(parents=True)
+        for name, content in FILES.items():
+            (dest / name).write_bytes(content)
+
+        client.download_weights("art-1", dest)
+
+        assert not calls  # everything already on disk and verified
+
+    def test_unsafe_descriptor_name_rejected(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        client = _make_sync_client(_api_routes(_descriptor({"../evil.bin": b"x"})))
+
+        with pytest.raises(ValueError, match="unsafe file name"):
+            client.download_weights("art-1", tmp_path / "out")
+
+    def test_resumes_from_existing_part_file(self, tmp_path, monkeypatch):
+        calls: list = []
+        self._patch_transport(monkeypatch, _presigned_handler(SINGLE_FILE, calls))
+        client = _make_sync_client(_api_routes(_descriptor(SINGLE_FILE)))
+        dest = tmp_path / "out"
+        dest.mkdir()
+        # A previous interrupted run left the first 100 bytes on disk.
+        (dest / "shard.bin.part").write_bytes(SINGLE_FILE["shard.bin"][:100])
+
+        client.download_weights("art-1", dest, max_concurrency=1)
+
+        assert (dest / "shard.bin").read_bytes() == SINGLE_FILE["shard.bin"]
+        assert calls[0].headers["Range"] == "bytes=100-"
+
+    def test_oversized_part_is_discarded_and_refetched(self, tmp_path, monkeypatch):
+        calls: list = []
+        self._patch_transport(monkeypatch, _presigned_handler(SINGLE_FILE, calls))
+        client = _make_sync_client(_api_routes(_descriptor(SINGLE_FILE)))
+        dest = tmp_path / "out"
+        dest.mkdir()
+        # Longer than the manifest size: not resumable, must restart at 0.
+        (dest / "shard.bin.part").write_bytes(b"x" * (len(SINGLE_FILE["shard.bin"]) + 10))
+
+        client.download_weights("art-1", dest, max_concurrency=1)
+
+        assert (dest / "shard.bin").read_bytes() == SINGLE_FILE["shard.bin"]
+        assert "Range" not in calls[0].headers
+
+    def test_transport_error_retries_with_range_resume(self, tmp_path, monkeypatch):
+        content = SINGLE_FILE["shard.bin"]
+        seen: list = []
+
+        def flaky(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            if len(seen) == 1:
+                # First attempt dies after the partial write already landed.
+                raise httpx.ReadError("connection reset")
+            range_header = request.headers.get("Range")
+            start = int(range_header.split("=", 1)[1].split("-", 1)[0]) if range_header else 0
+            return httpx.Response(206 if range_header else 200, content=content[start:])
+
+        self._patch_transport(monkeypatch, flaky)
+        client = _make_sync_client(_api_routes(_descriptor(SINGLE_FILE)))
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "shard.bin.part").write_bytes(content[:100])
+
+        client.download_weights("art-1", dest, max_concurrency=1)
+
+        assert (dest / "shard.bin").read_bytes() == content
+        assert len(seen) == 2
+        assert seen[1].headers["Range"] == "bytes=100-"
+
+    def test_max_concurrency_must_be_positive(self, tmp_path):
+        client = _make_sync_client(_api_routes(_descriptor(FILES)))
+        with pytest.raises(ValueError, match="max_concurrency"):
+            client.download_weights("art-1", tmp_path / "out", max_concurrency=0)
+
+
+# ---------------------------------------------------------------------------
+# AsyncServiceClient.download_weights (async twin)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncDownloadWeights:
+    def _patch_transport(self, monkeypatch, handler):
+        monkeypatch.setattr(
+            async_service_client,
+            "build_async_download_client",
+            lambda timeout=None: httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+
+    def test_parallel_download_by_artifact_id(self, tmp_path, monkeypatch):
+        calls: list = []
+        self._patch_transport(monkeypatch, _presigned_handler(FILES, calls))
+        client = _make_async_client(_api_routes(_descriptor(FILES)))
+
+        dest = asyncio.run(client.download_weights("art-1", tmp_path / "out"))
+
+        for name, content in FILES.items():
+            assert (dest / name).read_bytes() == content
+        assert not list(dest.rglob("*.part"))
+        assert len(calls) == len(FILES)
+        client.http.get.assert_awaited_once_with("/api/v1/artifacts/art-1/download")
+
+    def test_checkpoint_uri_resolution_flow(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        client = _make_async_client(_api_routes(_descriptor(FILES)))
+
+        asyncio.run(client.download_weights(CHECKPOINT_URI, tmp_path / "out"))
+
+        paths = [call.args[0] for call in client.http.get.call_args_list]
+        assert paths == [
+            "/api/v1/models/mdl-123/checkpoints",
+            "/api/v1/checkpoints/ckpt-1/artifacts",
+            "/api/v1/artifacts/art-1/download",
+        ]
+
+    def test_no_completed_artifact_never_exports_implicitly(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        pending = [{**ADAPTER_ARTIFACT, "status": "pending"}]
+        client = _make_async_client(_api_routes(_descriptor(FILES), artifacts=pending))
+
+        with pytest.raises(RuntimeError, match="export_weights"):
+            asyncio.run(client.download_weights(CHECKPOINT_URI, tmp_path / "out"))
+
+    def test_sha256_mismatch_raises(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        descriptor = _descriptor(FILES, sha_overrides={"adapter_config.json": "0" * 64})
+        client = _make_async_client(_api_routes(descriptor))
+
+        with pytest.raises(RuntimeError, match="sha256 mismatch"):
+            asyncio.run(client.download_weights("art-1", tmp_path / "out"))
+
+    def test_expired_url_refreshes_descriptor(self, tmp_path, monkeypatch):
+        self._patch_transport(monkeypatch, _presigned_handler(FILES))
+        descriptor_calls = {"count": 0}
+
+        async def api_get(path, **_kwargs):
+            if path == "/api/v1/artifacts/art-1/download":
+                descriptor_calls["count"] += 1
+                sig = "expired" if descriptor_calls["count"] == 1 else "ok"
+                return _descriptor(FILES, sig=sig)
+            raise AssertionError(f"unexpected API GET {path}")
+
+        client = AsyncServiceClient(base_url="https://test.example.com", api_key="sk-test")
+        client._http = MagicMock()
+        client._http.get = AsyncMock(side_effect=api_get)
+
+        dest = asyncio.run(client.download_weights("art-1", tmp_path / "out"))
+
+        assert descriptor_calls["count"] >= 2
+        for name, content in FILES.items():
+            assert (dest / name).read_bytes() == content
+
+    def test_resumes_from_existing_part_file(self, tmp_path, monkeypatch):
+        calls: list = []
+        self._patch_transport(monkeypatch, _presigned_handler(SINGLE_FILE, calls))
+        client = _make_async_client(_api_routes(_descriptor(SINGLE_FILE)))
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "shard.bin.part").write_bytes(SINGLE_FILE["shard.bin"][:100])
+
+        asyncio.run(client.download_weights("art-1", dest, max_concurrency=1))
+
+        assert (dest / "shard.bin").read_bytes() == SINGLE_FILE["shard.bin"]
+        assert calls[0].headers["Range"] == "bytes=100-"
+
+    def test_max_concurrency_must_be_positive(self, tmp_path):
+        client = _make_async_client(_api_routes(_descriptor(FILES)))
+        with pytest.raises(ValueError, match="max_concurrency"):
+            asyncio.run(client.download_weights("art-1", tmp_path / "out", max_concurrency=0))
+
+
+# ---------------------------------------------------------------------------
+# CLI: weaver checkpoint download
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointDownloadCLI:
+    def test_download_invokes_service_client(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+        monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+        client = MagicMock()
+        client.download_weights.return_value = tmp_path / "out"
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "checkpoint",
+                    "download",
+                    f"{CHECKPOINT_URI}/artifacts/hf_adapter",
+                    "-o",
+                    str(tmp_path / "out"),
+                    "--kind",
+                    "hf_adapter",
+                ],
+            )
+
+        assert result.exit_code == 0
+        client.connect.assert_called_once_with(ensure_session=False)
+        client.download_weights.assert_called_once_with(
+            f"{CHECKPOINT_URI}/artifacts/hf_adapter",
+            str(tmp_path / "out"),
+            kind="hf_adapter",
+        )
+        client.close.assert_called_once_with()
+
+    def test_download_error_exits_nonzero(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+        monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+        client = MagicMock()
+        client.download_weights.side_effect = RuntimeError("No completed HF weights artifact")
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli,
+                ["checkpoint", "download", "art-1", "-o", str(tmp_path / "out")],
+            )
+
+        assert result.exit_code == 1
+        assert "No completed HF weights artifact" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Bare download client never carries Weaver credentials
+# ---------------------------------------------------------------------------
+
+
+class TestBareDownloadClient:
+    def test_sync_client_has_no_api_key_header(self):
+        with _http.build_download_client() as client:
+            assert "X-WEAVER-API-KEY" not in client.headers
+            assert client.headers.get("User-Agent", "").startswith("weaver-sdk/")
+
+    def test_async_client_has_no_api_key_header(self):
+        async def run():
+            async with _async_http.build_async_download_client() as client:
+                assert "X-WEAVER-API-KEY" not in client.headers
+                assert client.headers.get("User-Agent", "").startswith("weaver-sdk/")
+
+        asyncio.run(run())

--- a/tests/test_hf_export.py
+++ b/tests/test_hf_export.py
@@ -1,0 +1,395 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for HF weights export: WeightsArtifact type and export_weights."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from weaver.async_training_client import AsyncTrainingClient
+from weaver.cli import cli
+from weaver.operations import AsyncOperationHandle, OperationHandle
+from weaver.training_client import TrainingClient
+from weaver.types.checkpoint import Checkpoint
+from weaver.types.weights_artifact import WeightsArtifact
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ARTIFACT_PAYLOAD: Dict[str, Any] = {
+    "id": "art-1",
+    "checkpoint_id": "ckpt-1",
+    "model_id": "mdl-123",
+    "kind": "hf_adapter",
+    "status": "completed",
+    "uri": "weaver://mdl-123/checkpoints/step-5/artifacts/hf_adapter",
+    "size_bytes": 1024,
+    "manifest": {"format_version": 1, "files": [{"name": "adapter_model.safetensors"}]},
+    "ttl_seconds": 604800,
+    "expires_at": "2026-08-19T00:00:00Z",
+    "created_at": "2026-08-12T00:00:00Z",
+    "updated_at": "2026-08-12T00:10:00Z",
+}
+
+
+def _make_training_client() -> TrainingClient:
+    """Create a TrainingClient with a mocked ServiceClient."""
+    service = MagicMock()
+    service.next_operation_seq.return_value = 1
+    return TrainingClient(
+        service=service,
+        model_id="mdl-123",
+        base_model="Qwen/Qwen3-8B",
+        session_id="sess-abc",
+    )
+
+
+def _make_async_training_client() -> AsyncTrainingClient:
+    """Create an AsyncTrainingClient with a mocked AsyncServiceClient."""
+    service = MagicMock()
+    service.next_operation_seq.return_value = 1
+    service.http.post = AsyncMock()
+    service.http.get = AsyncMock()
+    return AsyncTrainingClient(
+        service=service,
+        model_id="mdl-123",
+        base_model="Qwen/Qwen3-8B",
+        session_id="sess-abc",
+    )
+
+
+def _done_operation(response: Dict[str, Any]) -> Dict[str, Any]:
+    return {"id": "op-1", "status": "done", "response": response}
+
+
+# ---------------------------------------------------------------------------
+# WeightsArtifact type
+# ---------------------------------------------------------------------------
+
+
+class TestWeightsArtifactType:
+    def test_from_payload(self):
+        artifact = WeightsArtifact.from_payload(ARTIFACT_PAYLOAD)
+        assert artifact.id == "art-1"
+        assert artifact.checkpoint_id == "ckpt-1"
+        assert artifact.model_id == "mdl-123"
+        assert artifact.kind == "hf_adapter"
+        assert artifact.status == "completed"
+        assert artifact.uri == "weaver://mdl-123/checkpoints/step-5/artifacts/hf_adapter"
+        assert artifact.size_bytes == 1024
+        assert artifact.manifest == ARTIFACT_PAYLOAD["manifest"]
+        assert artifact.error is None
+        assert artifact.ttl_seconds == 604800
+        assert artifact.expires_at == "2026-08-19T00:00:00Z"
+        assert artifact.created_at == "2026-08-12T00:00:00Z"
+        assert artifact.updated_at == "2026-08-12T00:10:00Z"
+
+    def test_from_payload_minimal(self):
+        artifact = WeightsArtifact.from_payload({"id": "art-2"})
+        assert artifact.id == "art-2"
+        assert artifact.kind == "hf_model"
+        assert artifact.status is None
+        assert artifact.manifest is None
+        assert artifact.size_bytes is None
+
+    def test_from_payload_error_state(self):
+        artifact = WeightsArtifact.from_payload(
+            {"id": "art-3", "kind": "hf_model", "status": "error", "error": "conversion failed"}
+        )
+        assert artifact.status == "error"
+        assert artifact.error == "conversion failed"
+
+    def test_is_frozen(self):
+        artifact = WeightsArtifact(id="art-1")
+        with pytest.raises(AttributeError):
+            artifact.id = "art-2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TrainingClient.export_weights (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestExportWeights:
+    def test_one_step_export_without_checkpoint(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
+
+        artifact = tc.export_weights()
+
+        assert isinstance(artifact, WeightsArtifact)
+        assert artifact.id == "art-1"
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/models/mdl-123/export-hf"
+        assert args[1]["json"] == {
+            "format": "huggingface",
+            "merge_adapter": False,
+            "ttl_seconds": 604800,
+        }
+        assert args[1]["max_retries"] == 1
+
+    def test_checkpoint_export_with_checkpoint_object(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
+
+        ckpt = Checkpoint(id="ckpt-1", path="weaver://mdl-123/checkpoints/step-5")
+        artifact = tc.export_weights(checkpoint=ckpt, merge_adapter=True, force=True)
+
+        assert isinstance(artifact, WeightsArtifact)
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/export"
+        assert args[1]["json"] == {
+            "format": "huggingface",
+            "merge_adapter": True,
+            "ttl_seconds": 604800,
+            "force": True,
+        }
+
+    def test_checkpoint_export_with_raw_id(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
+
+        tc.export_weights(checkpoint="ckpt-raw", ttl_seconds=None)
+
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-raw/export"
+        assert args[1]["json"]["ttl_seconds"] is None
+
+    def test_checkpoint_export_resolves_weaver_path(self):
+        tc = _make_training_client()
+        tc._service.http.get.return_value = {
+            "items": [
+                {"id": "ckpt-0", "path": "weaver://mdl-123/checkpoints/step-1"},
+                {"id": "ckpt-1", "path": "weaver://mdl-123/checkpoints/step-5"},
+            ]
+        }
+        tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
+
+        tc.export_weights(checkpoint="weaver://mdl-123/checkpoints/step-5")
+
+        tc._service.http.get.assert_called_once_with("/api/v1/models/mdl-123/checkpoints")
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/export"
+
+    def test_checkpoint_export_unknown_path_raises(self):
+        tc = _make_training_client()
+        tc._service.http.get.return_value = {"items": []}
+
+        with pytest.raises(ValueError, match="No checkpoint with path"):
+            tc.export_weights(checkpoint="weaver://mdl-123/checkpoints/missing")
+        tc._service.http.post.assert_not_called()
+
+    def test_checkpoint_export_foreign_model_path_raises(self):
+        tc = _make_training_client()
+
+        with pytest.raises(ValueError, match="belongs to model other"):
+            tc.export_weights(checkpoint="weaver://other/checkpoints/step-5")
+        tc._service.http.post.assert_not_called()
+
+    def test_idempotent_completed_hit_returns_artifact_even_without_wait(self):
+        # HTTP 200 idempotent hit: the response body is the artifact itself,
+        # so there is no operation to hand back even when wait=False.
+        tc = _make_training_client()
+        tc._service.http.post.return_value = dict(ARTIFACT_PAYLOAD)
+
+        artifact = tc.export_weights(checkpoint="ckpt-1", wait=False)
+
+        assert isinstance(artifact, WeightsArtifact)
+        assert artifact.status == "completed"
+
+    def test_no_wait_returns_operation_handle(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = {"id": "op-9", "status": "pending"}
+
+        handle = tc.export_weights(checkpoint="ckpt-1", wait=False)
+
+        assert isinstance(handle, OperationHandle)
+        assert handle.operation_id == "op-9"
+
+    def test_wait_parses_operation_response_into_artifact(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
+
+        artifact = tc.export_weights(checkpoint="ckpt-1")
+
+        assert isinstance(artifact, WeightsArtifact)
+        assert artifact.kind == "hf_adapter"
+        assert artifact.checkpoint_id == "ckpt-1"
+
+    def test_empty_checkpoint_reference_raises(self):
+        tc = _make_training_client()
+        with pytest.raises(ValueError, match="must not be empty"):
+            tc.export_weights(checkpoint="   ")
+
+    def test_checkpoint_object_without_id_raises(self):
+        tc = _make_training_client()
+        ckpt = Checkpoint(id="", path="weaver://mdl-123/checkpoints/step-5")
+        with pytest.raises(ValueError, match="no id"):
+            tc.export_weights(checkpoint=ckpt)
+
+
+# ---------------------------------------------------------------------------
+# AsyncTrainingClient.export_weights (async twin)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncExportWeights:
+    def test_one_step_export_without_checkpoint(self):
+        tc = _make_async_training_client()
+        tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
+
+        artifact = asyncio.run(tc.export_weights())
+
+        assert isinstance(artifact, WeightsArtifact)
+        assert artifact.id == "art-1"
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/models/mdl-123/export-hf"
+        assert args[1]["json"] == {
+            "format": "huggingface",
+            "merge_adapter": False,
+            "ttl_seconds": 604800,
+        }
+        assert args[1]["max_retries"] == 1
+
+    def test_checkpoint_export_resolves_weaver_path(self):
+        tc = _make_async_training_client()
+        tc._service.http.get.return_value = {
+            "items": [{"id": "ckpt-1", "path": "weaver://mdl-123/checkpoints/step-5"}]
+        }
+        tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
+
+        artifact = asyncio.run(
+            tc.export_weights(checkpoint="weaver://mdl-123/checkpoints/step-5", force=True)
+        )
+
+        assert isinstance(artifact, WeightsArtifact)
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/export"
+        assert args[1]["json"]["force"] is True
+
+    def test_idempotent_completed_hit_returns_artifact_even_without_wait(self):
+        tc = _make_async_training_client()
+        tc._service.http.post.return_value = dict(ARTIFACT_PAYLOAD)
+
+        artifact = asyncio.run(tc.export_weights(checkpoint="ckpt-1", wait=False))
+
+        assert isinstance(artifact, WeightsArtifact)
+        assert artifact.status == "completed"
+
+    def test_no_wait_returns_async_operation_handle(self):
+        tc = _make_async_training_client()
+        tc._service.http.post.return_value = {"id": "op-9", "status": "pending"}
+
+        handle = asyncio.run(tc.export_weights(checkpoint="ckpt-1", wait=False))
+
+        assert isinstance(handle, AsyncOperationHandle)
+        assert handle.operation_id == "op-9"
+
+    def test_foreign_model_path_raises(self):
+        tc = _make_async_training_client()
+        with pytest.raises(ValueError, match="belongs to model other"):
+            asyncio.run(tc.export_weights(checkpoint="weaver://other/checkpoints/step-5"))
+
+
+# ---------------------------------------------------------------------------
+# CLI: weaver checkpoint export
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointExportCLI:
+    def _client(self) -> MagicMock:
+        client = MagicMock()
+        client.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
+        return client
+
+    def test_export_with_checkpoint_id(self, monkeypatch):
+        monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+        monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+        client = self._client()
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["checkpoint", "export", "ckpt-1"])
+
+        assert result.exit_code == 0
+        client.connect.assert_called_once_with(ensure_session=False)
+        args = client.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/export"
+        assert args[1]["json"] == {
+            "format": "huggingface",
+            "merge_adapter": False,
+            "ttl_seconds": 604800,
+            "force": False,
+        }
+        assert "Export completed" in result.output
+        client.close.assert_called_once_with()
+
+    def test_export_resolves_weaver_uri_and_flags(self, monkeypatch):
+        monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+        monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+        client = self._client()
+        client.http.get.return_value = {
+            "items": [{"id": "ckpt-7", "path": "weaver://mdl-123/checkpoints/step-5"}]
+        }
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "checkpoint",
+                    "export",
+                    "weaver://mdl-123/checkpoints/step-5",
+                    "--merge-adapter",
+                    "--ttl",
+                    "3600",
+                    "--force",
+                ],
+            )
+
+        assert result.exit_code == 0
+        client.http.get.assert_called_once_with("/api/v1/models/mdl-123/checkpoints")
+        args = client.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-7/export"
+        assert args[1]["json"] == {
+            "format": "huggingface",
+            "merge_adapter": True,
+            "ttl_seconds": 3600,
+            "force": True,
+        }
+
+    def test_export_no_wait_prints_operation_id(self, monkeypatch):
+        monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+        monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+        client = MagicMock()
+        client.http.post.return_value = {"id": "op-42", "status": "pending"}
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["checkpoint", "export", "ckpt-1", "--no-wait"])
+
+        assert result.exit_code == 0
+        assert "op-42" in result.output
+
+    def test_export_idempotent_hit_prints_artifact(self, monkeypatch):
+        monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+        monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+        client = MagicMock()
+        client.http.post.return_value = dict(ARTIFACT_PAYLOAD)
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["checkpoint", "export", "ckpt-1"])
+
+        assert result.exit_code == 0
+        assert "already completed" in result.output

--- a/weaver/__init__.py
+++ b/weaver/__init__.py
@@ -30,6 +30,7 @@ from .async_service_client import AsyncServiceClient  # noqa: F401
 from .async_training_client import AsyncTrainingClient  # noqa: F401
 from .operations import AsyncOperationHandle, OperationHandle  # noqa: F401
 from .service_client import ServiceClient  # noqa: F401
+from .types.weights_artifact import WeightsArtifact  # noqa: F401
 
 __all__ = [
     "ServiceClient",
@@ -39,6 +40,7 @@ __all__ = [
     "AsyncSamplingClient",
     "AsyncOperationHandle",
     "WeaverAPIError",
+    "WeightsArtifact",
     "types",
     "__version__",
 ]

--- a/weaver/_artifacts.py
+++ b/weaver/_artifacts.py
@@ -1,0 +1,292 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HF weights export/download helpers shared by the sync and async clients.
+
+Everything in this module is pure (no IO) so both client stacks build
+identical requests and interpret identical responses; see
+``.claude/rules/async-compatibility.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, List, Optional
+
+from ._utils import lookup_case_insensitive
+
+# Artifact kinds the server can produce. The server derives the kind
+# (full_ft -> hf_model; lora -> hf_adapter, merge_adapter=true -> hf_model);
+# clients only ever use it to *select* among existing artifacts.
+ARTIFACT_KINDS = ("hf_model", "hf_adapter")
+
+# Export artifacts default to a bounded 7-day TTL: they are regenerable from
+# the source checkpoint, and full HF exports are tens of GB of object storage.
+DEFAULT_EXPORT_TTL_SECONDS = 604800  # 7 days
+
+# Per-file retry budgets for artifact downloads (shared by both stacks).
+# Descriptor re-fetches are idempotent and cheap, but bounded so a URL the
+# server keeps signing wrong fails fast instead of looping.
+DOWNLOAD_MAX_URL_REFRESHES = 3
+DOWNLOAD_MAX_TRANSPORT_RETRIES = 3
+
+# ``weaver://{model_id}/checkpoints/{name}`` optionally followed by
+# ``/artifacts/{kind}`` (the artifact URI shape).
+_ARTIFACT_URI_RE = re.compile(
+    r"^weaver://(?P<model_id>[^/]+)/checkpoints/(?P<name>[^/]+)"
+    r"(?:/artifacts/(?P<kind>[^/]+))?/?$"
+)
+
+
+@dataclass(frozen=True)
+class ArtifactTarget:
+    """A parsed ``download_weights`` target.
+
+    Exactly one of ``artifact_id`` or (``model_id`` + ``checkpoint_path``)
+    is populated. ``kind`` is set only when the target was an artifact URI
+    that names it explicitly.
+    """
+
+    artifact_id: Optional[str] = None
+    model_id: Optional[str] = None
+    checkpoint_path: Optional[str] = None
+    kind: Optional[str] = None
+
+
+def parse_download_target(target: str) -> ArtifactTarget:
+    """Classify a string download target.
+
+    Args:
+        target: An artifact ``weaver://.../artifacts/{kind}`` URI, a
+            checkpoint ``weaver://...`` URI, or a raw artifact id.
+
+    Returns:
+        An :class:`ArtifactTarget` describing how to resolve the artifact.
+
+    Raises:
+        ValueError: If *target* is empty, or is a ``weaver://`` URI that does
+            not match the checkpoint/artifact shape, or names an unknown
+            artifact kind.
+    """
+    normalized = (target or "").strip()
+    if not normalized:
+        raise ValueError("download target must not be empty")
+    if not normalized.startswith("weaver://"):
+        # Anything that is not a weaver URI is treated as an artifact id.
+        return ArtifactTarget(artifact_id=normalized)
+    match = _ARTIFACT_URI_RE.match(normalized)
+    if not match:
+        raise ValueError(
+            f"Unrecognized weaver URI {normalized!r}: expected "
+            "weaver://{model_id}/checkpoints/{name} or "
+            "weaver://{model_id}/checkpoints/{name}/artifacts/{kind}"
+        )
+    kind = match.group("kind")
+    if kind is not None and kind not in ARTIFACT_KINDS:
+        raise ValueError(
+            f"Unknown artifact kind {kind!r} in {normalized!r}; expected one of {ARTIFACT_KINDS}"
+        )
+    model_id = match.group("model_id")
+    name = match.group("name")
+    return ArtifactTarget(
+        model_id=model_id,
+        checkpoint_path=f"weaver://{model_id}/checkpoints/{name}",
+        kind=kind,
+    )
+
+
+def is_artifact_payload(payload: Any) -> bool:
+    """Return True when *payload* is an artifact JSON, not an operation envelope.
+
+    The HTTP layer flattens status codes, so an idempotent completed hit
+    (HTTP 200 artifact body) and a freshly enqueued export (HTTP 202
+    operation body) both arrive as plain dicts. Only artifacts carry a
+    ``kind`` of ``hf_model``/``hf_adapter``; operation envelopes never do.
+    """
+    if not isinstance(payload, dict):
+        return False
+    kind = lookup_case_insensitive(payload, "kind")
+    return isinstance(kind, str) and kind in ARTIFACT_KINDS
+
+
+def resolve_checkpoint_id_from_listing(
+    items: List[Dict[str, Any]], checkpoint_path: str
+) -> Optional[str]:
+    """Find the checkpoint id whose storage ``path`` equals *checkpoint_path*."""
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        path = lookup_case_insensitive(item, "path")
+        if path is not None and str(path) == checkpoint_path:
+            identifier = lookup_case_insensitive(item, "id")
+            if identifier is not None:
+                return str(identifier)
+    return None
+
+
+def select_artifact_payload(
+    items: List[Dict[str, Any]],
+    kind: Optional[str],
+    *,
+    context: str,
+) -> Dict[str, Any]:
+    """Pick the completed artifact to download from a listing.
+
+    Args:
+        items: Raw artifact dicts from ``GET /checkpoints/{id}/artifacts``.
+        kind: Required artifact kind, or ``None`` to accept the single
+            completed artifact.
+        context: Human-readable target description for error messages.
+
+    Returns:
+        The selected artifact payload.
+
+    Raises:
+        RuntimeError: If no completed artifact matches — downloads never
+            trigger exports implicitly, so the caller is told to run
+            ``export_weights`` first.
+        ValueError: If *kind* is omitted while several completed kinds exist.
+    """
+    completed = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        status = lookup_case_insensitive(item, "status")
+        if status is not None and str(status).lower() != "completed":
+            continue
+        item_kind = lookup_case_insensitive(item, "kind")
+        if kind is not None and str(item_kind) != kind:
+            continue
+        completed.append(item)
+    if not completed:
+        wanted = f" of kind {kind!r}" if kind else ""
+        raise RuntimeError(
+            f"No completed HF weights artifact{wanted} exists for {context}. "
+            "Downloads never trigger a conversion implicitly; call "
+            "export_weights() (or `weaver checkpoint export`) first, then retry."
+        )
+    if len(completed) > 1:
+        kinds = sorted(str(lookup_case_insensitive(item, "kind")) for item in completed)
+        raise ValueError(
+            f"Multiple completed artifacts exist for {context} (kinds: {kinds}); "
+            "disambiguate with kind='hf_model' or kind='hf_adapter'."
+        )
+    return completed[0]
+
+
+@dataclass(frozen=True)
+class ArtifactFile:
+    """One downloadable file from an artifact download descriptor."""
+
+    name: str
+    url: str
+    size: Optional[int] = None
+    sha256: Optional[str] = None
+    url_expires_at: Optional[str] = None
+
+
+def descriptor_files(descriptor: Any) -> List[ArtifactFile]:
+    """Validate and normalize ``GET /artifacts/{id}/download`` file entries.
+
+    File names are server-controlled input used to build local paths, so
+    absolute names and ``..`` traversal segments are rejected.
+
+    Raises:
+        ValueError: On a malformed descriptor or an unsafe file name.
+    """
+    payload = descriptor if isinstance(descriptor, dict) else {}
+    raw_files = lookup_case_insensitive(payload, "files")
+    if not isinstance(raw_files, list) or not raw_files:
+        raise ValueError("artifact download descriptor contains no files")
+    files: List[ArtifactFile] = []
+    for raw in raw_files:
+        if not isinstance(raw, dict):
+            raise ValueError(f"malformed descriptor file entry: {raw!r}")
+        name = str(lookup_case_insensitive(raw, "name") or "")
+        url = str(lookup_case_insensitive(raw, "url") or "")
+        if not name or not url:
+            raise ValueError(f"descriptor file entry missing name or url: {raw!r}")
+        pure = PurePosixPath(name)
+        if pure.is_absolute() or ".." in pure.parts:
+            raise ValueError(f"unsafe file name in download descriptor: {name!r}")
+        size = lookup_case_insensitive(raw, "size")
+        sha256 = lookup_case_insensitive(raw, "sha256")
+        expires = lookup_case_insensitive(raw, "url_expires_at")
+        files.append(
+            ArtifactFile(
+                name=name,
+                url=url,
+                size=int(size) if size is not None else None,
+                sha256=str(sha256) if sha256 else None,
+                url_expires_at=str(expires) if expires else None,
+            )
+        )
+    return files
+
+
+def file_sha256(path: Path) -> str:
+    """Compute the sha256 hex digest of *path* by streaming it from disk.
+
+    Hashing what actually landed on disk (rather than the bytes seen on the
+    wire) is deliberate: it also catches short writes and torn resumes.
+    """
+    digest = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def check_downloaded_file(part_path: Path, entry: ArtifactFile, *, verify: bool) -> None:
+    """Validate a fully downloaded ``.part`` file against its manifest entry.
+
+    Deletes the corrupt file before raising so a later retry cannot resume
+    from poisoned bytes.
+
+    Raises:
+        RuntimeError: On size or sha256 mismatch.
+    """
+    actual_size = part_path.stat().st_size
+    if entry.size is not None and actual_size != entry.size:
+        part_path.unlink()
+        raise RuntimeError(
+            f"Downloaded size mismatch for {entry.name!r}: "
+            f"expected {entry.size} bytes, got {actual_size}"
+        )
+    if verify and entry.sha256:
+        actual = file_sha256(part_path)
+        if actual != entry.sha256:
+            part_path.unlink()
+            raise RuntimeError(
+                f"sha256 mismatch for {entry.name!r}: " f"expected {entry.sha256}, got {actual}"
+            )
+
+
+def is_file_already_complete(final_path: Path, entry: ArtifactFile, *, verify: bool) -> bool:
+    """Return True when *final_path* already matches its manifest entry.
+
+    Lets a re-run of ``download_weights`` skip files that finished earlier.
+    Requires a known size (and matching sha256 when *verify*); otherwise the
+    file is re-downloaded.
+    """
+    if not final_path.is_file() or entry.size is None:
+        return False
+    if final_path.stat().st_size != entry.size:
+        return False
+    if verify and entry.sha256:
+        return file_sha256(final_path) == entry.sha256
+    return True

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from pathlib import Path
 from typing import Any, Mapping, MutableMapping
 
 import httpx
@@ -37,7 +38,10 @@ from ._http import (
     DEFAULT_CONNECTION_RETRIES,
     DEFAULT_MAX_RETRIES,
     DEFAULT_TIMEOUT,
+    DOWNLOAD_CHUNK_SIZE,
+    DOWNLOAD_TIMEOUT,
     USER_AGENT,
+    DownloadURLExpiredError,
     WeaverAPIError,
     _is_connection_error,
     apply_request_span_attributes,
@@ -49,6 +53,72 @@ from ._telemetry import get_tracer
 from .config import WeaverConfig
 
 logger = logging.getLogger(__name__)
+
+
+def build_async_download_client(timeout: httpx.Timeout | float | None = None) -> httpx.AsyncClient:
+    """Asyncio twin of :func:`weaver._http.build_download_client`.
+
+    Presigned URLs are self-authorizing plain object-storage URLs; the Weaver
+    API key must never be sent to an external host, so this client carries no
+    auth headers and no Weaver base URL — only a User-Agent.
+    """
+    return httpx.AsyncClient(
+        timeout=timeout or DOWNLOAD_TIMEOUT,
+        headers={"User-Agent": USER_AGENT},
+        limits=DEFAULT_CONNECTION_LIMITS,
+        follow_redirects=True,
+    )
+
+
+async def async_stream_download_to_file(
+    url: str,
+    dest: Path,
+    *,
+    client: httpx.AsyncClient,
+    resume_from: int = 0,
+    chunk_size: int = DOWNLOAD_CHUNK_SIZE,
+) -> int:
+    """Asyncio twin of :func:`weaver._http.stream_download_to_file`.
+
+    Network reads are awaited so the event loop stays free; the per-chunk
+    ``fh.write`` is a buffered local-disk write that is fast relative to the
+    awaited network reads, which keeps the loop responsive without a thread
+    hop per chunk.
+
+    Returns:
+        Total bytes now present in *dest*.
+
+    Raises:
+        DownloadURLExpiredError: The URL was rejected with 401/403 — refresh
+            the download descriptor and retry with a fresh URL.
+        WeaverAPIError: Any other non-success response.
+    """
+    headers: dict[str, str] = {}
+    if resume_from > 0:
+        headers["Range"] = f"bytes={resume_from}-"
+    async with client.stream("GET", url, headers=headers) as response:
+        if response.status_code in (401, 403):
+            await response.aread()
+            raise DownloadURLExpiredError(
+                f"presigned URL rejected with HTTP {response.status_code}; "
+                "the download descriptor must be re-fetched for a fresh URL"
+            )
+        if response.status_code == httpx.codes.REQUESTED_RANGE_NOT_SATISFIABLE:
+            # The requested offset is at/past EOF: the bytes on disk already
+            # cover the file. The caller verifies size/sha before trusting it.
+            await response.aread()
+            return resume_from
+        if not response.is_success:
+            await response.aread()
+            raise_for_response(response)
+        partial = response.status_code == httpx.codes.PARTIAL_CONTENT
+        mode = "ab" if partial else "wb"
+        written = resume_from if partial else 0
+        with open(dest, mode) as fh:
+            async for chunk in response.aiter_bytes(chunk_size):
+                fh.write(chunk)
+                written += len(chunk)
+    return written
 
 
 class AsyncAPIClient:

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import time
+from pathlib import Path
 from typing import Any, Mapping, MutableMapping
 
 import httpx
@@ -45,6 +46,13 @@ MAX_RETRY_DELAY = 10.0
 # Transport-layer errors that indicate the request never reached the server.
 # Safe to retry regardless of idempotency because no server-side state was created.
 CONNECTION_ERRORS = (OSError, httpx.ConnectError, httpx.RemoteProtocolError)
+
+# Artifact file downloads stream multi-GB safetensors shards; chunks are
+# written to disk as they arrive so memory stays flat.
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MiB
+# Per-read timeout, not whole-transfer: httpx applies ``read`` between socket
+# reads, so a long download stays alive as long as bytes keep flowing.
+DOWNLOAD_TIMEOUT = httpx.Timeout(timeout=60.0, connect=10.0)
 
 logger = logging.getLogger(__name__)
 
@@ -211,6 +219,85 @@ def apply_request_span_attributes(
 def compute_retry_delay(attempt: int) -> float:
     """Exponential backoff delay for retry *attempt* (1-based)."""
     return min(INITIAL_RETRY_DELAY * (2 ** (attempt - 1)), MAX_RETRY_DELAY)
+
+
+class DownloadURLExpiredError(RuntimeError):
+    """A presigned artifact URL was rejected (HTTP 401/403).
+
+    Presigned URLs are short-lived (~15 minutes); callers recover by
+    re-fetching the download descriptor for fresh URLs and retrying.
+    """
+
+
+def build_download_client(timeout: httpx.Timeout | float | None = None) -> httpx.Client:
+    """Build a bare client for downloading presigned artifact URLs.
+
+    Presigned URLs are self-authorizing plain object-storage URLs; the Weaver
+    API key must never be sent to an external host, so this client carries no
+    auth headers and no Weaver base URL — only a User-Agent.
+    """
+    return httpx.Client(
+        timeout=timeout or DOWNLOAD_TIMEOUT,
+        headers={"User-Agent": USER_AGENT},
+        limits=DEFAULT_CONNECTION_LIMITS,
+        follow_redirects=True,
+    )
+
+
+def stream_download_to_file(
+    url: str,
+    dest: Path,
+    *,
+    client: httpx.Client,
+    resume_from: int = 0,
+    chunk_size: int = DOWNLOAD_CHUNK_SIZE,
+) -> int:
+    """Stream a plain (non-API) URL to *dest* on disk.
+
+    Args:
+        url: Presigned download URL. No Weaver auth headers are attached;
+            *client* must be a bare client (see :func:`build_download_client`).
+        dest: File to write. Appended to when the server honors the Range
+            request, truncated and rewritten when it does not.
+        client: Bare ``httpx.Client`` used for the request.
+        resume_from: Byte offset already present in *dest*; sends a ``Range``
+            header so an interrupted download resumes instead of restarting.
+        chunk_size: Streaming chunk size in bytes.
+
+    Returns:
+        Total bytes now present in *dest*.
+
+    Raises:
+        DownloadURLExpiredError: The URL was rejected with 401/403 — refresh
+            the download descriptor and retry with a fresh URL.
+        WeaverAPIError: Any other non-success response.
+    """
+    headers: dict[str, str] = {}
+    if resume_from > 0:
+        headers["Range"] = f"bytes={resume_from}-"
+    with client.stream("GET", url, headers=headers) as response:
+        if response.status_code in (401, 403):
+            response.read()
+            raise DownloadURLExpiredError(
+                f"presigned URL rejected with HTTP {response.status_code}; "
+                "the download descriptor must be re-fetched for a fresh URL"
+            )
+        if response.status_code == httpx.codes.REQUESTED_RANGE_NOT_SATISFIABLE:
+            # The requested offset is at/past EOF: the bytes on disk already
+            # cover the file. The caller verifies size/sha before trusting it.
+            response.read()
+            return resume_from
+        if not response.is_success:
+            response.read()
+            raise_for_response(response)
+        partial = response.status_code == httpx.codes.PARTIAL_CONTENT
+        mode = "ab" if partial else "wb"
+        written = resume_from if partial else 0
+        with open(dest, mode) as fh:
+            for chunk in response.iter_bytes(chunk_size):
+                fh.write(chunk)
+                written += len(chunk)
+    return written
 
 
 class APIClient:

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -73,14 +73,46 @@ from __future__ import annotations
 import asyncio
 import atexit
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
+
+import httpx
 
 from . import __version__
-from ._async_http import AsyncAPIClient
+from ._artifacts import (
+    ARTIFACT_KINDS,
+    DOWNLOAD_MAX_TRANSPORT_RETRIES,
+    DOWNLOAD_MAX_URL_REFRESHES,
+    ArtifactFile,
+    check_downloaded_file,
+    descriptor_files,
+    is_file_already_complete,
+    parse_download_target,
+    resolve_checkpoint_id_from_listing,
+    select_artifact_payload,
+)
+from ._async_http import (
+    AsyncAPIClient,
+    async_stream_download_to_file,
+    build_async_download_client,
+)
+from ._http import DownloadURLExpiredError, compute_retry_delay
 from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import AsyncOperationHandle, build_async_operation_handle
 from .types import LoraConfig
+from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
     from .async_sampling_client import AsyncSamplingClient
@@ -708,3 +740,148 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
     async def get_model(self, model_id: str) -> Dict[str, Any]:
         """Get detailed information about a specific model."""
         return await self.http.get(f"/api/v1/models/{model_id}")
+
+    # ------------------------------------------------------------------
+    # HF weights download
+    # ------------------------------------------------------------------
+
+    async def download_weights(
+        self,
+        target: str | WeightsArtifact,
+        dest: str | Path,
+        *,
+        kind: str | None = None,
+        verify: bool = True,
+        max_concurrency: int = 4,
+    ) -> Path:
+        """Download an exported HF weights artifact to a local directory.
+
+        See :meth:`weaver.service_client.ServiceClient.download_weights`.
+        Files are streamed concurrently on the event loop (bounded by
+        *max_concurrency*); hash verification runs in worker threads so the
+        loop stays responsive.
+        """
+        if kind is not None and kind not in ARTIFACT_KINDS:
+            raise ValueError(f"kind must be one of {ARTIFACT_KINDS}, got {kind!r}")
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be >= 1")
+        artifact_id = await self._resolve_weights_artifact_id(target, kind)
+        dest_dir = Path(dest).expanduser()
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        descriptor_path = f"/api/v1/artifacts/{artifact_id}/download"
+        files = descriptor_files(await self.http.get(descriptor_path))
+        urls = {entry.name: entry.url for entry in files}
+        urls_lock = asyncio.Lock()
+
+        async def current_url(name: str) -> str:
+            async with urls_lock:
+                return urls[name]
+
+        async def refresh_url(name: str) -> str:
+            # Presigned URLs live ~15 minutes; re-fetching the descriptor is
+            # idempotent and cheap, and refreshes every pending file at once.
+            async with urls_lock:
+                for entry in descriptor_files(await self.http.get(descriptor_path)):
+                    urls[entry.name] = entry.url
+                return urls[name]
+
+        semaphore = asyncio.Semaphore(max(1, min(max_concurrency, len(files))))
+        async with build_async_download_client() as download_client:
+
+            async def bounded_download(entry: ArtifactFile) -> None:
+                async with semaphore:
+                    await self._download_weights_file(
+                        download_client,
+                        entry,
+                        dest_dir=dest_dir,
+                        verify=verify,
+                        current_url=current_url,
+                        refresh_url=refresh_url,
+                    )
+
+            # return_exceptions=True drains every task before the client is
+            # closed (no orphan writers), then the first failure is re-raised.
+            results = await asyncio.gather(
+                *(bounded_download(entry) for entry in files), return_exceptions=True
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    raise result
+        return dest_dir
+
+    async def _resolve_weights_artifact_id(
+        self, target: str | WeightsArtifact, kind: str | None
+    ) -> str:
+        """Resolve a download target to a concrete artifact id."""
+        if isinstance(target, WeightsArtifact):
+            if not target.id:
+                raise ValueError("WeightsArtifact has no id")
+            return target.id
+        parsed = parse_download_target(target)
+        if parsed.artifact_id:
+            return parsed.artifact_id
+        if parsed.kind and kind and parsed.kind != kind:
+            raise ValueError(f"kind={kind!r} conflicts with the artifact URI kind {parsed.kind!r}")
+        effective_kind = parsed.kind or kind
+        listing = await self.http.get(f"/api/v1/models/{parsed.model_id}/checkpoints")
+        items = (listing or {}).get("items", []) if isinstance(listing, dict) else []
+        checkpoint_id = resolve_checkpoint_id_from_listing(items, parsed.checkpoint_path or "")
+        if checkpoint_id is None:
+            raise ValueError(
+                f"No checkpoint with path {parsed.checkpoint_path!r} found for "
+                f"model {parsed.model_id}"
+            )
+        artifacts = await self.http.get(f"/api/v1/checkpoints/{checkpoint_id}/artifacts")
+        artifact_items = (artifacts or {}).get("items", []) if isinstance(artifacts, dict) else []
+        selected = select_artifact_payload(artifact_items, effective_kind, context=str(target))
+        return extract_id(selected)
+
+    async def _download_weights_file(
+        self,
+        download_client: httpx.AsyncClient,
+        entry: ArtifactFile,
+        *,
+        dest_dir: Path,
+        verify: bool,
+        current_url: Callable[[str], Awaitable[str]],
+        refresh_url: Callable[[str], Awaitable[str]],
+    ) -> None:
+        """Download one manifest file with resume, URL refresh, and verification."""
+        final_path = dest_dir / entry.name
+        final_path.parent.mkdir(parents=True, exist_ok=True)
+        # Hashing an existing multi-GB file is blocking CPU+disk work; keep it
+        # off the event loop.
+        if await asyncio.to_thread(is_file_already_complete, final_path, entry, verify=verify):
+            return
+        part_path = final_path.with_name(final_path.name + ".part")
+        url = await current_url(entry.name)
+        url_refreshes = 0
+        transport_retries = 0
+        while True:
+            resume_from = part_path.stat().st_size if part_path.exists() else 0
+            if entry.size is not None and resume_from > entry.size:
+                # Longer than the manifest says it should be: poisoned partial.
+                part_path.unlink()
+                resume_from = 0
+            try:
+                await async_stream_download_to_file(
+                    url, part_path, client=download_client, resume_from=resume_from
+                )
+                break
+            except DownloadURLExpiredError:
+                url_refreshes += 1
+                if url_refreshes > DOWNLOAD_MAX_URL_REFRESHES:
+                    raise
+                url = await refresh_url(entry.name)
+            except (httpx.TransportError, OSError):
+                # GETs are idempotent and the .part keeps its bytes, so retry
+                # with a Range resume instead of restarting the shard.
+                transport_retries += 1
+                if transport_retries > DOWNLOAD_MAX_TRANSPORT_RETRIES:
+                    raise
+                await asyncio.sleep(compute_retry_delay(transport_retries))
+        # sha256 of a multi-GB shard is blocking work; run it off-loop.
+        await asyncio.to_thread(check_downloaded_file, part_path, entry, verify=verify)
+        # Atomic publish: readers never observe a half-written file.
+        part_path.replace(final_path)

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -31,6 +31,7 @@ import math
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
+from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload
 from ._payloads import (
     build_request_metadata,
     build_surrogate_data,
@@ -38,11 +39,13 @@ from ._payloads import (
     forward_payload,
     parse_logprob_tensors,
 )
+from ._sampling_utils import parse_model_id_from_weaver_path
 from ._utils import DEFAULT_SAMPLER_TTL_SECONDS, UNSET, _UnsetType, lookup_case_insensitive
 from .async_service_client import AsyncServiceClient
-from .operations import AsyncOperationHandle
+from .operations import AsyncOperationHandle, build_async_operation_handle
 from .types import AdamParams, Datum
 from .types.checkpoint import Checkpoint
+from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -574,6 +577,98 @@ class AsyncTrainingClient:
         return await self._service.http.patch(
             f"/api/v1/models/{self.model_id}/checkpoints/ttl",
             json=body,
+        )
+
+    # ------------------------------------------------------------------
+    # HF weights export
+    # ------------------------------------------------------------------
+
+    @overload
+    async def export_weights(
+        self,
+        *,
+        checkpoint: str | Checkpoint | None = None,
+        merge_adapter: bool = False,
+        ttl_seconds: int | None = DEFAULT_EXPORT_TTL_SECONDS,
+        force: bool = False,
+        wait: "Literal[True]" = True,
+    ) -> WeightsArtifact: ...
+
+    @overload
+    async def export_weights(
+        self,
+        *,
+        checkpoint: str | Checkpoint | None = None,
+        merge_adapter: bool = False,
+        ttl_seconds: int | None = DEFAULT_EXPORT_TTL_SECONDS,
+        force: bool = False,
+        wait: "Literal[False]",
+    ) -> WeightsArtifact | AsyncOperationHandle: ...
+
+    async def export_weights(
+        self,
+        *,
+        checkpoint: str | Checkpoint | None = None,
+        merge_adapter: bool = False,
+        ttl_seconds: int | None = DEFAULT_EXPORT_TTL_SECONDS,
+        force: bool = False,
+        wait: bool = True,
+    ) -> WeightsArtifact | AsyncOperationHandle:
+        """Export model weights in HuggingFace format.
+
+        See :meth:`weaver.training_client.TrainingClient.export_weights`.
+        Returns a :class:`~weaver.types.WeightsArtifact` when *wait* is True
+        (or on an idempotent completed hit), else an ``AsyncOperationHandle``.
+        """
+        body: Dict[str, Any] = {
+            "format": "huggingface",
+            "merge_adapter": merge_adapter,
+            "ttl_seconds": ttl_seconds,
+        }
+        if checkpoint is None:
+            path = f"/api/v1/models/{self.model_id}/export-hf"
+        else:
+            checkpoint_id = await self._resolve_checkpoint_id(checkpoint)
+            body["force"] = force
+            path = f"/api/v1/checkpoints/{checkpoint_id}/export"
+        # max_retries=1: exports are non-idempotent POSTs (see enqueue_operation).
+        response = await self._service.http.post(path, json=body, max_retries=1)
+        # A completed idempotent hit answers with the artifact itself instead
+        # of an operation envelope; return it directly even when wait=False.
+        if is_artifact_payload(response):
+            return WeightsArtifact.from_payload(response)
+        handle = build_async_operation_handle(
+            self._service.http, response if isinstance(response, dict) else {}
+        )
+        if not wait:
+            return handle
+        result = await handle.result()
+        return WeightsArtifact.from_payload(result if isinstance(result, dict) else {})
+
+    async def _resolve_checkpoint_id(self, checkpoint: str | Checkpoint) -> str:
+        """Resolve a checkpoint reference to its server-side id."""
+        if isinstance(checkpoint, Checkpoint):
+            if not checkpoint.id:
+                raise ValueError("Checkpoint object has no id")
+            return checkpoint.id
+        reference = checkpoint.strip()
+        if not reference:
+            raise ValueError("checkpoint reference must not be empty")
+        if not reference.startswith("weaver://"):
+            return reference  # already a checkpoint id
+        owner = parse_model_id_from_weaver_path(reference)
+        if owner and owner != self.model_id:
+            raise ValueError(
+                f"Checkpoint path {reference!r} belongs to model {owner}, "
+                f"but this client trains model {self.model_id}"
+            )
+        for existing in await self.list_checkpoints():
+            if existing.path == reference:
+                return existing.id
+        raise ValueError(
+            f"No checkpoint with path {reference!r} found for model "
+            f"{self.model_id}; pass a Checkpoint from save_state() or "
+            "list_checkpoints()"
         )
 
     async def terminate(self, instance_types: list[str] | None = None) -> Dict[str, Any]:

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -24,7 +24,14 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
+from ._artifacts import (
+    DEFAULT_EXPORT_TTL_SECONDS,
+    is_artifact_payload,
+    parse_download_target,
+    resolve_checkpoint_id_from_listing,
+)
 from ._http import WeaverAPIError
+from .operations import build_operation_handle
 from .service_client import ServiceClient
 
 console = Console()
@@ -683,6 +690,131 @@ def checkpoint_set_ttl_cmd(  # pylint: disable=too-many-positional-arguments
                 console.print(f"[green]TTL set to {seconds}s for checkpoint:[/green] {path}")
     except Exception as e:
         handle_error(e)
+
+
+def _resolve_cli_checkpoint_id(client: ServiceClient, target: str) -> str:
+    """Resolve a ``weaver://`` checkpoint URI (or raw id) to a checkpoint id."""
+    if not target.startswith("weaver://"):
+        return target
+    parsed = parse_download_target(target)
+    listing = client.http.get(f"/api/v1/models/{parsed.model_id}/checkpoints")
+    items = (listing or {}).get("items", []) if isinstance(listing, dict) else []
+    checkpoint_id = resolve_checkpoint_id_from_listing(items, parsed.checkpoint_path or "")
+    if checkpoint_id is None:
+        raise ValueError(
+            f"No checkpoint with path {parsed.checkpoint_path!r} found for "
+            f"model {parsed.model_id}"
+        )
+    return checkpoint_id
+
+
+@checkpoint.command("export")
+@click.argument("target")
+@click.option(
+    "--merge-adapter",
+    is_flag=True,
+    help="Merge a LoRA adapter into the base model (exports a full HF model)",
+)
+@click.option(
+    "--ttl",
+    "ttl_seconds",
+    type=int,
+    default=DEFAULT_EXPORT_TTL_SECONDS,
+    show_default=True,
+    help="Artifact TTL in seconds",
+)
+@click.option("--force", is_flag=True, help="Re-export even if a completed artifact exists")
+@click.option("--no-wait", is_flag=True, help="Enqueue the export and exit without waiting")
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def checkpoint_export_cmd(  # pylint: disable=too-many-positional-arguments
+    target: str,
+    merge_adapter: bool,
+    ttl_seconds: int,
+    force: bool,
+    no_wait: bool,
+    base_url: Optional[str],
+    api_key: Optional[str],
+):
+    """Export a checkpoint to HuggingFace format.
+
+    TARGET is a checkpoint weaver:// URI or a checkpoint id. The export
+    produces a downloadable artifact (full HF model for full fine-tuning,
+    HF PEFT adapter for LoRA); fetch it with `weaver checkpoint download`.
+    """
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        checkpoint_id = _resolve_cli_checkpoint_id(client, target)
+        body = {
+            "format": "huggingface",
+            "merge_adapter": merge_adapter,
+            "ttl_seconds": ttl_seconds,
+            "force": force,
+        }
+        response = client.http.post(
+            f"/api/v1/checkpoints/{checkpoint_id}/export", json=body, max_retries=1
+        )
+        # A completed idempotent hit answers with the artifact itself instead
+        # of an operation envelope.
+        if is_artifact_payload(response):
+            console.print("[green]Export already completed:[/green]")
+            format_json_output(response)
+            return
+        handle = build_operation_handle(client.http, response if isinstance(response, dict) else {})
+        if no_wait:
+            console.print(f"[green]Export enqueued.[/green] Operation ID: {handle.operation_id}")
+            return
+        console.print(f"Waiting for export operation {handle.operation_id}...")
+        result = handle.result()
+        console.print("[green]Export completed:[/green]")
+        format_json_output(result)
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+@checkpoint.command("download")
+@click.argument("uri")
+@click.option(
+    "--output",
+    "-o",
+    "output_dir",
+    required=True,
+    type=click.Path(file_okay=False),
+    help="Directory to download the files into",
+)
+@click.option(
+    "--kind",
+    type=click.Choice(["hf_model", "hf_adapter"]),
+    default=None,
+    help="Artifact kind to select when the checkpoint has several",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def checkpoint_download_cmd(  # pylint: disable=too-many-positional-arguments
+    uri: str,
+    output_dir: str,
+    kind: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+):
+    """Download exported HF weights to a local directory.
+
+    URI is an artifact weaver:// URI (…/artifacts/{kind}), a checkpoint
+    weaver:// URI, or an artifact id. Requires a completed export — run
+    `weaver checkpoint export` first.
+    """
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        dest = client.download_weights(uri, output_dir, kind=kind)
+        console.print(f"[green]Downloaded weights to:[/green] {dest}")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
 
 
 if __name__ == "__main__":

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -20,14 +20,37 @@ import atexit
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
+
+import httpx
 
 from . import __version__
-from ._http import APIClient
+from ._artifacts import (
+    ARTIFACT_KINDS,
+    DOWNLOAD_MAX_TRANSPORT_RETRIES,
+    DOWNLOAD_MAX_URL_REFRESHES,
+    ArtifactFile,
+    check_downloaded_file,
+    descriptor_files,
+    is_file_already_complete,
+    parse_download_target,
+    resolve_checkpoint_id_from_listing,
+    select_artifact_payload,
+)
+from ._http import (
+    APIClient,
+    DownloadURLExpiredError,
+    build_download_client,
+    compute_retry_delay,
+    stream_download_to_file,
+)
 from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import OperationHandle, build_operation_handle
 from .types import LoraConfig
+from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
     from .sampling_client import SamplingClient
@@ -739,3 +762,162 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             Dictionary with model details
         """
         return self.http.get(f"/api/v1/models/{model_id}")  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # HF weights download
+    # ------------------------------------------------------------------
+
+    def download_weights(
+        self,
+        target: str | WeightsArtifact,
+        dest: str | Path,
+        *,
+        kind: str | None = None,
+        verify: bool = True,
+        max_concurrency: int = 4,
+    ) -> Path:
+        """Download an exported HF weights artifact to a local directory.
+
+        Fetches the artifact's download descriptor and streams every file to
+        *dest* in parallel. Each file is written atomically (``.part`` then
+        rename), resumed with HTTP Range requests on transport errors, and
+        re-fetched with fresh presigned URLs when one expires. Downloads never
+        trigger a conversion implicitly: if no completed artifact exists, run
+        :meth:`~weaver.training_client.TrainingClient.export_weights` first.
+
+        Args:
+            target: What to download — a
+                :class:`~weaver.types.WeightsArtifact`, an artifact
+                ``weaver://.../artifacts/{kind}`` URI, a checkpoint
+                ``weaver://`` URI (its single completed artifact is chosen),
+                or a raw artifact id.
+            dest: Directory the files are written into (created if missing).
+            kind: Artifact kind (``"hf_model"`` or ``"hf_adapter"``) to select
+                when *target* is a checkpoint URI with several artifacts.
+            verify: If True (default), verify each file's sha256 against the
+                download manifest.
+            max_concurrency: Maximum number of files downloaded in parallel.
+
+        Returns:
+            The destination directory as a :class:`~pathlib.Path`.
+
+        Raises:
+            ValueError: On an unresolvable target, kind conflict, or
+                ambiguous artifact selection.
+            RuntimeError: When no completed artifact exists, or on a
+                size/sha256 mismatch.
+        """
+        if kind is not None and kind not in ARTIFACT_KINDS:
+            raise ValueError(f"kind must be one of {ARTIFACT_KINDS}, got {kind!r}")
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be >= 1")
+        artifact_id = self._resolve_weights_artifact_id(target, kind)
+        dest_dir = Path(dest).expanduser()
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        descriptor_path = f"/api/v1/artifacts/{artifact_id}/download"
+        files = descriptor_files(self.http.get(descriptor_path))
+        urls = {entry.name: entry.url for entry in files}
+        urls_lock = threading.Lock()
+
+        def current_url(name: str) -> str:
+            with urls_lock:
+                return urls[name]
+
+        def refresh_url(name: str) -> str:
+            # Presigned URLs live ~15 minutes; re-fetching the descriptor is
+            # idempotent and cheap, and refreshes every pending file at once.
+            with urls_lock:
+                for entry in descriptor_files(self.http.get(descriptor_path)):
+                    urls[entry.name] = entry.url
+                return urls[name]
+
+        workers = max(1, min(max_concurrency, len(files)))
+        with build_download_client() as download_client:
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                futures = [
+                    pool.submit(
+                        self._download_weights_file,
+                        download_client,
+                        entry,
+                        dest_dir=dest_dir,
+                        verify=verify,
+                        current_url=current_url,
+                        refresh_url=refresh_url,
+                    )
+                    for entry in files
+                ]
+                for future in futures:
+                    future.result()
+        return dest_dir
+
+    def _resolve_weights_artifact_id(self, target: str | WeightsArtifact, kind: str | None) -> str:
+        """Resolve a download target to a concrete artifact id."""
+        if isinstance(target, WeightsArtifact):
+            if not target.id:
+                raise ValueError("WeightsArtifact has no id")
+            return target.id
+        parsed = parse_download_target(target)
+        if parsed.artifact_id:
+            return parsed.artifact_id
+        if parsed.kind and kind and parsed.kind != kind:
+            raise ValueError(f"kind={kind!r} conflicts with the artifact URI kind {parsed.kind!r}")
+        effective_kind = parsed.kind or kind
+        listing = self.http.get(f"/api/v1/models/{parsed.model_id}/checkpoints")
+        items = (listing or {}).get("items", []) if isinstance(listing, dict) else []
+        checkpoint_id = resolve_checkpoint_id_from_listing(items, parsed.checkpoint_path or "")
+        if checkpoint_id is None:
+            raise ValueError(
+                f"No checkpoint with path {parsed.checkpoint_path!r} found for "
+                f"model {parsed.model_id}"
+            )
+        artifacts = self.http.get(f"/api/v1/checkpoints/{checkpoint_id}/artifacts")
+        artifact_items = (artifacts or {}).get("items", []) if isinstance(artifacts, dict) else []
+        selected = select_artifact_payload(artifact_items, effective_kind, context=str(target))
+        return extract_id(selected)
+
+    def _download_weights_file(
+        self,
+        download_client: httpx.Client,
+        entry: ArtifactFile,
+        *,
+        dest_dir: Path,
+        verify: bool,
+        current_url: Callable[[str], str],
+        refresh_url: Callable[[str], str],
+    ) -> None:
+        """Download one manifest file with resume, URL refresh, and verification."""
+        final_path = dest_dir / entry.name
+        final_path.parent.mkdir(parents=True, exist_ok=True)
+        if is_file_already_complete(final_path, entry, verify=verify):
+            return
+        part_path = final_path.with_name(final_path.name + ".part")
+        url = current_url(entry.name)
+        url_refreshes = 0
+        transport_retries = 0
+        while True:
+            resume_from = part_path.stat().st_size if part_path.exists() else 0
+            if entry.size is not None and resume_from > entry.size:
+                # Longer than the manifest says it should be: poisoned partial.
+                part_path.unlink()
+                resume_from = 0
+            try:
+                stream_download_to_file(
+                    url, part_path, client=download_client, resume_from=resume_from
+                )
+                break
+            except DownloadURLExpiredError:
+                url_refreshes += 1
+                if url_refreshes > DOWNLOAD_MAX_URL_REFRESHES:
+                    raise
+                url = refresh_url(entry.name)
+            except (httpx.TransportError, OSError):
+                # GETs are idempotent and the .part keeps its bytes, so retry
+                # with a Range resume instead of restarting the shard.
+                transport_retries += 1
+                if transport_retries > DOWNLOAD_MAX_TRANSPORT_RETRIES:
+                    raise
+                time.sleep(compute_retry_delay(transport_retries))
+        check_downloaded_file(part_path, entry, verify=verify)
+        # Atomic publish: readers never observe a half-written file.
+        part_path.replace(final_path)

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
+from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload
 from ._payloads import (
     build_request_metadata,
     build_surrogate_data,
@@ -30,11 +31,13 @@ from ._payloads import (
     parse_logprob_tensors,
     serialize_data,
 )
+from ._sampling_utils import parse_model_id_from_weaver_path
 from ._utils import DEFAULT_SAMPLER_TTL_SECONDS, UNSET, _UnsetType, lookup_case_insensitive
-from .operations import OperationHandle
+from .operations import OperationHandle, build_operation_handle
 from .service_client import ServiceClient
 from .types import AdamParams, Datum
 from .types.checkpoint import Checkpoint
+from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -686,6 +689,128 @@ class TrainingClient:
         return self._service.http.patch(
             f"/api/v1/models/{self.model_id}/checkpoints/ttl",
             json=body,
+        )
+
+    # ------------------------------------------------------------------
+    # HF weights export
+    # ------------------------------------------------------------------
+
+    @overload
+    def export_weights(
+        self,
+        *,
+        checkpoint: str | Checkpoint | None = None,
+        merge_adapter: bool = False,
+        ttl_seconds: int | None = DEFAULT_EXPORT_TTL_SECONDS,
+        force: bool = False,
+        wait: Literal[True] = True,
+    ) -> WeightsArtifact: ...
+
+    @overload
+    def export_weights(
+        self,
+        *,
+        checkpoint: str | Checkpoint | None = None,
+        merge_adapter: bool = False,
+        ttl_seconds: int | None = DEFAULT_EXPORT_TTL_SECONDS,
+        force: bool = False,
+        wait: Literal[False],
+    ) -> WeightsArtifact | OperationHandle: ...
+
+    def export_weights(
+        self,
+        *,
+        checkpoint: str | Checkpoint | None = None,
+        merge_adapter: bool = False,
+        ttl_seconds: int | None = DEFAULT_EXPORT_TTL_SECONDS,
+        force: bool = False,
+        wait: bool = True,
+    ) -> WeightsArtifact | OperationHandle:
+        """Export model weights in HuggingFace format.
+
+        The server converts the checkpoint's native DCP weights into a
+        HuggingFace directory (full model for full fine-tuning, PEFT adapter
+        for LoRA) and stores it as a downloadable artifact. Download it with
+        :meth:`~weaver.service_client.ServiceClient.download_weights`.
+
+        Args:
+            checkpoint: Which checkpoint to export. ``None`` (default) saves
+                the current weights and exports them in one step. Accepts a
+                :class:`~weaver.types.Checkpoint`, a ``weaver://`` checkpoint
+                path (resolved via :meth:`list_checkpoints`), or a raw
+                checkpoint id.
+            merge_adapter: For LoRA models, merge the adapter into the base
+                model and export a full HF model instead of a PEFT adapter.
+                The server rejects it for full fine-tuning models.
+            ttl_seconds: Artifact time-to-live in seconds. Defaults to 7 days;
+                pass ``None`` to follow the source checkpoint's retention.
+            force: Re-export even when a completed artifact of the same kind
+                already exists (the old artifact is soft-deleted). Only
+                meaningful with an explicit *checkpoint*; ignored for the
+                one-step export, which always creates a fresh checkpoint.
+            wait: If True (default), blocks until the export completes and
+                returns a :class:`~weaver.types.WeightsArtifact`.
+
+        Returns:
+            A :class:`~weaver.types.WeightsArtifact` when *wait* is True.
+            When *wait* is False, an :class:`OperationHandle` — unless the
+            server answers an idempotent completed hit, in which case the
+            finished :class:`~weaver.types.WeightsArtifact` is returned
+            immediately.
+
+        Raises:
+            ValueError: If a ``weaver://`` *checkpoint* path cannot be
+                resolved to a checkpoint of this model.
+        """
+        body: Dict[str, Any] = {
+            "format": "huggingface",
+            "merge_adapter": merge_adapter,
+            "ttl_seconds": ttl_seconds,
+        }
+        if checkpoint is None:
+            path = f"/api/v1/models/{self.model_id}/export-hf"
+        else:
+            checkpoint_id = self._resolve_checkpoint_id(checkpoint)
+            body["force"] = force
+            path = f"/api/v1/checkpoints/{checkpoint_id}/export"
+        # max_retries=1: exports are non-idempotent POSTs (see enqueue_operation).
+        response = self._service.http.post(path, json=body, max_retries=1)
+        # A completed idempotent hit answers with the artifact itself instead
+        # of an operation envelope; return it directly even when wait=False.
+        if is_artifact_payload(response):
+            return WeightsArtifact.from_payload(response)
+        handle = build_operation_handle(
+            self._service.http, response if isinstance(response, dict) else {}
+        )
+        if not wait:
+            return handle
+        result = handle.result()
+        return WeightsArtifact.from_payload(result if isinstance(result, dict) else {})
+
+    def _resolve_checkpoint_id(self, checkpoint: str | Checkpoint) -> str:
+        """Resolve a checkpoint reference to its server-side id."""
+        if isinstance(checkpoint, Checkpoint):
+            if not checkpoint.id:
+                raise ValueError("Checkpoint object has no id")
+            return checkpoint.id
+        reference = checkpoint.strip()
+        if not reference:
+            raise ValueError("checkpoint reference must not be empty")
+        if not reference.startswith("weaver://"):
+            return reference  # already a checkpoint id
+        owner = parse_model_id_from_weaver_path(reference)
+        if owner and owner != self.model_id:
+            raise ValueError(
+                f"Checkpoint path {reference!r} belongs to model {owner}, "
+                f"but this client trains model {self.model_id}"
+            )
+        for existing in self.list_checkpoints():
+            if existing.path == reference:
+                return existing.id
+        raise ValueError(
+            f"No checkpoint with path {reference!r} found for model "
+            f"{self.model_id}; pass a Checkpoint from save_state() or "
+            "list_checkpoints()"
         )
 
     def terminate(self, instance_types: list[str] | None = None) -> Dict[str, Any]:

--- a/weaver/types/__init__.py
+++ b/weaver/types/__init__.py
@@ -50,6 +50,7 @@ from .router_replay import (
 from .sampling import SamplingParams
 from .sampling_control import PauseMode, coerce_pause_mode
 from .tensor import TensorData
+from .weights_artifact import WeightsArtifact
 
 # Public API only. Router-replay / payload-ref symbols are imported above for
 # internal consumers (NexRL, weaver-trainer) but intentionally omitted here so
@@ -65,5 +66,6 @@ __all__ = [
     "PauseMode",
     "SamplingParams",
     "TensorData",
+    "WeightsArtifact",
     "coerce_pause_mode",
 ]

--- a/weaver/types/weights_artifact.py
+++ b/weaver/types/weights_artifact.py
@@ -1,0 +1,105 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WeightsArtifact type for HuggingFace weights export management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WeightsArtifact:
+    """Represents an exported HuggingFace-format weights artifact.
+
+    An artifact is produced from a checkpoint by
+    :meth:`~weaver.training_client.TrainingClient.export_weights` and lives in
+    object storage independently of its source checkpoint (deleting or
+    expiring the checkpoint does not cascade to the artifact).
+
+    Attributes:
+        id: Unique artifact identifier (UUID, server-generated).
+        checkpoint_id: Identifier of the source checkpoint.
+        model_id: Identifier of the model that produced the checkpoint.
+        kind: ``"hf_model"`` (full HF model directory) or ``"hf_adapter"``
+            (HF PEFT adapter directory).
+        status: Current status (``"pending"``, ``"completed"``, ``"error"``,
+            or ``"deleted"``).
+        uri: Server-generated artifact URI
+            (``weaver://{model_id}/checkpoints/{name}/artifacts/{kind}``).
+            Read-only — accepted by
+            :meth:`~weaver.service_client.ServiceClient.download_weights`.
+        size_bytes: Total size of the exported files, or ``None`` if unknown.
+        manifest: Export manifest (file names, sizes, sha256 digests), or
+            ``None`` while the export is still pending.
+        error: Failure detail when ``status == "error"``.
+        ttl_seconds: Time-to-live in seconds, or ``None`` to follow the
+            source checkpoint's retention.
+        expires_at: ISO 8601 expiration timestamp (server-generated), or
+            ``None`` if permanent.
+        created_at: ISO 8601 creation timestamp (server-generated).
+        updated_at: ISO 8601 last-update timestamp (server-generated).
+    """
+
+    id: str
+    checkpoint_id: str | None = None
+    model_id: str | None = None
+    kind: str = "hf_model"
+    status: str | None = None
+    uri: str | None = None
+    size_bytes: int | None = None
+    manifest: dict[str, Any] | None = None
+    error: str | None = None
+    ttl_seconds: int | None = None
+    expires_at: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> WeightsArtifact:
+        """Create a WeightsArtifact from a server response dict.
+
+        Args:
+            payload: Raw JSON dict from the Weaver API.
+
+        Returns:
+            A ``WeightsArtifact`` instance.
+        """
+        from .._utils import lookup_case_insensitive
+
+        manifest = lookup_case_insensitive(payload, "manifest")
+        return cls(
+            id=str(lookup_case_insensitive(payload, "id") or ""),
+            checkpoint_id=_str_or_none(lookup_case_insensitive(payload, "checkpoint_id")),
+            model_id=_str_or_none(lookup_case_insensitive(payload, "model_id")),
+            kind=str(lookup_case_insensitive(payload, "kind") or "hf_model"),
+            status=_str_or_none(lookup_case_insensitive(payload, "status")),
+            uri=_str_or_none(lookup_case_insensitive(payload, "uri")),
+            size_bytes=_int_or_none(lookup_case_insensitive(payload, "size_bytes")),
+            manifest=manifest if isinstance(manifest, dict) else None,
+            error=_str_or_none(lookup_case_insensitive(payload, "error")),
+            ttl_seconds=_int_or_none(lookup_case_insensitive(payload, "ttl_seconds")),
+            expires_at=_str_or_none(lookup_case_insensitive(payload, "expires_at")),
+            created_at=_str_or_none(lookup_case_insensitive(payload, "created_at")),
+            updated_at=_str_or_none(lookup_case_insensitive(payload, "updated_at")),
+        )
+
+
+def _str_or_none(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _int_or_none(value: Any) -> int | None:
+    return int(value) if value is not None else None


### PR DESCRIPTION
## Why

Checkpoints are stored in the trainer's native distributed format. Every checkpoint API in the SDK returned only a `weaver://` URI, and the HTTP layer spoke JSON exclusively — there was no way for a user to obtain HuggingFace-format weights, or any bytes at all. This adds both halves: converting a checkpoint into an HF directory, and downloading it.

Implements the SDK slice of `weaver-hf-export-design.md` (P1).

## What

**`TrainingClient.export_weights(*, checkpoint=None, merge_adapter=False, ttl_seconds=604800, force=False, wait=True) -> WeightsArtifact | OperationHandle`**

- `checkpoint=None` drives the one-step endpoint (`POST /models/{id}/export-hf`: save current weights, then convert); an explicit checkpoint targets `POST /checkpoints/{id}/export`.
- Accepts a `Checkpoint`, a `weaver://` path (resolved via `list_checkpoints`, and rejected if it belongs to another model), or a raw id.
- A completed idempotent hit answers with the artifact JSON instead of an operation envelope. The response is discriminated on `kind`, so that artifact is returned directly — including under `wait=False`, where there is no operation left to hand back.

**`ServiceClient.download_weights(target, dest, *, kind=None, verify=True, max_concurrency=4) -> Path`**

- Resolves an artifact object / artifact URI / checkpoint URI / raw id, fetches the download descriptor, and streams every file in parallel.
- **Never triggers an export.** A full-model conversion is minutes of compute and tens of GB of storage; a "download" that quietly starts one is a trap. With no completed artifact it raises and names the call to make first.
- `.part` file renamed only after verification, so no reader observes a torn shard; interrupted files resume with a Range request rather than restarting a multi-GB download.
- Expired presigned URL (401/403) is a refresh signal, not a failure: re-fetch the descriptor (idempotent, refreshes every pending file at once) and retry, bounded.
- sha256 computed over what actually landed on disk, which also catches short writes and torn resumes.

**New:** `WeightsArtifact` type (exported from `weaver`), `weaver checkpoint export`, `weaver checkpoint download`, README sections (EN + ZH).

## Security notes

- Presigned URLs are self-authorizing URLs on an external host, so they are fetched with a **bare** client carrying no `X-WEAVER-API-KEY` — the credential must never leave the Weaver API. Asserted on every request in the tests.
- Descriptor file names are server-controlled input used to build local paths; absolute names and `..` segments are rejected before anything is opened.

## Async compatibility

Per `.claude/rules/async-compatibility.md`, every pure decision — target parsing, artifact selection, descriptor validation, hashing, resume policy — lives in `weaver/_artifacts.py`, so both stacks build identical requests and reach identical verdicts. Only the IO differs. The async path keeps the loop free: hashing and existing-file checks are multi-GB blocking work and run via `asyncio.to_thread`, and the gather drains every task before the client closes so no writer is orphaned. Async twins exist for `export_weights`, `download_weights`, and the streaming HTTP helper.

## Testing

`tests/test_hf_export.py` + `tests/test_hf_download.py`, 71 new tests covering both stacks and the CLI: request shape for both endpoints, checkpoint resolution and its failure modes, the idempotent-hit branch, `wait=False`, descriptor validation and path-traversal rejection, parallel download, Range resume from an existing `.part`, oversized-`.part` discard, transport-error retry, URL-expiry refresh, sha256 mismatch (and `verify=False`), rerun skip, ambiguous-artifact and kind-conflict errors, and the no-API-key-on-presigned-URLs invariant.

```
pytest tests/          329 passed
black --check          clean
isort --check-only     clean
mypy weaver/           Success: no issues found in 31 source files
pylint weaver/         9.68/10 (identical to origin/main baseline)
license headers        clean
```
