### PR TITLE
feat(deployments): deploy checkpoints to NorthGate from the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,46 @@ Three things to know:
 Downloads run in parallel, resume interrupted files, refresh expired URLs, and verify each
 file's sha256 before publishing it. Both methods have `Async*` twins.
 
+### Deploying a checkpoint
+
+`deploy_checkpoint()` publishes a checkpoint as a public, OpenAI-compatible endpoint: the
+server converts it to HuggingFace format, launches a dedicated inference workload, and
+registers that workload on the NorthGate gateway under the name you choose.
+
+```python
+deployment = training_client.deploy_checkpoint(ckpt, name="my-chat-model")
+print(deployment.endpoint)          # OpenAI-compatible URL
+
+service.list_deployments()
+service.get_deployment(deployment.id)
+service.delete_deployment(deployment.id)
+```
+
+```bash
+weaver deployment create weaver://<model>/checkpoints/step-42 --name my-chat-model
+weaver deployment list
+weaver deployment get <deployment-id>
+weaver deployment delete <deployment-id>
+```
+
+Four things to know:
+
+- **Publishing is permission-gated and off by default.** The `deployment.publish` capability
+  is granted by principal origin, not by Weaver role: an SSO session always qualifies, an API
+  key only when it was minted under an IAM `biz_code` on the server's allowlist, and a service
+  credential never. A server with the feature switched off answers 503. Both cases raise a
+  `WeaverAPIError` that names what has to change. Listing, reading and deleting your own
+  deployments need no capability — whoever published an endpoint can always take it down.
+- **A deployment is independent and long-lived.** It does not share the training inference
+  instance, it outlives the training session, and it holds its GPUs until you delete it. It
+  also pins the source checkpoint and the exported artifact against garbage collection.
+- **The name is global and must be valid everywhere it lands.** It is the served model name,
+  the gateway's `model_name`, and a Kubernetes label at once: at most 63 characters of
+  letters, digits, `.`, `-` and `_`, starting and ending alphanumerically. `overwrite=True`
+  replaces an existing *gateway* registration; it does not free a name Weaver already uses.
+- **It takes tens of minutes**, dominated by the conversion. Pass `wait=False` to get an
+  `OperationHandle` instead of blocking. Every method has an `Async*` twin.
+
 ## Ecosystem
 
 [NexRL](https://github.com/nex-agi/NexRL) is the companion RL training framework.

--- a/README_zh.md
+++ b/README_zh.md
@@ -101,6 +101,33 @@ weaver checkpoint download weaver://<model>/checkpoints/step-42 -o ./hf-weights
 
 下载是并行的，支持断点续传、过期 URL 自动刷新，并在落盘前校验每个文件的 sha256。两个方法都有对应的 `Async*` 版本。
 
+### 部署 checkpoint
+
+`deploy_checkpoint()` 把一个 checkpoint 上架成公开的 OpenAI 兼容端点：服务端会把它转换成 HuggingFace 格式，拉起一个独立的推理负载，再用你指定的名字注册到 NorthGate 网关。
+
+```python
+deployment = training_client.deploy_checkpoint(ckpt, name="my-chat-model")
+print(deployment.endpoint)          # OpenAI 兼容的 URL
+
+service.list_deployments()
+service.get_deployment(deployment.id)
+service.delete_deployment(deployment.id)
+```
+
+```bash
+weaver deployment create weaver://<model>/checkpoints/step-42 --name my-chat-model
+weaver deployment list
+weaver deployment get <deployment-id>
+weaver deployment delete <deployment-id>
+```
+
+需要知道四件事：
+
+- **上架有权限门，且默认关闭。** `deployment.publish` 这个能力不按 Weaver 角色授予，而是按主体来源：SSO 会话天然满足；API key 只有在铸造时使用的 IAM `biz_code` 位于服务端白名单里才满足；service credential 一律不满足。功能未开启的服务端会返回 503。两种情况都会抛出 `WeaverAPIError`，并在报错信息里说明该改什么。列出、查看、删除自己的部署不需要这个能力——谁上架的端点，谁始终可以下架。
+- **部署是独立且长期存在的。** 它不复用训练用的推理实例，生命周期长于训练会话，在你删除它之前会一直占着 GPU；同时它会钉住源 checkpoint 和导出产物，使其不被回收。
+- **名字是全局的，且必须在所有下游都合法。** 它同时是 served model name、网关的 `model_name` 和 Kubernetes label：最长 63 个字符，只能包含字母、数字、`.`、`-`、`_`，且首尾必须是字母或数字。`overwrite=True` 只会替换网关上的同名注册，不会释放 Weaver 侧已被占用的名字。
+- **整个过程需要几十分钟**，主要耗时在转换。传 `wait=False` 可以拿到 `OperationHandle` 而不阻塞。所有方法都有对应的 `Async*` 版本。
+
 ## 生态
 
 [NexRL](https://github.com/nex-agi/NexRL) 是配套的 RL 训练框架。在其 **training-service** 模式下，NexRL 负责编排完整的 RL 流程（rollout、轨迹收集、策略更新），Weaver 提供底层的训练和推理服务。

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1,0 +1,843 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for checkpoint deployments: Deployment type, clients, and CLI."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from weaver._deployments import (
+    build_create_deployment_body,
+    deployment_error_guidance,
+    deployment_items,
+    next_page_offset,
+    translate_deployment_error,
+    validate_deployment_name,
+)
+from weaver._http import WeaverAPIError
+from weaver.async_service_client import AsyncServiceClient
+from weaver.async_training_client import AsyncTrainingClient
+from weaver.cli import cli
+from weaver.operations import AsyncOperationHandle, OperationHandle
+from weaver.service_client import ServiceClient
+from weaver.training_client import TrainingClient
+from weaver.types.checkpoint import Checkpoint
+from weaver.types.deployment import Deployment
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Mirrors DeploymentService.PublicView in weaver-server
+# (internal/services/deployments.go): a closed allowlist that deliberately
+# omits provisioner metadata and the native workload id.
+DEPLOYMENT_PAYLOAD: Dict[str, Any] = {
+    "id": "dep-1",
+    "checkpoint_id": "ckpt-1",
+    "artifact_id": "art-1",
+    "model_id": "mdl-123",
+    "name": "my-chat-model",
+    "status": "running",
+    "endpoint": "https://northgate.example.com/v1",
+    "northgate_model_id": "ng-77",
+    "gpu_type": "H800",
+    "replicas": 2,
+    "gpus_per_replica": 4,
+    "error": None,
+    "created_at": "2026-08-12T00:00:00Z",
+    "updated_at": "2026-08-12T00:30:00Z",
+}
+
+
+def _make_training_client() -> TrainingClient:
+    """Create a TrainingClient with a mocked ServiceClient."""
+    service = MagicMock()
+    service.next_operation_seq.return_value = 1
+    return TrainingClient(
+        service=service,
+        model_id="mdl-123",
+        base_model="Qwen/Qwen3-8B",
+        session_id="sess-abc",
+    )
+
+
+def _make_async_training_client() -> AsyncTrainingClient:
+    """Create an AsyncTrainingClient with a mocked AsyncServiceClient."""
+    service = MagicMock()
+    service.next_operation_seq.return_value = 1
+    service.http.post = AsyncMock()
+    service.http.get = AsyncMock()
+    return AsyncTrainingClient(
+        service=service,
+        model_id="mdl-123",
+        base_model="Qwen/Qwen3-8B",
+        session_id="sess-abc",
+    )
+
+
+def _make_service_client() -> ServiceClient:
+    client = ServiceClient(base_url="https://test.example.com", api_key="sk-test")
+    client._http = MagicMock()
+    return client
+
+
+def _make_async_service_client() -> AsyncServiceClient:
+    client = AsyncServiceClient(base_url="https://test.example.com", api_key="sk-test")
+    client._http = MagicMock()
+    client._http.get = AsyncMock()
+    client._http.delete = AsyncMock()
+    return client
+
+
+def _done_operation(response: Dict[str, Any]) -> Dict[str, Any]:
+    return {"id": "op-1", "status": "done", "response": response}
+
+
+def _page(items: list, total: int) -> Dict[str, Any]:
+    return {"items": items, "pagination": {"total_count": total}}
+
+
+def _api_error(status: int, code: str, message: str) -> WeaverAPIError:
+    return WeaverAPIError(status, code=code, message=message, retryable=False)
+
+
+# ---------------------------------------------------------------------------
+# Deployment type
+# ---------------------------------------------------------------------------
+
+
+class TestDeploymentType:
+    def test_from_payload(self):
+        deployment = Deployment.from_payload(DEPLOYMENT_PAYLOAD)
+        assert deployment.id == "dep-1"
+        assert deployment.checkpoint_id == "ckpt-1"
+        assert deployment.artifact_id == "art-1"
+        assert deployment.model_id == "mdl-123"
+        assert deployment.name == "my-chat-model"
+        assert deployment.status == "running"
+        assert deployment.endpoint == "https://northgate.example.com/v1"
+        assert deployment.northgate_model_id == "ng-77"
+        assert deployment.gpu_type == "H800"
+        assert deployment.replicas == 2
+        assert deployment.gpus_per_replica == 4
+        assert deployment.error is None
+        assert deployment.created_at == "2026-08-12T00:00:00Z"
+        assert deployment.updated_at == "2026-08-12T00:30:00Z"
+
+    def test_from_payload_pending_nulls(self):
+        # The server nulls endpoint/artifact/northgate id until they exist.
+        deployment = Deployment.from_payload(
+            {
+                "id": "dep-2",
+                "checkpoint_id": "ckpt-2",
+                "model_id": "mdl-9",
+                "name": "pending-model",
+                "status": "pending",
+                "artifact_id": None,
+                "endpoint": None,
+                "northgate_model_id": None,
+                "gpu_type": None,
+                "replicas": 1,
+                "gpus_per_replica": 0,
+                "error": None,
+            }
+        )
+        assert deployment.status == "pending"
+        assert deployment.artifact_id is None
+        assert deployment.endpoint is None
+        assert deployment.northgate_model_id is None
+        assert deployment.gpu_type is None
+        assert deployment.gpus_per_replica == 0
+
+    def test_from_payload_minimal(self):
+        deployment = Deployment.from_payload({"id": "dep-3"})
+        assert deployment.id == "dep-3"
+        assert deployment.name is None
+        assert deployment.replicas is None
+
+    def test_from_payload_failed_carries_error_code(self):
+        deployment = Deployment.from_payload(
+            {"id": "dep-4", "status": "failed", "error": "provisioning_failed"}
+        )
+        assert deployment.status == "failed"
+        assert deployment.error == "provisioning_failed"
+
+    def test_is_frozen(self):
+        deployment = Deployment(id="dep-1")
+        with pytest.raises(AttributeError):
+            deployment.id = "dep-2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (_deployments)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDeploymentName:
+    @pytest.mark.parametrize(
+        "name",
+        ["a", "my-chat-model", "Model.v1_2", "a" * 63, "qwen3-8b.sft-2026"],
+    )
+    def test_accepts_valid_names(self, name):
+        assert validate_deployment_name(name) == name
+
+    def test_strips_surrounding_whitespace(self):
+        assert validate_deployment_name("  my-model  ") == "my-model"
+
+    @pytest.mark.parametrize(
+        "name,match",
+        [
+            ("", "must not be empty"),
+            ("   ", "must not be empty"),
+            ("a" * 64, "at most 63 characters"),
+            ("-leading", "invalid deployment name"),
+            ("trailing-", "invalid deployment name"),
+            ("has space", "invalid deployment name"),
+            ("has/slash", "invalid deployment name"),
+            ("has:colon", "invalid deployment name"),
+        ],
+    )
+    def test_rejects_invalid_names(self, name, match):
+        with pytest.raises(ValueError, match=match):
+            validate_deployment_name(name)
+
+
+class TestBuildCreateDeploymentBody:
+    def test_defaults_omit_unset_sizing(self):
+        body = build_create_deployment_body(name="my-model")
+        assert body == {"name": "my-model", "overwrite": False, "replicas": 1}
+
+    def test_all_fields(self):
+        body = build_create_deployment_body(
+            name="my-model",
+            gpu_type="H800",
+            replicas=3,
+            gpus_per_replica=8,
+            overwrite=True,
+        )
+        assert body == {
+            "name": "my-model",
+            "overwrite": True,
+            "replicas": 3,
+            "gpus_per_replica": 8,
+            "gpu_type": "H800",
+        }
+
+    @pytest.mark.parametrize("replicas", [0, -1, 9])
+    def test_rejects_out_of_range_replicas(self, replicas):
+        with pytest.raises(ValueError, match="replicas must be between 1 and 8"):
+            build_create_deployment_body(name="m", replicas=replicas)
+
+    @pytest.mark.parametrize("gpus", [0, -1, 17])
+    def test_rejects_out_of_range_gpus_per_replica(self, gpus):
+        with pytest.raises(ValueError, match="gpus_per_replica must be between 1 and 16"):
+            build_create_deployment_body(name="m", gpus_per_replica=gpus)
+
+    def test_rejects_blank_gpu_type(self):
+        with pytest.raises(ValueError, match="gpu_type must not be blank"):
+            build_create_deployment_body(name="m", gpu_type="  ")
+
+    def test_invalid_name_propagates(self):
+        with pytest.raises(ValueError, match="invalid deployment name"):
+            build_create_deployment_body(name="bad name")
+
+
+class TestListingHelpers:
+    def test_deployment_items_filters_non_dicts(self):
+        assert deployment_items({"items": [{"id": "a"}, "junk", None]}) == [{"id": "a"}]
+
+    def test_deployment_items_on_garbage(self):
+        assert deployment_items(None) == []
+        assert deployment_items({"items": "nope"}) == []
+
+    def test_next_page_offset_advances_until_total(self):
+        assert next_page_offset(_page([{}] * 100, 250), 0, 100) == 100
+        assert next_page_offset(_page([{}] * 100, 250), 100, 100) == 200
+        assert next_page_offset(_page([{}] * 50, 250), 200, 50) is None
+
+    def test_next_page_offset_stops_on_empty_page(self):
+        assert next_page_offset(_page([], 250), 0, 0) is None
+
+    def test_next_page_offset_stops_without_usable_total(self):
+        assert next_page_offset({"items": [{}]}, 0, 1) is None
+        assert next_page_offset(_page([{}], "many"), 0, 1) is None
+
+
+class TestDeploymentErrorTranslation:
+    def test_permission_denied_names_the_gate(self):
+        error = _api_error(403, "forbidden", "insufficient capability")
+        translated = translate_deployment_error(error)
+        assert translated.status_code == 403
+        assert translated.code == "forbidden"
+        assert "deployment.publish" in translated.message
+        assert "allowed_biz_codes" in translated.message
+        assert "SSO" in translated.message
+
+    def test_feature_disabled_names_the_flag(self):
+        error = _api_error(
+            503, "deployment_unavailable", "checkpoint deployment is not enabled on this server"
+        )
+        translated = translate_deployment_error(error)
+        assert translated.status_code == 503
+        assert "administrator" in translated.message
+        assert "deny-by-default" in translated.message
+
+    def test_name_taken_explains_overwrite_does_not_help(self):
+        translated = translate_deployment_error(
+            _api_error(409, "name_taken", "deployment name is already in use")
+        )
+        assert "overwrite=True only replaces a registration on the gateway" in translated.message
+
+    def test_quota_points_at_delete(self):
+        translated = translate_deployment_error(
+            _api_error(409, "deployment_limit_reached", "deployment limit reached")
+        )
+        assert "delete_deployment()" in translated.message
+
+    def test_unrelated_forbidden_is_left_alone(self):
+        # The create route also answers 403 for a checkpoint the caller cannot
+        # write to; that is a different problem with different advice.
+        error = _api_error(403, "forbidden", "insufficient access to checkpoint")
+        assert translate_deployment_error(error) is error
+        assert deployment_error_guidance(error) is None
+
+    def test_other_errors_pass_through_unchanged(self):
+        error = _api_error(404, "not_found", "deployment not found")
+        assert translate_deployment_error(error) is error
+
+    def test_structured_fields_survive_translation(self):
+        error = WeaverAPIError(
+            403,
+            code="forbidden",
+            message="insufficient capability",
+            retryable=False,
+            request_id="req-9",
+            details={"hint": "x"},
+        )
+        translated = translate_deployment_error(error)
+        assert translated.request_id == "req-9"
+        assert translated.details == {"hint": "x"}
+        assert translated.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# TrainingClient.deploy_checkpoint (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestDeployCheckpoint:
+    def test_deploy_with_raw_checkpoint_id(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
+
+        deployment = tc.deploy_checkpoint("ckpt-1", name="my-chat-model")
+
+        assert isinstance(deployment, Deployment)
+        assert deployment.id == "dep-1"
+        assert deployment.endpoint == "https://northgate.example.com/v1"
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert args[1]["json"] == {
+            "name": "my-chat-model",
+            "overwrite": False,
+            "replicas": 1,
+        }
+        assert args[1]["max_retries"] == 1
+
+    def test_deploy_with_all_options(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
+
+        tc.deploy_checkpoint(
+            "ckpt-1",
+            name="my-chat-model",
+            gpu_type="H800",
+            replicas=2,
+            gpus_per_replica=4,
+            overwrite=True,
+        )
+
+        assert tc._service.http.post.call_args[1]["json"] == {
+            "name": "my-chat-model",
+            "overwrite": True,
+            "replicas": 2,
+            "gpus_per_replica": 4,
+            "gpu_type": "H800",
+        }
+
+    def test_deploy_with_checkpoint_object(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
+
+        ckpt = Checkpoint(id="ckpt-7", path="weaver://mdl-123/checkpoints/step-5")
+        tc.deploy_checkpoint(ckpt, name="my-chat-model")
+
+        assert tc._service.http.post.call_args[0][0] == "/api/v1/checkpoints/ckpt-7/deployments"
+
+    def test_deploy_resolves_weaver_path(self):
+        tc = _make_training_client()
+        tc._service.http.get.return_value = {
+            "items": [
+                {"id": "ckpt-0", "path": "weaver://mdl-123/checkpoints/step-1"},
+                {"id": "ckpt-1", "path": "weaver://mdl-123/checkpoints/step-5"},
+            ]
+        }
+        tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
+
+        tc.deploy_checkpoint("weaver://mdl-123/checkpoints/step-5", name="my-chat-model")
+
+        tc._service.http.get.assert_called_once_with("/api/v1/models/mdl-123/checkpoints")
+        assert tc._service.http.post.call_args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+
+    def test_deploy_foreign_model_path_raises(self):
+        tc = _make_training_client()
+        with pytest.raises(ValueError, match="belongs to model other"):
+            tc.deploy_checkpoint("weaver://other/checkpoints/step-5", name="my-model")
+        tc._service.http.post.assert_not_called()
+
+    def test_no_wait_returns_operation_handle(self):
+        tc = _make_training_client()
+        tc._service.http.post.return_value = {"id": "op-9", "status": "pending"}
+
+        handle = tc.deploy_checkpoint("ckpt-1", name="my-model", wait=False)
+
+        assert isinstance(handle, OperationHandle)
+        assert handle.operation_id == "op-9"
+
+    def test_invalid_name_fails_before_any_request(self):
+        tc = _make_training_client()
+        with pytest.raises(ValueError, match="invalid deployment name"):
+            tc.deploy_checkpoint("ckpt-1", name="not a valid name")
+        tc._service.http.post.assert_not_called()
+        tc._service.http.get.assert_not_called()
+
+    def test_out_of_range_replicas_fails_before_any_request(self):
+        tc = _make_training_client()
+        with pytest.raises(ValueError, match="replicas must be between 1 and 8"):
+            tc.deploy_checkpoint("ckpt-1", name="my-model", replicas=99)
+        tc._service.http.post.assert_not_called()
+
+    def test_permission_error_is_translated(self):
+        tc = _make_training_client()
+        tc._service.http.post.side_effect = _api_error(403, "forbidden", "insufficient capability")
+
+        with pytest.raises(WeaverAPIError) as excinfo:
+            tc.deploy_checkpoint("ckpt-1", name="my-model")
+
+        assert excinfo.value.status_code == 403
+        assert "deployment.publish" in excinfo.value.message
+
+    def test_feature_disabled_error_is_translated(self):
+        tc = _make_training_client()
+        tc._service.http.post.side_effect = _api_error(
+            503, "deployment_unavailable", "checkpoint deployment is not enabled on this server"
+        )
+
+        with pytest.raises(WeaverAPIError) as excinfo:
+            tc.deploy_checkpoint("ckpt-1", name="my-model")
+
+        assert excinfo.value.code == "deployment_unavailable"
+        assert "administrator" in excinfo.value.message
+
+
+# ---------------------------------------------------------------------------
+# AsyncTrainingClient.deploy_checkpoint (async twin)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncDeployCheckpoint:
+    def test_deploy_with_raw_checkpoint_id(self):
+        tc = _make_async_training_client()
+        tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
+
+        deployment = asyncio.run(tc.deploy_checkpoint("ckpt-1", name="my-chat-model"))
+
+        assert isinstance(deployment, Deployment)
+        assert deployment.id == "dep-1"
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert args[1]["json"] == {"name": "my-chat-model", "overwrite": False, "replicas": 1}
+        assert args[1]["max_retries"] == 1
+
+    def test_deploy_resolves_weaver_path(self):
+        tc = _make_async_training_client()
+        tc._service.http.get.return_value = {
+            "items": [{"id": "ckpt-1", "path": "weaver://mdl-123/checkpoints/step-5"}]
+        }
+        tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
+
+        deployment = asyncio.run(
+            tc.deploy_checkpoint(
+                "weaver://mdl-123/checkpoints/step-5", name="my-model", gpu_type="H800"
+            )
+        )
+
+        assert isinstance(deployment, Deployment)
+        args = tc._service.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert args[1]["json"]["gpu_type"] == "H800"
+
+    def test_no_wait_returns_async_operation_handle(self):
+        tc = _make_async_training_client()
+        tc._service.http.post.return_value = {"id": "op-9", "status": "pending"}
+
+        handle = asyncio.run(tc.deploy_checkpoint("ckpt-1", name="my-model", wait=False))
+
+        assert isinstance(handle, AsyncOperationHandle)
+        assert handle.operation_id == "op-9"
+
+    def test_invalid_name_fails_before_any_request(self):
+        tc = _make_async_training_client()
+        with pytest.raises(ValueError, match="invalid deployment name"):
+            asyncio.run(tc.deploy_checkpoint("ckpt-1", name="bad name"))
+        tc._service.http.post.assert_not_called()
+
+    def test_permission_error_is_translated(self):
+        tc = _make_async_training_client()
+        tc._service.http.post.side_effect = _api_error(403, "forbidden", "insufficient capability")
+
+        with pytest.raises(WeaverAPIError) as excinfo:
+            asyncio.run(tc.deploy_checkpoint("ckpt-1", name="my-model"))
+
+        assert "deployment.publish" in excinfo.value.message
+
+
+# ---------------------------------------------------------------------------
+# ServiceClient deployment reads and teardown (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestServiceClientDeployments:
+    def test_list_deployments(self):
+        client = _make_service_client()
+        client._http.get.return_value = _page([DEPLOYMENT_PAYLOAD], 1)
+
+        deployments = client.list_deployments()
+
+        assert [d.id for d in deployments] == ["dep-1"]
+        assert isinstance(deployments[0], Deployment)
+        client._http.get.assert_called_once_with(
+            "/api/v1/deployments", params={"limit": 100, "offset": 0}
+        )
+
+    def test_list_deployments_walks_every_page(self):
+        client = _make_service_client()
+        first = [dict(DEPLOYMENT_PAYLOAD, id=f"dep-{i}") for i in range(100)]
+        second = [dict(DEPLOYMENT_PAYLOAD, id="dep-100")]
+        client._http.get.side_effect = [_page(first, 101), _page(second, 101)]
+
+        deployments = client.list_deployments()
+
+        assert len(deployments) == 101
+        assert deployments[-1].id == "dep-100"
+        assert client._http.get.call_args_list[1][1]["params"] == {"limit": 100, "offset": 100}
+
+    def test_list_deployments_translates_unavailable(self):
+        client = _make_service_client()
+        client._http.get.side_effect = _api_error(
+            503, "deployment_unavailable", "checkpoint deployment is not enabled on this server"
+        )
+
+        with pytest.raises(WeaverAPIError) as excinfo:
+            client.list_deployments()
+
+        assert "administrator" in excinfo.value.message
+
+    def test_get_deployment(self):
+        client = _make_service_client()
+        client._http.get.return_value = DEPLOYMENT_PAYLOAD
+
+        deployment = client.get_deployment("dep-1")
+
+        assert isinstance(deployment, Deployment)
+        assert deployment.northgate_model_id == "ng-77"
+        client._http.get.assert_called_once_with("/api/v1/deployments/dep-1")
+
+    def test_delete_deployment_waits_and_returns_stopped(self):
+        client = _make_service_client()
+        stopped = dict(DEPLOYMENT_PAYLOAD, status="stopped", endpoint=None)
+        client._http.delete.return_value = _done_operation(stopped)
+
+        deployment = client.delete_deployment("dep-1")
+
+        assert isinstance(deployment, Deployment)
+        assert deployment.status == "stopped"
+        client._http.delete.assert_called_once_with("/api/v1/deployments/dep-1")
+
+    def test_delete_deployment_no_wait_returns_handle(self):
+        client = _make_service_client()
+        client._http.delete.return_value = {"id": "op-5", "status": "pending"}
+
+        handle = client.delete_deployment("dep-1", wait=False)
+
+        assert isinstance(handle, OperationHandle)
+        assert handle.operation_id == "op-5"
+
+    def test_delete_already_stopped_passes_through(self):
+        client = _make_service_client()
+        client._http.delete.side_effect = _api_error(
+            409, "already_stopped", "deployment is already stopped"
+        )
+
+        with pytest.raises(WeaverAPIError) as excinfo:
+            client.delete_deployment("dep-1")
+
+        assert excinfo.value.code == "already_stopped"
+
+
+# ---------------------------------------------------------------------------
+# AsyncServiceClient deployment reads and teardown (async twin)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncServiceClientDeployments:
+    def test_list_deployments(self):
+        client = _make_async_service_client()
+        client._http.get.return_value = _page([DEPLOYMENT_PAYLOAD], 1)
+
+        deployments = asyncio.run(client.list_deployments())
+
+        assert [d.id for d in deployments] == ["dep-1"]
+        client._http.get.assert_called_once_with(
+            "/api/v1/deployments", params={"limit": 100, "offset": 0}
+        )
+
+    def test_list_deployments_walks_every_page(self):
+        client = _make_async_service_client()
+        first = [dict(DEPLOYMENT_PAYLOAD, id=f"dep-{i}") for i in range(100)]
+        client._http.get.side_effect = [
+            _page(first, 101),
+            _page([dict(DEPLOYMENT_PAYLOAD, id="dep-100")], 101),
+        ]
+
+        deployments = asyncio.run(client.list_deployments())
+
+        assert len(deployments) == 101
+        assert deployments[-1].id == "dep-100"
+
+    def test_get_deployment(self):
+        client = _make_async_service_client()
+        client._http.get.return_value = DEPLOYMENT_PAYLOAD
+
+        deployment = asyncio.run(client.get_deployment("dep-1"))
+
+        assert isinstance(deployment, Deployment)
+        client._http.get.assert_called_once_with("/api/v1/deployments/dep-1")
+
+    def test_delete_deployment_waits_and_returns_stopped(self):
+        client = _make_async_service_client()
+        client._http.delete.return_value = _done_operation(
+            dict(DEPLOYMENT_PAYLOAD, status="stopped")
+        )
+
+        deployment = asyncio.run(client.delete_deployment("dep-1"))
+
+        assert deployment.status == "stopped"
+        client._http.delete.assert_called_once_with("/api/v1/deployments/dep-1")
+
+    def test_delete_deployment_no_wait_returns_handle(self):
+        client = _make_async_service_client()
+        client._http.delete.return_value = {"id": "op-5", "status": "pending"}
+
+        handle = asyncio.run(client.delete_deployment("dep-1", wait=False))
+
+        assert isinstance(handle, AsyncOperationHandle)
+        assert handle.operation_id == "op-5"
+
+    def test_permission_error_is_translated(self):
+        client = _make_async_service_client()
+        client._http.get.side_effect = _api_error(
+            503, "deployment_unavailable", "checkpoint deployment is not enabled on this server"
+        )
+
+        with pytest.raises(WeaverAPIError) as excinfo:
+            asyncio.run(client.list_deployments())
+
+        assert "administrator" in excinfo.value.message
+
+
+# ---------------------------------------------------------------------------
+# CLI: weaver deployment
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="clean_env")
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+
+
+class TestDeploymentCLI:
+    def test_create_with_checkpoint_id(self, clean_env):
+        client = MagicMock()
+        client.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli, ["deployment", "create", "ckpt-1", "--name", "my-chat-model"]
+            )
+
+        assert result.exit_code == 0, result.output
+        client.connect.assert_called_once_with(ensure_session=False)
+        args = client.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert args[1]["json"] == {"name": "my-chat-model", "overwrite": False, "replicas": 1}
+        assert args[1]["max_retries"] == 1
+        assert "Deployment ready" in result.output
+        client.close.assert_called_once_with()
+
+    def test_create_resolves_weaver_uri_and_flags(self, clean_env):
+        client = MagicMock()
+        client.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
+        client.http.get.return_value = {
+            "items": [{"id": "ckpt-7", "path": "weaver://mdl-123/checkpoints/step-5"}]
+        }
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "deployment",
+                    "create",
+                    "weaver://mdl-123/checkpoints/step-5",
+                    "--name",
+                    "my-chat-model",
+                    "--gpu-type",
+                    "H800",
+                    "--replicas",
+                    "2",
+                    "--gpus-per-replica",
+                    "4",
+                    "--overwrite",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        client.http.get.assert_called_once_with("/api/v1/models/mdl-123/checkpoints")
+        args = client.http.post.call_args
+        assert args[0][0] == "/api/v1/checkpoints/ckpt-7/deployments"
+        assert args[1]["json"] == {
+            "name": "my-chat-model",
+            "overwrite": True,
+            "replicas": 2,
+            "gpus_per_replica": 4,
+            "gpu_type": "H800",
+        }
+
+    def test_create_no_wait_prints_operation_id(self, clean_env):
+        client = MagicMock()
+        client.http.post.return_value = {"id": "op-42", "status": "pending"}
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli, ["deployment", "create", "ckpt-1", "--name", "m", "--no-wait"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "op-42" in result.output
+
+    def test_create_invalid_name_exits_without_request(self, clean_env):
+        client = MagicMock()
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli, ["deployment", "create", "ckpt-1", "--name", "bad name"]
+            )
+
+        assert result.exit_code == 1
+        assert "invalid deployment name" in result.output
+        client.http.post.assert_not_called()
+
+    def test_create_permission_denied_prints_guidance(self, clean_env):
+        client = MagicMock()
+        client.http.post.side_effect = _api_error(403, "forbidden", "insufficient capability")
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli, ["deployment", "create", "ckpt-1", "--name", "my-model"]
+            )
+
+        assert result.exit_code == 1
+        assert "deployment.publish" in result.output
+
+    def test_create_feature_disabled_prints_guidance(self, clean_env):
+        client = MagicMock()
+        client.http.post.side_effect = _api_error(
+            503, "deployment_unavailable", "checkpoint deployment is not enabled on this server"
+        )
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli, ["deployment", "create", "ckpt-1", "--name", "my-model"]
+            )
+
+        assert result.exit_code == 1
+        assert "administrator" in result.output
+
+    def test_list_table(self, clean_env):
+        client = MagicMock()
+        client.list_deployments.return_value = [Deployment.from_payload(DEPLOYMENT_PAYLOAD)]
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["deployment", "list"])
+
+        assert result.exit_code == 0, result.output
+        # Rich elides long cells at the 80-column test width, so assert on the
+        # short columns and the summary line rather than on the full name.
+        assert "dep-1" in result.output
+        assert "running" in result.output
+        assert "H800" in result.output
+        assert "Showing 1 deployment(s)" in result.output
+
+    def test_list_json(self, clean_env):
+        client = MagicMock()
+        client.list_deployments.return_value = [Deployment.from_payload(DEPLOYMENT_PAYLOAD)]
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["deployment", "list", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert "northgate_model_id" in result.output
+
+    def test_get(self, clean_env):
+        client = MagicMock()
+        client.get_deployment.return_value = Deployment.from_payload(DEPLOYMENT_PAYLOAD)
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["deployment", "get", "dep-1"])
+
+        assert result.exit_code == 0, result.output
+        client.get_deployment.assert_called_once_with("dep-1")
+        assert "northgate.example.com" in result.output
+
+    def test_delete_waits_by_default(self, clean_env):
+        client = MagicMock()
+        client.delete_deployment.return_value = Deployment.from_payload(
+            dict(DEPLOYMENT_PAYLOAD, status="stopped")
+        )
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["deployment", "delete", "dep-1"])
+
+        assert result.exit_code == 0, result.output
+        client.delete_deployment.assert_called_once_with("dep-1")
+        assert "Deployment stopped" in result.output
+
+    def test_delete_no_wait_prints_operation_id(self, clean_env):
+        client = MagicMock()
+        handle = MagicMock()
+        handle.operation_id = "op-77"
+        client.delete_deployment.return_value = handle
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["deployment", "delete", "dep-1", "--no-wait"])
+
+        assert result.exit_code == 0, result.output
+        client.delete_deployment.assert_called_once_with("dep-1", wait=False)
+        assert "op-77" in result.output

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -927,3 +927,15 @@ class TestDeploymentIdValidation:
         with pytest.raises(ValueError, match="checkpoint id must be a"):
             client.deploy_checkpoint("../models/x", name="n")
         client._service.http.post.assert_not_called()
+
+
+class TestCLIIdGuard:
+    @pytest.mark.parametrize("raw", ["../models/target", "a/b", "%2e%2e%2fmodels", "ckpt-1"])
+    def test_deployment_create_rejects_traversal_ids(self, clean_env, raw):
+        client = MagicMock()
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(
+                cli, ["deployment", "create", raw, "--name", "m", "--no-wait"]
+            )
+        assert result.exit_code != 0
+        client.http.post.assert_not_called()

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -227,6 +227,23 @@ class TestBuildCreateDeploymentBody:
         body = build_create_deployment_body(name="my-model")
         assert body == {"name": "my-model", "overwrite": False, "replicas": 1}
 
+    @pytest.mark.parametrize("replicas", [True, 1.5, "2", None])
+    def test_rejects_non_int_replicas(self, replicas):
+        # bool is an int subclass and floats compare fine against range
+        # bounds, so exact-type checks are required to keep them off the wire.
+        with pytest.raises(ValueError, match="replicas must be"):
+            build_create_deployment_body(name="my-model", replicas=replicas)
+
+    @pytest.mark.parametrize("gpus", [True, 2.5, "4"])
+    def test_rejects_non_int_gpus_per_replica(self, gpus):
+        with pytest.raises(ValueError, match="gpus_per_replica must be"):
+            build_create_deployment_body(name="my-model", gpus_per_replica=gpus)
+
+    @pytest.mark.parametrize("overwrite", ["false", 1, 0, None])
+    def test_rejects_non_bool_overwrite(self, overwrite):
+        with pytest.raises(ValueError, match="overwrite must be"):
+            build_create_deployment_body(name="my-model", overwrite=overwrite)
+
     def test_all_fields(self):
         body = build_create_deployment_body(
             name="my-model",

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -48,9 +48,12 @@ from weaver.types.deployment import Deployment
 # Mirrors DeploymentService.PublicView in weaver-server
 # (internal/services/deployments.go): a closed allowlist that deliberately
 # omits provisioner metadata and the native workload id.
+DEPLOYMENT_UUID = "11111111-2222-4333-8444-555555555555"
+CHECKPOINT_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
 DEPLOYMENT_PAYLOAD: Dict[str, Any] = {
     "id": "dep-1",
-    "checkpoint_id": "ckpt-1",
+    "checkpoint_id": CHECKPOINT_UUID,
     "artifact_id": "art-1",
     "model_id": "mdl-123",
     "name": "my-chat-model",
@@ -127,7 +130,7 @@ class TestDeploymentType:
     def test_from_payload(self):
         deployment = Deployment.from_payload(DEPLOYMENT_PAYLOAD)
         assert deployment.id == "dep-1"
-        assert deployment.checkpoint_id == "ckpt-1"
+        assert deployment.checkpoint_id == CHECKPOINT_UUID
         assert deployment.artifact_id == "art-1"
         assert deployment.model_id == "mdl-123"
         assert deployment.name == "my-chat-model"
@@ -260,8 +263,11 @@ class TestBuildCreateDeploymentBody:
 
 
 class TestListingHelpers:
-    def test_deployment_items_filters_non_dicts(self):
-        assert deployment_items({"items": [{"id": "a"}, "junk", None]}) == [{"id": "a"}]
+    def test_deployment_items_raises_on_malformed_entries(self):
+        # Pagination advances by item count; silently dropping malformed
+        # entries would undercount the consumed page (duplicates / early stop).
+        with pytest.raises(ValueError, match="malformed deployment list entry"):
+            deployment_items({"items": [{"id": "a"}, "junk", None]})
 
     def test_deployment_items_on_garbage(self):
         assert deployment_items(None) == []
@@ -347,13 +353,13 @@ class TestDeployCheckpoint:
         tc = _make_training_client()
         tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
 
-        deployment = tc.deploy_checkpoint("ckpt-1", name="my-chat-model")
+        deployment = tc.deploy_checkpoint(CHECKPOINT_UUID, name="my-chat-model")
 
         assert isinstance(deployment, Deployment)
         assert deployment.id == "dep-1"
         assert deployment.endpoint == "https://northgate.example.com/v1"
         args = tc._service.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/deployments"
         assert args[1]["json"] == {
             "name": "my-chat-model",
             "overwrite": False,
@@ -366,7 +372,7 @@ class TestDeployCheckpoint:
         tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
 
         tc.deploy_checkpoint(
-            "ckpt-1",
+            CHECKPOINT_UUID,
             name="my-chat-model",
             gpu_type="H800",
             replicas=2,
@@ -386,17 +392,23 @@ class TestDeployCheckpoint:
         tc = _make_training_client()
         tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
 
-        ckpt = Checkpoint(id="ckpt-7", path="weaver://mdl-123/checkpoints/step-5")
+        ckpt = Checkpoint(id=CHECKPOINT_UUID, path="weaver://mdl-123/checkpoints/step-5")
         tc.deploy_checkpoint(ckpt, name="my-chat-model")
 
-        assert tc._service.http.post.call_args[0][0] == "/api/v1/checkpoints/ckpt-7/deployments"
+        assert (
+            tc._service.http.post.call_args[0][0]
+            == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/deployments"
+        )
 
     def test_deploy_resolves_weaver_path(self):
         tc = _make_training_client()
         tc._service.http.get.return_value = {
             "items": [
-                {"id": "ckpt-0", "path": "weaver://mdl-123/checkpoints/step-1"},
-                {"id": "ckpt-1", "path": "weaver://mdl-123/checkpoints/step-5"},
+                {
+                    "id": "00000000-0000-4000-8000-000000000000",
+                    "path": "weaver://mdl-123/checkpoints/step-1",
+                },
+                {"id": CHECKPOINT_UUID, "path": "weaver://mdl-123/checkpoints/step-5"},
             ]
         }
         tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
@@ -404,7 +416,10 @@ class TestDeployCheckpoint:
         tc.deploy_checkpoint("weaver://mdl-123/checkpoints/step-5", name="my-chat-model")
 
         tc._service.http.get.assert_called_once_with("/api/v1/models/mdl-123/checkpoints")
-        assert tc._service.http.post.call_args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert (
+            tc._service.http.post.call_args[0][0]
+            == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/deployments"
+        )
 
     def test_deploy_foreign_model_path_raises(self):
         tc = _make_training_client()
@@ -416,7 +431,7 @@ class TestDeployCheckpoint:
         tc = _make_training_client()
         tc._service.http.post.return_value = {"id": "op-9", "status": "pending"}
 
-        handle = tc.deploy_checkpoint("ckpt-1", name="my-model", wait=False)
+        handle = tc.deploy_checkpoint(CHECKPOINT_UUID, name="my-model", wait=False)
 
         assert isinstance(handle, OperationHandle)
         assert handle.operation_id == "op-9"
@@ -424,14 +439,14 @@ class TestDeployCheckpoint:
     def test_invalid_name_fails_before_any_request(self):
         tc = _make_training_client()
         with pytest.raises(ValueError, match="invalid deployment name"):
-            tc.deploy_checkpoint("ckpt-1", name="not a valid name")
+            tc.deploy_checkpoint(CHECKPOINT_UUID, name="not a valid name")
         tc._service.http.post.assert_not_called()
         tc._service.http.get.assert_not_called()
 
     def test_out_of_range_replicas_fails_before_any_request(self):
         tc = _make_training_client()
         with pytest.raises(ValueError, match="replicas must be between 1 and 8"):
-            tc.deploy_checkpoint("ckpt-1", name="my-model", replicas=99)
+            tc.deploy_checkpoint(CHECKPOINT_UUID, name="my-model", replicas=99)
         tc._service.http.post.assert_not_called()
 
     def test_permission_error_is_translated(self):
@@ -439,7 +454,7 @@ class TestDeployCheckpoint:
         tc._service.http.post.side_effect = _api_error(403, "forbidden", "insufficient capability")
 
         with pytest.raises(WeaverAPIError) as excinfo:
-            tc.deploy_checkpoint("ckpt-1", name="my-model")
+            tc.deploy_checkpoint(CHECKPOINT_UUID, name="my-model")
 
         assert excinfo.value.status_code == 403
         assert "deployment.publish" in excinfo.value.message
@@ -451,7 +466,7 @@ class TestDeployCheckpoint:
         )
 
         with pytest.raises(WeaverAPIError) as excinfo:
-            tc.deploy_checkpoint("ckpt-1", name="my-model")
+            tc.deploy_checkpoint(CHECKPOINT_UUID, name="my-model")
 
         assert excinfo.value.code == "deployment_unavailable"
         assert "administrator" in excinfo.value.message
@@ -467,19 +482,19 @@ class TestAsyncDeployCheckpoint:
         tc = _make_async_training_client()
         tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
 
-        deployment = asyncio.run(tc.deploy_checkpoint("ckpt-1", name="my-chat-model"))
+        deployment = asyncio.run(tc.deploy_checkpoint(CHECKPOINT_UUID, name="my-chat-model"))
 
         assert isinstance(deployment, Deployment)
         assert deployment.id == "dep-1"
         args = tc._service.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/deployments"
         assert args[1]["json"] == {"name": "my-chat-model", "overwrite": False, "replicas": 1}
         assert args[1]["max_retries"] == 1
 
     def test_deploy_resolves_weaver_path(self):
         tc = _make_async_training_client()
         tc._service.http.get.return_value = {
-            "items": [{"id": "ckpt-1", "path": "weaver://mdl-123/checkpoints/step-5"}]
+            "items": [{"id": CHECKPOINT_UUID, "path": "weaver://mdl-123/checkpoints/step-5"}]
         }
         tc._service.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
 
@@ -491,14 +506,14 @@ class TestAsyncDeployCheckpoint:
 
         assert isinstance(deployment, Deployment)
         args = tc._service.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/deployments"
         assert args[1]["json"]["gpu_type"] == "H800"
 
     def test_no_wait_returns_async_operation_handle(self):
         tc = _make_async_training_client()
         tc._service.http.post.return_value = {"id": "op-9", "status": "pending"}
 
-        handle = asyncio.run(tc.deploy_checkpoint("ckpt-1", name="my-model", wait=False))
+        handle = asyncio.run(tc.deploy_checkpoint(CHECKPOINT_UUID, name="my-model", wait=False))
 
         assert isinstance(handle, AsyncOperationHandle)
         assert handle.operation_id == "op-9"
@@ -506,7 +521,7 @@ class TestAsyncDeployCheckpoint:
     def test_invalid_name_fails_before_any_request(self):
         tc = _make_async_training_client()
         with pytest.raises(ValueError, match="invalid deployment name"):
-            asyncio.run(tc.deploy_checkpoint("ckpt-1", name="bad name"))
+            asyncio.run(tc.deploy_checkpoint(CHECKPOINT_UUID, name="bad name"))
         tc._service.http.post.assert_not_called()
 
     def test_permission_error_is_translated(self):
@@ -514,7 +529,7 @@ class TestAsyncDeployCheckpoint:
         tc._service.http.post.side_effect = _api_error(403, "forbidden", "insufficient capability")
 
         with pytest.raises(WeaverAPIError) as excinfo:
-            asyncio.run(tc.deploy_checkpoint("ckpt-1", name="my-model"))
+            asyncio.run(tc.deploy_checkpoint(CHECKPOINT_UUID, name="my-model"))
 
         assert "deployment.publish" in excinfo.value.message
 
@@ -564,28 +579,28 @@ class TestServiceClientDeployments:
         client = _make_service_client()
         client._http.get.return_value = DEPLOYMENT_PAYLOAD
 
-        deployment = client.get_deployment("dep-1")
+        deployment = client.get_deployment(DEPLOYMENT_UUID)
 
         assert isinstance(deployment, Deployment)
         assert deployment.northgate_model_id == "ng-77"
-        client._http.get.assert_called_once_with("/api/v1/deployments/dep-1")
+        client._http.get.assert_called_once_with(f"/api/v1/deployments/{DEPLOYMENT_UUID}")
 
     def test_delete_deployment_waits_and_returns_stopped(self):
         client = _make_service_client()
         stopped = dict(DEPLOYMENT_PAYLOAD, status="stopped", endpoint=None)
         client._http.delete.return_value = _done_operation(stopped)
 
-        deployment = client.delete_deployment("dep-1")
+        deployment = client.delete_deployment(DEPLOYMENT_UUID)
 
         assert isinstance(deployment, Deployment)
         assert deployment.status == "stopped"
-        client._http.delete.assert_called_once_with("/api/v1/deployments/dep-1")
+        client._http.delete.assert_called_once_with(f"/api/v1/deployments/{DEPLOYMENT_UUID}")
 
     def test_delete_deployment_no_wait_returns_handle(self):
         client = _make_service_client()
         client._http.delete.return_value = {"id": "op-5", "status": "pending"}
 
-        handle = client.delete_deployment("dep-1", wait=False)
+        handle = client.delete_deployment(DEPLOYMENT_UUID, wait=False)
 
         assert isinstance(handle, OperationHandle)
         assert handle.operation_id == "op-5"
@@ -597,7 +612,7 @@ class TestServiceClientDeployments:
         )
 
         with pytest.raises(WeaverAPIError) as excinfo:
-            client.delete_deployment("dep-1")
+            client.delete_deployment(DEPLOYMENT_UUID)
 
         assert excinfo.value.code == "already_stopped"
 
@@ -636,10 +651,10 @@ class TestAsyncServiceClientDeployments:
         client = _make_async_service_client()
         client._http.get.return_value = DEPLOYMENT_PAYLOAD
 
-        deployment = asyncio.run(client.get_deployment("dep-1"))
+        deployment = asyncio.run(client.get_deployment(DEPLOYMENT_UUID))
 
         assert isinstance(deployment, Deployment)
-        client._http.get.assert_called_once_with("/api/v1/deployments/dep-1")
+        client._http.get.assert_called_once_with(f"/api/v1/deployments/{DEPLOYMENT_UUID}")
 
     def test_delete_deployment_waits_and_returns_stopped(self):
         client = _make_async_service_client()
@@ -647,16 +662,16 @@ class TestAsyncServiceClientDeployments:
             dict(DEPLOYMENT_PAYLOAD, status="stopped")
         )
 
-        deployment = asyncio.run(client.delete_deployment("dep-1"))
+        deployment = asyncio.run(client.delete_deployment(DEPLOYMENT_UUID))
 
         assert deployment.status == "stopped"
-        client._http.delete.assert_called_once_with("/api/v1/deployments/dep-1")
+        client._http.delete.assert_called_once_with(f"/api/v1/deployments/{DEPLOYMENT_UUID}")
 
     def test_delete_deployment_no_wait_returns_handle(self):
         client = _make_async_service_client()
         client._http.delete.return_value = {"id": "op-5", "status": "pending"}
 
-        handle = asyncio.run(client.delete_deployment("dep-1", wait=False))
+        handle = asyncio.run(client.delete_deployment(DEPLOYMENT_UUID, wait=False))
 
         assert isinstance(handle, AsyncOperationHandle)
         assert handle.operation_id == "op-5"
@@ -690,13 +705,13 @@ class TestDeploymentCLI:
         client.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
         with patch("weaver.cli.ServiceClient", return_value=client):
             result = CliRunner().invoke(
-                cli, ["deployment", "create", "ckpt-1", "--name", "my-chat-model"]
+                cli, ["deployment", "create", CHECKPOINT_UUID, "--name", "my-chat-model"]
             )
 
         assert result.exit_code == 0, result.output
         client.connect.assert_called_once_with(ensure_session=False)
         args = client.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/deployments"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/deployments"
         assert args[1]["json"] == {"name": "my-chat-model", "overwrite": False, "replicas": 1}
         assert args[1]["max_retries"] == 1
         assert "Deployment ready" in result.output
@@ -706,7 +721,7 @@ class TestDeploymentCLI:
         client = MagicMock()
         client.http.post.return_value = _done_operation(DEPLOYMENT_PAYLOAD)
         client.http.get.return_value = {
-            "items": [{"id": "ckpt-7", "path": "weaver://mdl-123/checkpoints/step-5"}]
+            "items": [{"id": CHECKPOINT_UUID, "path": "weaver://mdl-123/checkpoints/step-5"}]
         }
         with patch("weaver.cli.ServiceClient", return_value=client):
             result = CliRunner().invoke(
@@ -730,7 +745,7 @@ class TestDeploymentCLI:
         assert result.exit_code == 0, result.output
         client.http.get.assert_called_once_with("/api/v1/models/mdl-123/checkpoints")
         args = client.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-7/deployments"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/deployments"
         assert args[1]["json"] == {
             "name": "my-chat-model",
             "overwrite": True,
@@ -744,7 +759,7 @@ class TestDeploymentCLI:
         client.http.post.return_value = {"id": "op-42", "status": "pending"}
         with patch("weaver.cli.ServiceClient", return_value=client):
             result = CliRunner().invoke(
-                cli, ["deployment", "create", "ckpt-1", "--name", "m", "--no-wait"]
+                cli, ["deployment", "create", CHECKPOINT_UUID, "--name", "m", "--no-wait"]
             )
 
         assert result.exit_code == 0, result.output
@@ -754,7 +769,7 @@ class TestDeploymentCLI:
         client = MagicMock()
         with patch("weaver.cli.ServiceClient", return_value=client):
             result = CliRunner().invoke(
-                cli, ["deployment", "create", "ckpt-1", "--name", "bad name"]
+                cli, ["deployment", "create", CHECKPOINT_UUID, "--name", "bad name"]
             )
 
         assert result.exit_code == 1
@@ -766,7 +781,7 @@ class TestDeploymentCLI:
         client.http.post.side_effect = _api_error(403, "forbidden", "insufficient capability")
         with patch("weaver.cli.ServiceClient", return_value=client):
             result = CliRunner().invoke(
-                cli, ["deployment", "create", "ckpt-1", "--name", "my-model"]
+                cli, ["deployment", "create", CHECKPOINT_UUID, "--name", "my-model"]
             )
 
         assert result.exit_code == 1
@@ -779,7 +794,7 @@ class TestDeploymentCLI:
         )
         with patch("weaver.cli.ServiceClient", return_value=client):
             result = CliRunner().invoke(
-                cli, ["deployment", "create", "ckpt-1", "--name", "my-model"]
+                cli, ["deployment", "create", CHECKPOINT_UUID, "--name", "my-model"]
             )
 
         assert result.exit_code == 1
@@ -841,3 +856,57 @@ class TestDeploymentCLI:
         assert result.exit_code == 0, result.output
         client.delete_deployment.assert_called_once_with("dep-1", wait=False)
         assert "op-77" in result.output
+
+
+class TestDeploymentIdValidation:
+    """A raw deployment id becomes a URL path segment; dot-segment tricks must
+    be rejected before any request is built (httpx normalizes `..`, so
+    `../checkpoints/<uuid>` would otherwise reroute to the checkpoints API)."""
+
+    CHECKPOINT_UUID = "99999999-8888-4777-a666-555555555555"
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "../checkpoints/99999999-8888-4777-a666-555555555555",
+            "../models/99999999-8888-4777-a666-555555555555",
+            "a/b",
+            "..",
+            "%2e%2e%2fcheckpoints",
+            "dep-1",
+            "",
+            "11111111222243338444555555555555",  # unhyphenated alias
+            "urn:uuid:11111111-2222-4333-8444-555555555555",
+        ],
+    )
+    def test_get_and_delete_reject_non_uuid_ids(self, bad_id):
+        client = _make_service_client()
+        with pytest.raises(ValueError, match="deployment id must be a"):
+            client.get_deployment(bad_id)
+        with pytest.raises(ValueError, match="deployment id must be a"):
+            client.delete_deployment(bad_id)
+        client._http.get.assert_not_called()
+        client._http.delete.assert_not_called()
+
+    def test_async_twins_reject_traversal(self):
+        client = _make_async_service_client()
+        with pytest.raises(ValueError, match="deployment id must be a"):
+            asyncio.run(client.get_deployment("../checkpoints/x"))
+        with pytest.raises(ValueError, match="deployment id must be a"):
+            asyncio.run(client.delete_deployment("../checkpoints/x"))
+        client._http.get.assert_not_called()
+        client._http.delete.assert_not_called()
+
+    def test_uppercase_uuid_normalized(self):
+        client = _make_service_client()
+        client._http.get.return_value = dict(DEPLOYMENT_PAYLOAD)
+        client.get_deployment(DEPLOYMENT_UUID.upper())
+        client._http.get.assert_called_once_with(f"/api/v1/deployments/{DEPLOYMENT_UUID}")
+
+    def test_checkpoint_raw_id_must_be_uuid(self):
+        # export_weights / deploy_checkpoint share _resolve_checkpoint_id: a
+        # non-weaver:// string is a raw checkpoint id and gets the same guard.
+        client = _make_training_client()
+        with pytest.raises(ValueError, match="checkpoint id must be a"):
+            client.deploy_checkpoint("../models/x", name="n")
+        client._service.http.post.assert_not_called()

--- a/tests/test_hf_download.py
+++ b/tests/test_hf_download.py
@@ -228,6 +228,27 @@ class TestDescriptorFiles:
         with pytest.raises(ValueError, match="unsafe file name"):
             descriptor_files(bad)
 
+    @pytest.mark.parametrize("name", [".", "./"])
+    def test_rejects_names_that_normalize_to_nothing(self, name):
+        # Regression: PurePosixPath(".").parts is empty, so "." used to pass
+        # validation; the download path then aliased dest_dir itself and the
+        # .part landed OUTSIDE the requested directory as its sibling.
+        bad = _descriptor({name: b"x"})
+        with pytest.raises(ValueError, match="unsafe file name"):
+            descriptor_files(bad)
+
+    @pytest.mark.parametrize("name", ["a//b", "a/./b", "foo/", "./foo"])
+    def test_rejects_non_canonical_names(self, name):
+        bad = _descriptor({name: b"x"})
+        with pytest.raises(ValueError, match="non-canonical file name"):
+            descriptor_files(bad)
+
+    def test_rejects_duplicate_names(self):
+        descriptor = _descriptor(FILES)
+        descriptor["files"].append(dict(descriptor["files"][0]))
+        with pytest.raises(ValueError, match="duplicate file name"):
+            descriptor_files(descriptor)
+
     def test_rejects_empty_descriptor(self):
         with pytest.raises(ValueError, match="no files"):
             descriptor_files({"files": []})

--- a/tests/test_hf_download.py
+++ b/tests/test_hf_download.py
@@ -263,6 +263,16 @@ class TestDescriptorFiles:
         with pytest.raises(ValueError, match="unsafe file name"):
             descriptor_files(_descriptor({name: b"x"}))
 
+    @pytest.mark.parametrize(
+        "name",
+        ["CON", "NUL", "con.txt", "a/PRN/b", "COM1", "foo.", "foo ", "a/b:stream", "d/trail. /x"],
+    )
+    def test_rejects_windows_special_components(self, name):
+        # Device names (any extension), trailing dot/space aliases and ADS
+        # syntax target something other than the manifest path on Windows.
+        with pytest.raises(ValueError, match="unsafe file name"):
+            descriptor_files(_descriptor({name: b"x"}))
+
     def test_rejects_duplicate_names(self):
         descriptor = _descriptor(FILES)
         descriptor["files"].append(dict(descriptor["files"][0]))
@@ -720,3 +730,44 @@ class TestBareDownloadClient:
                 assert client.headers.get("User-Agent", "").startswith("weaver-sdk/")
 
         asyncio.run(run())
+
+
+class TestSymlinkContainment:
+    def test_symlink_inside_dest_cannot_escape(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "link").symlink_to(outside)
+        files = {"link/owned.bin": b"x"}
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(
+                transport=httpx.MockTransport(_presigned_handler(files))
+            ),
+        )
+        client = _make_sync_client(_api_routes(_descriptor(files)))
+        with pytest.raises(ValueError, match="outside the destination"):
+            client.download_weights(ARTIFACT_UUID, dest)
+        assert not (outside / "owned.bin").exists()
+        assert not (outside / "owned.bin.part").exists()
+
+    def test_async_symlink_inside_dest_cannot_escape(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "link").symlink_to(outside)
+        files = {"link/owned.bin": b"x"}
+        monkeypatch.setattr(
+            async_service_client,
+            "build_async_download_client",
+            lambda timeout=None: httpx.AsyncClient(
+                transport=httpx.MockTransport(_presigned_handler(files))
+            ),
+        )
+        client = _make_async_client(_api_routes(_descriptor(files)))
+        with pytest.raises(ValueError, match="outside the destination"):
+            asyncio.run(client.download_weights(ARTIFACT_UUID, dest))
+        assert not (outside / "owned.bin").exists()

--- a/tests/test_hf_download.py
+++ b/tests/test_hf_download.py
@@ -52,17 +52,20 @@ FILES: Dict[str, bytes] = {
 SINGLE_FILE: Dict[str, bytes] = {"shard.bin": bytes(range(256)) * 8}
 
 CHECKPOINT_URI = "weaver://mdl-123/checkpoints/step-5"
+ARTIFACT_UUID_2 = "bbbb2222-cc33-4d44-8e55-ffff6666aaaa"
+CHECKPOINT_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+ARTIFACT_UUID = "aaaa1111-bb22-4c33-8d44-eeee5555ffff"
 ADAPTER_ARTIFACT = {
-    "id": "art-1",
-    "checkpoint_id": "ckpt-1",
+    "id": ARTIFACT_UUID,
+    "checkpoint_id": CHECKPOINT_UUID,
     "model_id": "mdl-123",
     "kind": "hf_adapter",
     "status": "completed",
     "uri": f"{CHECKPOINT_URI}/artifacts/hf_adapter",
 }
 MODEL_ARTIFACT = {
-    "id": "art-2",
-    "checkpoint_id": "ckpt-1",
+    "id": ARTIFACT_UUID_2,
+    "checkpoint_id": CHECKPOINT_UUID,
     "model_id": "mdl-123",
     "kind": "hf_model",
     "status": "completed",
@@ -82,7 +85,7 @@ def _descriptor(
 ) -> Dict[str, Any]:
     overrides = sha_overrides or {}
     return {
-        "artifact_id": "art-1",
+        "artifact_id": ARTIFACT_UUID,
         "kind": "hf_adapter",
         "total_bytes": sum(len(content) for content in files.values()),
         "files": [
@@ -139,13 +142,13 @@ def _api_routes(descriptor: Dict[str, Any], artifacts: list | None = None):
 
     routes = {
         "/api/v1/models/mdl-123/checkpoints": {
-            "items": [{"id": "ckpt-1", "path": CHECKPOINT_URI, "type": "weight"}]
+            "items": [{"id": CHECKPOINT_UUID, "path": CHECKPOINT_URI, "type": "weight"}]
         },
-        "/api/v1/checkpoints/ckpt-1/artifacts": {
+        f"/api/v1/checkpoints/{CHECKPOINT_UUID}/artifacts": {
             "items": artifacts if artifacts is not None else [dict(ADAPTER_ARTIFACT)]
         },
-        "/api/v1/artifacts/art-1/download": descriptor,
-        "/api/v1/artifacts/art-2/download": descriptor,
+        f"/api/v1/artifacts/{ARTIFACT_UUID}/download": descriptor,
+        f"/api/v1/artifacts/{ARTIFACT_UUID_2}/download": descriptor,
     }
 
     def side_effect(path, **_kwargs):
@@ -173,8 +176,8 @@ class TestParseDownloadTarget:
         assert parsed.kind is None
 
     def test_raw_artifact_id(self):
-        parsed = parse_download_target("art-1")
-        assert parsed.artifact_id == "art-1"
+        parsed = parse_download_target(ARTIFACT_UUID)
+        assert parsed.artifact_id == ARTIFACT_UUID
 
     def test_unknown_kind_rejected(self):
         with pytest.raises(ValueError, match="Unknown artifact kind"):
@@ -192,12 +195,12 @@ class TestParseDownloadTarget:
 class TestSelectArtifactPayload:
     def test_single_completed(self):
         selected = select_artifact_payload([dict(ADAPTER_ARTIFACT)], None, context="t")
-        assert selected["id"] == "art-1"
+        assert selected["id"] == ARTIFACT_UUID
 
     def test_kind_filter(self):
         items = [dict(ADAPTER_ARTIFACT), dict(MODEL_ARTIFACT)]
         selected = select_artifact_payload(items, "hf_model", context="t")
-        assert selected["id"] == "art-2"
+        assert selected["id"] == ARTIFACT_UUID_2
 
     def test_no_completed_tells_user_to_export(self):
         items = [{**ADAPTER_ARTIFACT, "status": "pending"}]
@@ -349,7 +352,7 @@ class TestDownloadWeights:
         self._patch_transport(monkeypatch, _presigned_handler(FILES, calls))
         client = _make_sync_client(_api_routes(_descriptor(FILES)))
 
-        dest = client.download_weights("art-1", tmp_path / "out")
+        dest = client.download_weights(ARTIFACT_UUID, tmp_path / "out")
 
         assert dest == tmp_path / "out"
         for name, content in FILES.items():
@@ -357,7 +360,7 @@ class TestDownloadWeights:
         assert not list(dest.rglob("*.part"))
         assert len(calls) == len(FILES)
         # Only the descriptor endpoint is hit for a raw artifact id.
-        client.http.get.assert_called_once_with("/api/v1/artifacts/art-1/download")
+        client.http.get.assert_called_once_with(f"/api/v1/artifacts/{ARTIFACT_UUID}/download")
 
     def test_checkpoint_uri_resolution_flow(self, tmp_path, monkeypatch):
         self._patch_transport(monkeypatch, _presigned_handler(FILES))
@@ -368,8 +371,8 @@ class TestDownloadWeights:
         paths = [call.args[0] for call in client.http.get.call_args_list]
         assert paths == [
             "/api/v1/models/mdl-123/checkpoints",
-            "/api/v1/checkpoints/ckpt-1/artifacts",
-            "/api/v1/artifacts/art-1/download",
+            f"/api/v1/checkpoints/{CHECKPOINT_UUID}/artifacts",
+            f"/api/v1/artifacts/{ARTIFACT_UUID}/download",
         ]
 
     def test_artifact_uri_selects_kind(self, tmp_path, monkeypatch):
@@ -380,7 +383,7 @@ class TestDownloadWeights:
         client.download_weights(f"{CHECKPOINT_URI}/artifacts/hf_model", tmp_path / "out")
 
         paths = [call.args[0] for call in client.http.get.call_args_list]
-        assert paths[-1] == "/api/v1/artifacts/art-2/download"
+        assert paths[-1] == f"/api/v1/artifacts/{ARTIFACT_UUID_2}/download"
 
     def test_weights_artifact_object_target(self, tmp_path, monkeypatch):
         self._patch_transport(monkeypatch, _presigned_handler(FILES))
@@ -389,7 +392,7 @@ class TestDownloadWeights:
         artifact = WeightsArtifact.from_payload(ADAPTER_ARTIFACT)
         client.download_weights(artifact, tmp_path / "out")
 
-        client.http.get.assert_called_once_with("/api/v1/artifacts/art-1/download")
+        client.http.get.assert_called_once_with(f"/api/v1/artifacts/{ARTIFACT_UUID}/download")
 
     def test_no_completed_artifact_never_exports_implicitly(self, tmp_path, monkeypatch):
         self._patch_transport(monkeypatch, _presigned_handler(FILES))
@@ -418,7 +421,7 @@ class TestDownloadWeights:
     def test_invalid_kind_rejected(self, tmp_path):
         client = _make_sync_client(_api_routes(_descriptor(FILES)))
         with pytest.raises(ValueError, match="kind must be one of"):
-            client.download_weights("art-1", tmp_path / "out", kind="onnx")
+            client.download_weights(ARTIFACT_UUID, tmp_path / "out", kind="onnx")
 
     def test_sha256_mismatch_raises_and_removes_file(self, tmp_path, monkeypatch):
         self._patch_transport(monkeypatch, _presigned_handler(FILES))
@@ -426,7 +429,7 @@ class TestDownloadWeights:
         client = _make_sync_client(_api_routes(descriptor))
 
         with pytest.raises(RuntimeError, match="sha256 mismatch"):
-            client.download_weights("art-1", tmp_path / "out")
+            client.download_weights(ARTIFACT_UUID, tmp_path / "out")
         assert not (tmp_path / "out" / "adapter_config.json").exists()
         assert not (tmp_path / "out" / "adapter_config.json.part").exists()
 
@@ -435,7 +438,7 @@ class TestDownloadWeights:
         descriptor = _descriptor(FILES, sha_overrides={"adapter_config.json": "0" * 64})
         client = _make_sync_client(_api_routes(descriptor))
 
-        dest = client.download_weights("art-1", tmp_path / "out", verify=False)
+        dest = client.download_weights(ARTIFACT_UUID, tmp_path / "out", verify=False)
 
         assert (dest / "adapter_config.json").read_bytes() == FILES["adapter_config.json"]
 
@@ -444,7 +447,7 @@ class TestDownloadWeights:
         descriptor_calls = {"count": 0}
 
         def api_get(path, **_kwargs):
-            if path == "/api/v1/artifacts/art-1/download":
+            if path == f"/api/v1/artifacts/{ARTIFACT_UUID}/download":
                 descriptor_calls["count"] += 1
                 # First descriptor hands out already-expired URLs; the re-fetch
                 # (triggered by the 403) returns working ones.
@@ -453,7 +456,7 @@ class TestDownloadWeights:
             raise AssertionError(f"unexpected API GET {path}")
 
         client = _make_sync_client(api_get)
-        dest = client.download_weights("art-1", tmp_path / "out")
+        dest = client.download_weights(ARTIFACT_UUID, tmp_path / "out")
 
         assert descriptor_calls["count"] >= 2
         for name, content in FILES.items():
@@ -468,7 +471,7 @@ class TestDownloadWeights:
         for name, content in FILES.items():
             (dest / name).write_bytes(content)
 
-        client.download_weights("art-1", dest)
+        client.download_weights(ARTIFACT_UUID, dest)
 
         assert not calls  # everything already on disk and verified
 
@@ -477,7 +480,7 @@ class TestDownloadWeights:
         client = _make_sync_client(_api_routes(_descriptor({"../evil.bin": b"x"})))
 
         with pytest.raises(ValueError, match="unsafe file name"):
-            client.download_weights("art-1", tmp_path / "out")
+            client.download_weights(ARTIFACT_UUID, tmp_path / "out")
 
     def test_resumes_from_existing_part_file(self, tmp_path, monkeypatch):
         calls: list = []
@@ -488,7 +491,7 @@ class TestDownloadWeights:
         # A previous interrupted run left the first 100 bytes on disk.
         (dest / "shard.bin.part").write_bytes(SINGLE_FILE["shard.bin"][:100])
 
-        client.download_weights("art-1", dest, max_concurrency=1)
+        client.download_weights(ARTIFACT_UUID, dest, max_concurrency=1)
 
         assert (dest / "shard.bin").read_bytes() == SINGLE_FILE["shard.bin"]
         assert calls[0].headers["Range"] == "bytes=100-"
@@ -502,7 +505,7 @@ class TestDownloadWeights:
         # Longer than the manifest size: not resumable, must restart at 0.
         (dest / "shard.bin.part").write_bytes(b"x" * (len(SINGLE_FILE["shard.bin"]) + 10))
 
-        client.download_weights("art-1", dest, max_concurrency=1)
+        client.download_weights(ARTIFACT_UUID, dest, max_concurrency=1)
 
         assert (dest / "shard.bin").read_bytes() == SINGLE_FILE["shard.bin"]
         assert "Range" not in calls[0].headers
@@ -526,7 +529,7 @@ class TestDownloadWeights:
         dest.mkdir()
         (dest / "shard.bin.part").write_bytes(content[:100])
 
-        client.download_weights("art-1", dest, max_concurrency=1)
+        client.download_weights(ARTIFACT_UUID, dest, max_concurrency=1)
 
         assert (dest / "shard.bin").read_bytes() == content
         assert len(seen) == 2
@@ -535,7 +538,7 @@ class TestDownloadWeights:
     def test_max_concurrency_must_be_positive(self, tmp_path):
         client = _make_sync_client(_api_routes(_descriptor(FILES)))
         with pytest.raises(ValueError, match="max_concurrency"):
-            client.download_weights("art-1", tmp_path / "out", max_concurrency=0)
+            client.download_weights(ARTIFACT_UUID, tmp_path / "out", max_concurrency=0)
 
 
 # ---------------------------------------------------------------------------
@@ -556,13 +559,13 @@ class TestAsyncDownloadWeights:
         self._patch_transport(monkeypatch, _presigned_handler(FILES, calls))
         client = _make_async_client(_api_routes(_descriptor(FILES)))
 
-        dest = asyncio.run(client.download_weights("art-1", tmp_path / "out"))
+        dest = asyncio.run(client.download_weights(ARTIFACT_UUID, tmp_path / "out"))
 
         for name, content in FILES.items():
             assert (dest / name).read_bytes() == content
         assert not list(dest.rglob("*.part"))
         assert len(calls) == len(FILES)
-        client.http.get.assert_awaited_once_with("/api/v1/artifacts/art-1/download")
+        client.http.get.assert_awaited_once_with(f"/api/v1/artifacts/{ARTIFACT_UUID}/download")
 
     def test_checkpoint_uri_resolution_flow(self, tmp_path, monkeypatch):
         self._patch_transport(monkeypatch, _presigned_handler(FILES))
@@ -573,8 +576,8 @@ class TestAsyncDownloadWeights:
         paths = [call.args[0] for call in client.http.get.call_args_list]
         assert paths == [
             "/api/v1/models/mdl-123/checkpoints",
-            "/api/v1/checkpoints/ckpt-1/artifacts",
-            "/api/v1/artifacts/art-1/download",
+            f"/api/v1/checkpoints/{CHECKPOINT_UUID}/artifacts",
+            f"/api/v1/artifacts/{ARTIFACT_UUID}/download",
         ]
 
     def test_no_completed_artifact_never_exports_implicitly(self, tmp_path, monkeypatch):
@@ -591,14 +594,14 @@ class TestAsyncDownloadWeights:
         client = _make_async_client(_api_routes(descriptor))
 
         with pytest.raises(RuntimeError, match="sha256 mismatch"):
-            asyncio.run(client.download_weights("art-1", tmp_path / "out"))
+            asyncio.run(client.download_weights(ARTIFACT_UUID, tmp_path / "out"))
 
     def test_expired_url_refreshes_descriptor(self, tmp_path, monkeypatch):
         self._patch_transport(monkeypatch, _presigned_handler(FILES))
         descriptor_calls = {"count": 0}
 
         async def api_get(path, **_kwargs):
-            if path == "/api/v1/artifacts/art-1/download":
+            if path == f"/api/v1/artifacts/{ARTIFACT_UUID}/download":
                 descriptor_calls["count"] += 1
                 sig = "expired" if descriptor_calls["count"] == 1 else "ok"
                 return _descriptor(FILES, sig=sig)
@@ -608,7 +611,7 @@ class TestAsyncDownloadWeights:
         client._http = MagicMock()
         client._http.get = AsyncMock(side_effect=api_get)
 
-        dest = asyncio.run(client.download_weights("art-1", tmp_path / "out"))
+        dest = asyncio.run(client.download_weights(ARTIFACT_UUID, tmp_path / "out"))
 
         assert descriptor_calls["count"] >= 2
         for name, content in FILES.items():
@@ -622,7 +625,7 @@ class TestAsyncDownloadWeights:
         dest.mkdir()
         (dest / "shard.bin.part").write_bytes(SINGLE_FILE["shard.bin"][:100])
 
-        asyncio.run(client.download_weights("art-1", dest, max_concurrency=1))
+        asyncio.run(client.download_weights(ARTIFACT_UUID, dest, max_concurrency=1))
 
         assert (dest / "shard.bin").read_bytes() == SINGLE_FILE["shard.bin"]
         assert calls[0].headers["Range"] == "bytes=100-"
@@ -630,7 +633,7 @@ class TestAsyncDownloadWeights:
     def test_max_concurrency_must_be_positive(self, tmp_path):
         client = _make_async_client(_api_routes(_descriptor(FILES)))
         with pytest.raises(ValueError, match="max_concurrency"):
-            asyncio.run(client.download_weights("art-1", tmp_path / "out", max_concurrency=0))
+            asyncio.run(client.download_weights(ARTIFACT_UUID, tmp_path / "out", max_concurrency=0))
 
 
 # ---------------------------------------------------------------------------
@@ -675,7 +678,7 @@ class TestCheckpointDownloadCLI:
         with patch("weaver.cli.ServiceClient", return_value=client):
             result = CliRunner().invoke(
                 cli,
-                ["checkpoint", "download", "art-1", "-o", str(tmp_path / "out")],
+                ["checkpoint", "download", ARTIFACT_UUID, "-o", str(tmp_path / "out")],
             )
 
         assert result.exit_code == 1

--- a/tests/test_hf_download.py
+++ b/tests/test_hf_download.py
@@ -1168,3 +1168,159 @@ class TestPartSymlinkGuard:
         assert not (dest / "owned.bin").is_symlink()
         assert (dest / "owned.bin").read_bytes() == b"real-content"
         assert outside.read_bytes() == b"untouched"
+
+
+@requires_dir_fd
+class TestHardLinkGuard:
+    """A ``.part`` name that resolves to a multiply-linked inode is refused.
+
+    ``O_NOFOLLOW`` guards symlinks only; a pre-planted hard link
+    (``os.link(outside, dest/x.part)``) points a stable name at an inode that
+    can live outside the tree. The fstat-on-the-open-descriptor check
+    (:func:`weaver._safeio._reject_hard_link`) rejects it, and the fresh
+    ``O_CREAT | O_EXCL`` open never truncates a pre-existing name.
+    """
+
+    HARDLINK_FILES = {"owned.bin": b"real-downloaded-content"}
+
+    def _patch_sync(self, monkeypatch):
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(
+                transport=httpx.MockTransport(_presigned_handler(self.HARDLINK_FILES))
+            ),
+        )
+
+    def _patch_async(self, monkeypatch):
+        monkeypatch.setattr(
+            async_service_client,
+            "build_async_download_client",
+            lambda timeout=None: httpx.AsyncClient(
+                transport=httpx.MockTransport(_presigned_handler(self.HARDLINK_FILES))
+            ),
+        )
+
+    def test_open_for_write_refuses_a_preplanted_hard_link(self, tmp_path):
+        # The primitive, exercised directly in both modes. Append opens the
+        # inode and rejects it on the fstat; a fresh O_EXCL open never opens
+        # the occupied name at all and refuses the race — both safe, and
+        # neither writes a byte, so the outside inode is untouched.
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"SECRET")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        os.link(outside, dest / "x.part")
+        parent_fd = _safeio.open_parent_fd(dest, PurePosixPath("x"), create=False)
+        try:
+            with pytest.raises(ValueError, match="hard link"):
+                _safeio.open_for_write(parent_fd, "x.part", append=True)
+            with pytest.raises(ValueError, match="between validation and creation"):
+                _safeio.open_for_write(parent_fd, "x.part", append=False)
+        finally:
+            os.close(parent_fd)
+        assert outside.read_bytes() == b"SECRET"
+        assert os.stat(outside).st_nlink == 2
+
+    def test_sync_preplanted_hard_linked_part_is_refused(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"AAA")  # shorter than the manifest -> a "resumable" partial
+        dest = tmp_path / "out"
+        dest.mkdir()
+        os.link(outside, dest / "owned.bin.part")
+        self._patch_sync(monkeypatch)
+        client = _make_sync_client(_api_routes(_descriptor(self.HARDLINK_FILES)))
+
+        with pytest.raises(ValueError, match="hard link"):
+            client.download_weights(ARTIFACT_UUID, dest)
+
+        assert outside.read_bytes() == b"AAA"  # byte-for-byte unchanged
+        assert os.stat(outside).st_nlink == 2
+
+    def test_async_preplanted_hard_linked_part_is_refused(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"AAA")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        os.link(outside, dest / "owned.bin.part")
+        self._patch_async(monkeypatch)
+        client = _make_async_client(_api_routes(_descriptor(self.HARDLINK_FILES)))
+
+        with pytest.raises(ValueError, match="hard link"):
+            asyncio.run(client.download_weights(ARTIFACT_UUID, dest))
+
+        assert outside.read_bytes() == b"AAA"
+        assert os.stat(outside).st_nlink == 2
+
+    @staticmethod
+    def _racing_resume(module, dest, outside):
+        """Wrap ``resume_offset_at`` to swap the ``.part`` for a hard link.
+
+        Fires AFTER validation returns and BEFORE the write is opened — the
+        exact window an attacker races — so only the fstat on the opened
+        descriptor can catch it. Deterministic: no real race needed.
+        """
+        real = module.resume_offset_at
+
+        def racing(parent_fd, part_name, entry):
+            offset = real(parent_fd, part_name, entry)
+            # Repoint the validated name at an outside inode.
+            os.unlink(dest / part_name)
+            os.link(outside, dest / part_name)
+            return offset
+
+        return racing
+
+    def test_sync_hard_link_added_after_validation_is_caught_on_fstat(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"SECRET")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        # A legitimate single-linked partial exists at validation time.
+        (dest / "owned.bin.part").write_bytes(b"AA")
+        self._patch_sync(monkeypatch)
+        monkeypatch.setattr(
+            service_client, "resume_offset_at", self._racing_resume(service_client, dest, outside)
+        )
+        client = _make_sync_client(_api_routes(_descriptor(self.HARDLINK_FILES)))
+
+        with pytest.raises(ValueError, match="hard link"):
+            client.download_weights(ARTIFACT_UUID, dest)
+
+        assert outside.read_bytes() == b"SECRET"
+        assert os.stat(outside).st_nlink == 2
+
+    def test_async_hard_link_added_after_validation_is_caught_on_fstat(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"SECRET")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "owned.bin.part").write_bytes(b"AA")
+        self._patch_async(monkeypatch)
+        monkeypatch.setattr(
+            async_service_client,
+            "resume_offset_at",
+            self._racing_resume(async_service_client, dest, outside),
+        )
+        client = _make_async_client(_api_routes(_descriptor(self.HARDLINK_FILES)))
+
+        with pytest.raises(ValueError, match="hard link"):
+            asyncio.run(client.download_weights(ARTIFACT_UUID, dest))
+
+        assert outside.read_bytes() == b"SECRET"
+        assert os.stat(outside).st_nlink == 2
+
+    def test_normal_download_still_succeeds_over_a_single_linked_partial(
+        self, tmp_path, monkeypatch
+    ):
+        # Regression guard: the fstat check must not reject an ordinary resume.
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "owned.bin.part").write_bytes(self.HARDLINK_FILES["owned.bin"][:5])
+        self._patch_sync(monkeypatch)
+        client = _make_sync_client(_api_routes(_descriptor(self.HARDLINK_FILES)))
+
+        dest_ret = client.download_weights(ARTIFACT_UUID, dest, max_concurrency=1)
+
+        assert (dest_ret / "owned.bin").read_bytes() == self.HARDLINK_FILES["owned.bin"]
+        assert not list(dest_ret.rglob("*.part"))

--- a/tests/test_hf_download.py
+++ b/tests/test_hf_download.py
@@ -771,3 +771,51 @@ class TestSymlinkContainment:
         with pytest.raises(ValueError, match="outside the destination"):
             asyncio.run(client.download_weights(ARTIFACT_UUID, dest))
         assert not (outside / "owned.bin").exists()
+
+
+class TestUriModelIdGuard:
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "weaver://../checkpoints/x",
+            "weaver://%2e%2e/checkpoints/x",
+            "weaver://a\\b/checkpoints/x",
+            "weaver://.hidden/checkpoints/x",
+        ],
+    )
+    def test_parse_rejects_unsafe_model_ids(self, uri):
+        with pytest.raises(ValueError, match="unsafe model id|Unrecognized weaver URI"):
+            parse_download_target(uri)
+
+    def test_download_rejects_unsafe_model_id_before_any_request(self, tmp_path):
+        client = _make_sync_client(None)
+        with pytest.raises(ValueError, match="unsafe model id"):
+            client.download_weights("weaver://../checkpoints/x", tmp_path / "out")
+        client.http.get.assert_not_called()
+
+    def test_async_download_rejects_unsafe_model_id(self, tmp_path):
+        client = _make_async_client(None)
+        with pytest.raises(ValueError, match="unsafe model id"):
+            asyncio.run(client.download_weights("weaver://../checkpoints/x", tmp_path / "out"))
+        client.http.get.assert_not_called()
+
+
+class TestPartSymlinkGuard:
+    def test_preplanted_part_symlink_is_rejected(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files = {"owned.bin": b"x"}
+        (dest / "owned.bin.part").symlink_to(outside)
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(
+                transport=httpx.MockTransport(_presigned_handler(files))
+            ),
+        )
+        client = _make_sync_client(_api_routes(_descriptor(files)))
+        with pytest.raises(ValueError, match="refusing to write through a symlink"):
+            client.download_weights(ARTIFACT_UUID, dest)
+        assert outside.read_bytes() == b""

--- a/tests/test_hf_download.py
+++ b/tests/test_hf_download.py
@@ -246,6 +246,23 @@ class TestDescriptorFiles:
         with pytest.raises(ValueError, match="non-canonical file name"):
             descriptor_files(bad)
 
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "..\\owned.bin",
+            "a\\..\\owned.bin",
+            "C:\\Users\\victim\\owned.bin",
+            "\\Windows\\owned.bin",
+            "C:foo",
+        ],
+    )
+    def test_rejects_windows_traversal_names(self, name):
+        # PurePosixPath treats these as single ordinary names, but the final
+        # dest_dir / name write uses HOST semantics — on Windows they escape
+        # or replace dest_dir.
+        with pytest.raises(ValueError, match="unsafe file name"):
+            descriptor_files(_descriptor({name: b"x"}))
+
     def test_rejects_duplicate_names(self):
         descriptor = _descriptor(FILES)
         descriptor["files"].append(dict(descriptor["files"][0]))

--- a/tests/test_hf_download.py
+++ b/tests/test_hf_download.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import os
+from pathlib import PurePosixPath
 from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,7 +27,7 @@ import httpx
 import pytest
 from click.testing import CliRunner
 
-from weaver import _async_http, _http, async_service_client, service_client
+from weaver import _async_http, _http, _safeio, async_service_client, service_client
 from weaver._artifacts import (
     descriptor_files,
     parse_download_target,
@@ -290,16 +292,19 @@ class TestDescriptorFiles:
 
 
 class TestStreamDownload:
+    """The streamer writes into a sink its caller opened (and anchored)."""
+
     def test_full_download(self, tmp_path):
         content = FILES["adapter_model.safetensors"]
         transport = httpx.MockTransport(_presigned_handler(FILES))
         dest = tmp_path / "shard.bin"
         with httpx.Client(transport=transport) as client:
-            written = stream_download_to_file(
-                "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
-                dest,
-                client=client,
-            )
+            with open(dest, "wb") as sink:
+                written = stream_download_to_file(
+                    "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
+                    sink,
+                    client=client,
+                )
         assert written == len(content)
         assert dest.read_bytes() == content
 
@@ -309,12 +314,13 @@ class TestStreamDownload:
         dest = tmp_path / "shard.bin"
         dest.write_bytes(content[:100])
         with httpx.Client(transport=transport) as client:
-            written = stream_download_to_file(
-                "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
-                dest,
-                client=client,
-                resume_from=100,
-            )
+            with open(dest, "ab") as sink:
+                written = stream_download_to_file(
+                    "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
+                    sink,
+                    client=client,
+                    resume_from=100,
+                )
         assert written == len(content)
         assert dest.read_bytes() == content
 
@@ -327,21 +333,25 @@ class TestStreamDownload:
         dest = tmp_path / "f.bin"
         dest.write_bytes(b"stale-partial")
         with httpx.Client(transport=httpx.MockTransport(handler)) as client:
-            written = stream_download_to_file(
-                "https://tos.example.com/f", dest, client=client, resume_from=13
-            )
+            # Opened for append because the caller intended to resume; the 200
+            # forces the streamer to drop the stale bytes rather than append.
+            with open(dest, "ab") as sink:
+                written = stream_download_to_file(
+                    "https://tos.example.com/f", sink, client=client, resume_from=13
+                )
         assert written == len(content)
         assert dest.read_bytes() == content
 
     def test_expired_url_raises_dedicated_error(self, tmp_path):
         transport = httpx.MockTransport(_presigned_handler(FILES))
         with httpx.Client(transport=transport) as client:
-            with pytest.raises(DownloadURLExpiredError):
-                stream_download_to_file(
-                    "https://tos.example.com/files/adapter_config.json?sig=expired",
-                    tmp_path / "f.bin",
-                    client=client,
-                )
+            with open(tmp_path / "f.bin", "wb") as sink:
+                with pytest.raises(DownloadURLExpiredError):
+                    stream_download_to_file(
+                        "https://tos.example.com/files/adapter_config.json?sig=expired",
+                        sink,
+                        client=client,
+                    )
 
     def test_async_twin_full_download(self, tmp_path):
         content = FILES["adapter_model.safetensors"]
@@ -350,11 +360,32 @@ class TestStreamDownload:
 
         async def run():
             async with httpx.AsyncClient(transport=transport) as client:
-                return await _async_http.async_stream_download_to_file(
-                    "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
-                    dest,
-                    client=client,
-                )
+                with open(dest, "wb") as sink:
+                    return await _async_http.async_stream_download_to_file(
+                        "https://tos.example.com/files/adapter_model.safetensors?sig=ok",
+                        sink,
+                        client=client,
+                    )
+
+        written = asyncio.run(run())
+        assert written == len(content)
+        assert dest.read_bytes() == content
+
+    def test_async_twin_restart_when_server_ignores_range(self, tmp_path):
+        content = b"full-content"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=content)  # no Range support
+
+        dest = tmp_path / "f.bin"
+        dest.write_bytes(b"stale-partial")
+
+        async def run():
+            async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+                with open(dest, "ab") as sink:
+                    return await _async_http.async_stream_download_to_file(
+                        "https://tos.example.com/f", sink, client=client, resume_from=13
+                    )
 
         written = asyncio.run(run())
         assert written == len(content)
@@ -734,6 +765,7 @@ class TestBareDownloadClient:
 
 class TestSymlinkContainment:
     def test_symlink_inside_dest_cannot_escape(self, tmp_path, monkeypatch):
+        calls: list = []
         outside = tmp_path / "outside"
         outside.mkdir()
         dest = tmp_path / "out"
@@ -744,7 +776,7 @@ class TestSymlinkContainment:
             service_client,
             "build_download_client",
             lambda timeout=None: httpx.Client(
-                transport=httpx.MockTransport(_presigned_handler(files))
+                transport=httpx.MockTransport(_presigned_handler(files, calls))
             ),
         )
         client = _make_sync_client(_api_routes(_descriptor(files)))
@@ -752,8 +784,10 @@ class TestSymlinkContainment:
             client.download_weights(ARTIFACT_UUID, dest)
         assert not (outside / "owned.bin").exists()
         assert not (outside / "owned.bin.part").exists()
+        assert not calls  # rejected before a single byte was fetched
 
     def test_async_symlink_inside_dest_cannot_escape(self, tmp_path, monkeypatch):
+        calls: list = []
         outside = tmp_path / "outside"
         outside.mkdir()
         dest = tmp_path / "out"
@@ -764,13 +798,277 @@ class TestSymlinkContainment:
             async_service_client,
             "build_async_download_client",
             lambda timeout=None: httpx.AsyncClient(
-                transport=httpx.MockTransport(_presigned_handler(files))
+                transport=httpx.MockTransport(_presigned_handler(files, calls))
             ),
         )
         client = _make_async_client(_api_routes(_descriptor(files)))
         with pytest.raises(ValueError, match="outside the destination"):
             asyncio.run(client.download_weights(ARTIFACT_UUID, dest))
         assert not (outside / "owned.bin").exists()
+        assert not calls
+
+
+# ---------------------------------------------------------------------------
+# Descriptor-anchored destination walk (weaver._safeio)
+# ---------------------------------------------------------------------------
+
+requires_dir_fd = pytest.mark.skipif(
+    not _safeio.supports_dir_fd(), reason="platform has no dir_fd support"
+)
+
+
+@requires_dir_fd
+class TestAnchoredWalk:
+    def test_creates_and_returns_the_leaf_directory(self, tmp_path):
+        dest = tmp_path / "out"
+        dest.mkdir()
+
+        parent_fd = _safeio.open_parent_fd(dest, PurePosixPath("a/b/file.bin"), create=True)
+        try:
+            assert (dest / "a" / "b").is_dir()
+            with _safeio.open_for_write(parent_fd, "file.bin", append=False) as sink:
+                sink.write(b"payload")
+        finally:
+            os.close(parent_fd)
+
+        assert (dest / "a" / "b" / "file.bin").read_bytes() == b"payload"
+
+    def test_symlinked_intermediate_is_rejected(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "sub").symlink_to(outside)
+
+        with pytest.raises(ValueError, match="unsafe path component"):
+            _safeio.open_parent_fd(dest, PurePosixPath("sub/owned.bin"), create=True)
+
+    def test_walk_creates_nothing_outside_before_rejecting(self, tmp_path):
+        # Regression for the reported side effect: mkdir(parents=True) used to
+        # run ahead of the containment check and materialized a directory in
+        # the link target before anything raised.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "link").symlink_to(outside)
+
+        with pytest.raises(ValueError, match="unsafe path component"):
+            _safeio.open_parent_fd(dest, PurePosixPath("link/newdir/file.bin"), create=True)
+
+        assert list(outside.iterdir()) == []
+
+    def test_symlink_to_a_directory_inside_dest_is_also_rejected(self, tmp_path):
+        # The resolved-parent check would accept this one. The walk follows NO
+        # component, which is what makes the anchor unconditional.
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "real").mkdir()
+        (dest / "link").symlink_to(dest / "real")
+
+        with pytest.raises(ValueError, match="unsafe path component"):
+            _safeio.open_parent_fd(dest, PurePosixPath("link/owned.bin"), create=True)
+
+    def test_file_where_a_directory_is_expected_is_rejected(self, tmp_path):
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "sub").write_bytes(b"not a directory")
+
+        with pytest.raises(ValueError, match="unsafe path component"):
+            _safeio.open_parent_fd(dest, PurePosixPath("sub/owned.bin"), create=True)
+
+    def test_anchor_survives_a_directory_swap(self, tmp_path):
+        """The TOCTOU kill in isolation: swap the name AFTER the walk.
+
+        A descriptor names an inode. Once the walk has one, re-pointing the
+        path it came from is inert — no later call re-traverses the name.
+        """
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "sub").mkdir()
+
+        parent_fd = _safeio.open_parent_fd(dest, PurePosixPath("sub/owned.bin"), create=True)
+        try:
+            # Everything an attacker winning the race could do to the name.
+            os.rename(dest / "sub", dest / "sub-moved")
+            (dest / "sub").symlink_to(outside)
+
+            with _safeio.open_for_write(parent_fd, "owned.bin.part", append=False) as sink:
+                sink.write(b"anchored")
+            _safeio.rename_within(parent_fd, "owned.bin.part", "owned.bin")
+            assert os.listdir(parent_fd) == ["owned.bin"]
+        finally:
+            os.close(parent_fd)
+
+        assert (dest / "sub-moved" / "owned.bin").read_bytes() == b"anchored"
+        assert list(outside.iterdir()) == []
+
+
+@requires_dir_fd
+class TestDownloadAnchoring:
+    """End-to-end: the bytes land where the walk pointed, not where the name does."""
+
+    @staticmethod
+    def _swapping_handler(files, dest, outside, swapped):
+        """Presigned handler that swaps ``dest/sub`` out mid-download.
+
+        By the time a request reaches the transport, ``_download_weights_file``
+        has already walked and pinned the parent descriptor, so this is the
+        exact interleaving a racing attacker needs — made deterministic. The
+        first attempt then dies with a transport error, which puts the *whole*
+        remainder of the download after the swap: the resume stat, the reopen,
+        the write, the hash and the publishing rename.
+        """
+        base = _presigned_handler(files)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if not swapped:
+                os.rename(dest / "sub", dest / "sub-moved")
+                (dest / "sub").symlink_to(outside)
+                swapped.append(True)
+                raise httpx.ReadError("connection reset")
+            return base(request)
+
+        return handler
+
+    def _prepare(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "sub").mkdir()
+        return dest, outside, {"sub/owned.bin": b"anchored-bytes"}
+
+    def _assert_landed_inside(self, dest, outside, swapped):
+        assert swapped, "the swap must actually have happened mid-download"
+        assert (dest / "sub-moved" / "owned.bin").read_bytes() == b"anchored-bytes"
+        assert not (outside / "owned.bin").exists()
+        assert not (outside / "owned.bin.part").exists()
+        assert list(outside.iterdir()) == []
+
+    def test_sync_write_and_publish_follow_the_descriptor(self, tmp_path, monkeypatch):
+        dest, outside, files = self._prepare(tmp_path)
+        swapped: list = []
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(
+                transport=httpx.MockTransport(self._swapping_handler(files, dest, outside, swapped))
+            ),
+        )
+        client = _make_sync_client(_api_routes(_descriptor(files)))
+
+        client.download_weights(ARTIFACT_UUID, dest)
+
+        self._assert_landed_inside(dest, outside, swapped)
+
+    def test_async_write_and_publish_follow_the_descriptor(self, tmp_path, monkeypatch):
+        dest, outside, files = self._prepare(tmp_path)
+        swapped: list = []
+        monkeypatch.setattr(
+            async_service_client,
+            "build_async_download_client",
+            lambda timeout=None: httpx.AsyncClient(
+                transport=httpx.MockTransport(self._swapping_handler(files, dest, outside, swapped))
+            ),
+        )
+        client = _make_async_client(_api_routes(_descriptor(files)))
+
+        asyncio.run(client.download_weights(ARTIFACT_UUID, dest))
+
+        self._assert_landed_inside(dest, outside, swapped)
+
+
+class TestUnanchoredFallback:
+    """Platforms without ``dir_fd`` (Windows) keep the previous path-based flow."""
+
+    @pytest.fixture
+    def no_dir_fd(self, monkeypatch):
+        monkeypatch.setattr(os, "supports_dir_fd", frozenset())
+        assert not _safeio.supports_dir_fd()
+
+    def test_sync_download_uses_the_legacy_path(self, tmp_path, monkeypatch, no_dir_fd):
+        def unreachable(*_args, **_kwargs):
+            raise AssertionError("the anchored walk must not run without dir_fd support")
+
+        monkeypatch.setattr(service_client, "open_parent_fd", unreachable)
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(
+                transport=httpx.MockTransport(_presigned_handler(FILES))
+            ),
+        )
+        client = _make_sync_client(_api_routes(_descriptor(FILES)))
+
+        dest = client.download_weights(ARTIFACT_UUID, tmp_path / "out")
+
+        for name, content in FILES.items():
+            assert (dest / name).read_bytes() == content
+        assert not list(dest.rglob("*.part"))
+
+    def test_async_download_uses_the_legacy_path(self, tmp_path, monkeypatch, no_dir_fd):
+        def unreachable(*_args, **_kwargs):
+            raise AssertionError("the anchored walk must not run without dir_fd support")
+
+        monkeypatch.setattr(async_service_client, "open_parent_fd", unreachable)
+        monkeypatch.setattr(
+            async_service_client,
+            "build_async_download_client",
+            lambda timeout=None: httpx.AsyncClient(
+                transport=httpx.MockTransport(_presigned_handler(FILES))
+            ),
+        )
+        client = _make_async_client(_api_routes(_descriptor(FILES)))
+
+        dest = asyncio.run(client.download_weights(ARTIFACT_UUID, tmp_path / "out"))
+
+        for name, content in FILES.items():
+            assert (dest / name).read_bytes() == content
+        assert not list(dest.rglob("*.part"))
+
+    def test_legacy_path_still_resumes(self, tmp_path, monkeypatch, no_dir_fd):
+        calls: list = []
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(
+                transport=httpx.MockTransport(_presigned_handler(SINGLE_FILE, calls))
+            ),
+        )
+        client = _make_sync_client(_api_routes(_descriptor(SINGLE_FILE)))
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "shard.bin.part").write_bytes(SINGLE_FILE["shard.bin"][:100])
+
+        client.download_weights(ARTIFACT_UUID, dest, max_concurrency=1)
+
+        assert (dest / "shard.bin").read_bytes() == SINGLE_FILE["shard.bin"]
+        assert calls[0].headers["Range"] == "bytes=100-"
+
+    def test_legacy_path_still_rejects_a_preplanted_part_symlink(
+        self, tmp_path, monkeypatch, no_dir_fd
+    ):
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files = {"owned.bin": b"x"}
+        (dest / "owned.bin.part").symlink_to(outside)
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(
+                transport=httpx.MockTransport(_presigned_handler(files))
+            ),
+        )
+        client = _make_sync_client(_api_routes(_descriptor(files)))
+
+        with pytest.raises(ValueError, match="refusing to write through a symlink"):
+            client.download_weights(ARTIFACT_UUID, dest)
+        assert outside.read_bytes() == b""
 
 
 class TestUriModelIdGuard:
@@ -801,6 +1099,12 @@ class TestUriModelIdGuard:
 
 
 class TestPartSymlinkGuard:
+    """A ``.part`` name held by a symlink is refused, not written through.
+
+    The anchored path catches this at the resume ``lstat``, before anything is
+    opened: the link is seen as a link instead of being measured through.
+    """
+
     def test_preplanted_part_symlink_is_rejected(self, tmp_path, monkeypatch):
         outside = tmp_path / "outside.bin"
         outside.write_bytes(b"")
@@ -819,3 +1123,48 @@ class TestPartSymlinkGuard:
         with pytest.raises(ValueError, match="refusing to write through a symlink"):
             client.download_weights(ARTIFACT_UUID, dest)
         assert outside.read_bytes() == b""
+
+    def test_async_preplanted_part_symlink_is_rejected(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files = {"owned.bin": b"x"}
+        (dest / "owned.bin.part").symlink_to(outside)
+        monkeypatch.setattr(
+            async_service_client,
+            "build_async_download_client",
+            lambda timeout=None: httpx.AsyncClient(
+                transport=httpx.MockTransport(_presigned_handler(files))
+            ),
+        )
+        client = _make_async_client(_api_routes(_descriptor(files)))
+        with pytest.raises(ValueError, match="refusing to write through a symlink"):
+            asyncio.run(client.download_weights(ARTIFACT_UUID, dest))
+        assert outside.read_bytes() == b""
+
+    @requires_dir_fd
+    def test_symlink_at_the_final_name_is_replaced_not_written_through(self, tmp_path, monkeypatch):
+        # A link planted at the *published* name must not be treated as
+        # finished work, and the publishing rename must replace the link
+        # itself rather than following it.
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"untouched")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files = {"owned.bin": b"real-content"}
+        (dest / "owned.bin").symlink_to(outside)
+        monkeypatch.setattr(
+            service_client,
+            "build_download_client",
+            lambda timeout=None: httpx.Client(
+                transport=httpx.MockTransport(_presigned_handler(files))
+            ),
+        )
+        client = _make_sync_client(_api_routes(_descriptor(files)))
+
+        client.download_weights(ARTIFACT_UUID, dest)
+
+        assert not (dest / "owned.bin").is_symlink()
+        assert (dest / "owned.bin").read_bytes() == b"real-content"
+        assert outside.read_bytes() == b"untouched"

--- a/tests/test_hf_export.py
+++ b/tests/test_hf_export.py
@@ -34,9 +34,11 @@ from weaver.types.weights_artifact import WeightsArtifact
 # Helpers
 # ---------------------------------------------------------------------------
 
+CHECKPOINT_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
 ARTIFACT_PAYLOAD: Dict[str, Any] = {
-    "id": "art-1",
-    "checkpoint_id": "ckpt-1",
+    "id": "aaaa1111-bb22-4c33-8d44-eeee5555ffff",
+    "checkpoint_id": CHECKPOINT_UUID,
     "model_id": "mdl-123",
     "kind": "hf_adapter",
     "status": "completed",
@@ -88,8 +90,8 @@ def _done_operation(response: Dict[str, Any]) -> Dict[str, Any]:
 class TestWeightsArtifactType:
     def test_from_payload(self):
         artifact = WeightsArtifact.from_payload(ARTIFACT_PAYLOAD)
-        assert artifact.id == "art-1"
-        assert artifact.checkpoint_id == "ckpt-1"
+        assert artifact.id == "aaaa1111-bb22-4c33-8d44-eeee5555ffff"
+        assert artifact.checkpoint_id == CHECKPOINT_UUID
         assert artifact.model_id == "mdl-123"
         assert artifact.kind == "hf_adapter"
         assert artifact.status == "completed"
@@ -118,7 +120,7 @@ class TestWeightsArtifactType:
         assert artifact.error == "conversion failed"
 
     def test_is_frozen(self):
-        artifact = WeightsArtifact(id="art-1")
+        artifact = WeightsArtifact(id="aaaa1111-bb22-4c33-8d44-eeee5555ffff")
         with pytest.raises(AttributeError):
             artifact.id = "art-2"  # type: ignore[misc]
 
@@ -136,7 +138,7 @@ class TestExportWeights:
         artifact = tc.export_weights()
 
         assert isinstance(artifact, WeightsArtifact)
-        assert artifact.id == "art-1"
+        assert artifact.id == "aaaa1111-bb22-4c33-8d44-eeee5555ffff"
         args = tc._service.http.post.call_args
         assert args[0][0] == "/api/v1/models/mdl-123/export-hf"
         assert args[1]["json"] == {
@@ -150,12 +152,12 @@ class TestExportWeights:
         tc = _make_training_client()
         tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
 
-        ckpt = Checkpoint(id="ckpt-1", path="weaver://mdl-123/checkpoints/step-5")
+        ckpt = Checkpoint(id=CHECKPOINT_UUID, path="weaver://mdl-123/checkpoints/step-5")
         artifact = tc.export_weights(checkpoint=ckpt, merge_adapter=True, force=True)
 
         assert isinstance(artifact, WeightsArtifact)
         args = tc._service.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/export"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/export"
         assert args[1]["json"] == {
             "format": "huggingface",
             "merge_adapter": True,
@@ -167,10 +169,10 @@ class TestExportWeights:
         tc = _make_training_client()
         tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
 
-        tc.export_weights(checkpoint="ckpt-raw", ttl_seconds=None)
+        tc.export_weights(checkpoint=CHECKPOINT_UUID, ttl_seconds=None)
 
         args = tc._service.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-raw/export"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/export"
         assert args[1]["json"]["ttl_seconds"] is None
 
     def test_checkpoint_export_resolves_weaver_path(self):
@@ -178,7 +180,7 @@ class TestExportWeights:
         tc._service.http.get.return_value = {
             "items": [
                 {"id": "ckpt-0", "path": "weaver://mdl-123/checkpoints/step-1"},
-                {"id": "ckpt-1", "path": "weaver://mdl-123/checkpoints/step-5"},
+                {"id": CHECKPOINT_UUID, "path": "weaver://mdl-123/checkpoints/step-5"},
             ]
         }
         tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
@@ -187,7 +189,7 @@ class TestExportWeights:
 
         tc._service.http.get.assert_called_once_with("/api/v1/models/mdl-123/checkpoints")
         args = tc._service.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/export"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/export"
 
     def test_checkpoint_export_unknown_path_raises(self):
         tc = _make_training_client()
@@ -210,7 +212,7 @@ class TestExportWeights:
         tc = _make_training_client()
         tc._service.http.post.return_value = dict(ARTIFACT_PAYLOAD)
 
-        artifact = tc.export_weights(checkpoint="ckpt-1", wait=False)
+        artifact = tc.export_weights(checkpoint=CHECKPOINT_UUID, wait=False)
 
         assert isinstance(artifact, WeightsArtifact)
         assert artifact.status == "completed"
@@ -219,7 +221,7 @@ class TestExportWeights:
         tc = _make_training_client()
         tc._service.http.post.return_value = {"id": "op-9", "status": "pending"}
 
-        handle = tc.export_weights(checkpoint="ckpt-1", wait=False)
+        handle = tc.export_weights(checkpoint=CHECKPOINT_UUID, wait=False)
 
         assert isinstance(handle, OperationHandle)
         assert handle.operation_id == "op-9"
@@ -228,11 +230,11 @@ class TestExportWeights:
         tc = _make_training_client()
         tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
 
-        artifact = tc.export_weights(checkpoint="ckpt-1")
+        artifact = tc.export_weights(checkpoint=CHECKPOINT_UUID)
 
         assert isinstance(artifact, WeightsArtifact)
         assert artifact.kind == "hf_adapter"
-        assert artifact.checkpoint_id == "ckpt-1"
+        assert artifact.checkpoint_id == CHECKPOINT_UUID
 
     def test_empty_checkpoint_reference_raises(self):
         tc = _make_training_client()
@@ -259,7 +261,7 @@ class TestAsyncExportWeights:
         artifact = asyncio.run(tc.export_weights())
 
         assert isinstance(artifact, WeightsArtifact)
-        assert artifact.id == "art-1"
+        assert artifact.id == "aaaa1111-bb22-4c33-8d44-eeee5555ffff"
         args = tc._service.http.post.call_args
         assert args[0][0] == "/api/v1/models/mdl-123/export-hf"
         assert args[1]["json"] == {
@@ -272,7 +274,7 @@ class TestAsyncExportWeights:
     def test_checkpoint_export_resolves_weaver_path(self):
         tc = _make_async_training_client()
         tc._service.http.get.return_value = {
-            "items": [{"id": "ckpt-1", "path": "weaver://mdl-123/checkpoints/step-5"}]
+            "items": [{"id": CHECKPOINT_UUID, "path": "weaver://mdl-123/checkpoints/step-5"}]
         }
         tc._service.http.post.return_value = _done_operation(ARTIFACT_PAYLOAD)
 
@@ -282,14 +284,14 @@ class TestAsyncExportWeights:
 
         assert isinstance(artifact, WeightsArtifact)
         args = tc._service.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/export"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/export"
         assert args[1]["json"]["force"] is True
 
     def test_idempotent_completed_hit_returns_artifact_even_without_wait(self):
         tc = _make_async_training_client()
         tc._service.http.post.return_value = dict(ARTIFACT_PAYLOAD)
 
-        artifact = asyncio.run(tc.export_weights(checkpoint="ckpt-1", wait=False))
+        artifact = asyncio.run(tc.export_weights(checkpoint=CHECKPOINT_UUID, wait=False))
 
         assert isinstance(artifact, WeightsArtifact)
         assert artifact.status == "completed"
@@ -298,7 +300,7 @@ class TestAsyncExportWeights:
         tc = _make_async_training_client()
         tc._service.http.post.return_value = {"id": "op-9", "status": "pending"}
 
-        handle = asyncio.run(tc.export_weights(checkpoint="ckpt-1", wait=False))
+        handle = asyncio.run(tc.export_weights(checkpoint=CHECKPOINT_UUID, wait=False))
 
         assert isinstance(handle, AsyncOperationHandle)
         assert handle.operation_id == "op-9"
@@ -325,12 +327,12 @@ class TestCheckpointExportCLI:
         monkeypatch.delenv("WEAVER_API_KEY", raising=False)
         client = self._client()
         with patch("weaver.cli.ServiceClient", return_value=client):
-            result = CliRunner().invoke(cli, ["checkpoint", "export", "ckpt-1"])
+            result = CliRunner().invoke(cli, ["checkpoint", "export", CHECKPOINT_UUID])
 
         assert result.exit_code == 0
         client.connect.assert_called_once_with(ensure_session=False)
         args = client.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-1/export"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/export"
         assert args[1]["json"] == {
             "format": "huggingface",
             "merge_adapter": False,
@@ -345,7 +347,7 @@ class TestCheckpointExportCLI:
         monkeypatch.delenv("WEAVER_API_KEY", raising=False)
         client = self._client()
         client.http.get.return_value = {
-            "items": [{"id": "ckpt-7", "path": "weaver://mdl-123/checkpoints/step-5"}]
+            "items": [{"id": CHECKPOINT_UUID, "path": "weaver://mdl-123/checkpoints/step-5"}]
         }
         with patch("weaver.cli.ServiceClient", return_value=client):
             result = CliRunner().invoke(
@@ -364,7 +366,7 @@ class TestCheckpointExportCLI:
         assert result.exit_code == 0
         client.http.get.assert_called_once_with("/api/v1/models/mdl-123/checkpoints")
         args = client.http.post.call_args
-        assert args[0][0] == "/api/v1/checkpoints/ckpt-7/export"
+        assert args[0][0] == f"/api/v1/checkpoints/{CHECKPOINT_UUID}/export"
         assert args[1]["json"] == {
             "format": "huggingface",
             "merge_adapter": True,
@@ -378,7 +380,7 @@ class TestCheckpointExportCLI:
         client = MagicMock()
         client.http.post.return_value = {"id": "op-42", "status": "pending"}
         with patch("weaver.cli.ServiceClient", return_value=client):
-            result = CliRunner().invoke(cli, ["checkpoint", "export", "ckpt-1", "--no-wait"])
+            result = CliRunner().invoke(cli, ["checkpoint", "export", CHECKPOINT_UUID, "--no-wait"])
 
         assert result.exit_code == 0
         assert "op-42" in result.output
@@ -389,7 +391,7 @@ class TestCheckpointExportCLI:
         client = MagicMock()
         client.http.post.return_value = dict(ARTIFACT_PAYLOAD)
         with patch("weaver.cli.ServiceClient", return_value=client):
-            result = CliRunner().invoke(cli, ["checkpoint", "export", "ckpt-1"])
+            result = CliRunner().invoke(cli, ["checkpoint", "export", CHECKPOINT_UUID])
 
         assert result.exit_code == 0
         assert "already completed" in result.output

--- a/tests/test_hf_export.py
+++ b/tests/test_hf_export.py
@@ -395,3 +395,15 @@ class TestCheckpointExportCLI:
 
         assert result.exit_code == 0
         assert "already completed" in result.output
+
+
+class TestExportCLIIdGuard:
+    @pytest.mark.parametrize("raw", ["../models/target", "a/b", "ckpt-1"])
+    def test_checkpoint_export_rejects_traversal_ids(self, monkeypatch, raw):
+        monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+        monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+        client = MagicMock()
+        with patch("weaver.cli.ServiceClient", return_value=client):
+            result = CliRunner().invoke(cli, ["checkpoint", "export", raw, "--no-wait"])
+        assert result.exit_code != 0
+        client.http.post.assert_not_called()

--- a/weaver/__init__.py
+++ b/weaver/__init__.py
@@ -30,6 +30,7 @@ from .async_service_client import AsyncServiceClient  # noqa: F401
 from .async_training_client import AsyncTrainingClient  # noqa: F401
 from .operations import AsyncOperationHandle, OperationHandle  # noqa: F401
 from .service_client import ServiceClient  # noqa: F401
+from .types.deployment import Deployment  # noqa: F401
 from .types.weights_artifact import WeightsArtifact  # noqa: F401
 
 __all__ = [
@@ -41,6 +42,7 @@ __all__ = [
     "AsyncOperationHandle",
     "WeaverAPIError",
     "WeightsArtifact",
+    "Deployment",
     "types",
     "__version__",
 ]

--- a/weaver/_artifacts.py
+++ b/weaver/_artifacts.py
@@ -410,11 +410,22 @@ def is_file_already_complete(final_path: Path, entry: ArtifactFile, *, verify: b
 def resume_offset_at(parent_fd: int, part_name: str, entry: ArtifactFile) -> int:
     """Bytes of *part_name* a Range request may safely resume from.
 
-    The ``.part`` is inspected with ``lstat`` through the anchored descriptor,
-    so a symlink planted at that name is rejected here rather than quietly
-    redirecting the resumed write to its target. A partial longer than the
-    manifest says the whole file is cannot be a prefix of it, so it is
-    discarded and the download restarts.
+    Resume policy (option (a) from the review thread): stable-name resume is
+    kept, but only from a ``.part`` that is a plain single-linked regular file
+    the caller can safely append to. Anything else is not resumed:
+
+    - a symlink or non-regular file is refused outright (a planted redirect);
+    - a partial longer than the manifest whole-file size cannot be a prefix of
+      it, so it is discarded and the download restarts;
+    - an empty partial carries nothing to resume, so it too is dropped.
+
+    Whenever this returns 0 the ``.part`` name is guaranteed free, so the
+    caller's fresh :func:`weaver._safeio.open_for_write` can create a brand-new
+    inode with ``O_CREAT | O_EXCL`` rather than truncating whatever sits at the
+    name. When it returns a positive offset the caller resumes in append mode,
+    where the hard-link check on the opened descriptor runs before any bytes
+    are written — so a hard link planted at a resumable partial is caught there
+    even though ``lstat`` here cannot tell it apart from an ordinary file.
 
     Raises:
         ValueError: The ``.part`` name is held by a symlink or another
@@ -429,6 +440,11 @@ def resume_offset_at(parent_fd: int, part_name: str, entry: ArtifactFile) -> int
         raise ValueError(f"refusing to write through a non-regular file: {part_name}")
     if entry.size is not None and info.st_size > entry.size:
         # Longer than the manifest says it should be: poisoned partial.
+        unlink_within(parent_fd, part_name)
+        return 0
+    if info.st_size == 0:
+        # Nothing to resume; drop the empty leftover so the fresh, O_EXCL
+        # create below owns a new inode instead of hitting EEXIST.
         unlink_within(parent_fd, part_name)
         return 0
     return info.st_size

--- a/weaver/_artifacts.py
+++ b/weaver/_artifacts.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import hashlib
 import re
+import uuid
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 from ._utils import lookup_case_insensitive
@@ -50,6 +51,34 @@ _ARTIFACT_URI_RE = re.compile(
     r"^weaver://(?P<model_id>[^/]+)/checkpoints/(?P<name>[^/]+)"
     r"(?:/artifacts/(?P<kind>[^/]+))?/?$"
 )
+
+
+def validate_resource_id(value: str, *, kind: str) -> str:
+    """Validate a caller-supplied resource id before it becomes a URL segment.
+
+    Raw ids are interpolated into API paths; without this check a value like
+    ``../checkpoints/<uuid>`` is dot-segment-normalized by the HTTP stack into
+    a DIFFERENT route (e.g. deleting a checkpoint through the deployments
+    surface). Server resource ids are UUIDs, so anything else is rejected
+    before any request is built.
+
+    Returns:
+        The canonical lowercase hyphenated UUID text, safe to interpolate.
+
+    Raises:
+        ValueError: If *value* is not a canonical UUID.
+    """
+    candidate = (value or "").strip()
+    try:
+        parsed = uuid.UUID(candidate)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError(f"{kind} id must be a UUID, got {value!r}") from exc
+    canonical = str(parsed)
+    if candidate.lower() != canonical:
+        # Reject aliases (unhyphenated/braced/urn forms) so the text that
+        # reaches the URL is exactly the text that was validated.
+        raise ValueError(f"{kind} id must be a canonical hyphenated UUID, got {value!r}")
+    return canonical
 
 
 @dataclass(frozen=True)
@@ -86,8 +115,9 @@ def parse_download_target(target: str) -> ArtifactTarget:
     if not normalized:
         raise ValueError("download target must not be empty")
     if not normalized.startswith("weaver://"):
-        # Anything that is not a weaver URI is treated as an artifact id.
-        return ArtifactTarget(artifact_id=normalized)
+        # Anything that is not a weaver URI is treated as an artifact id, and
+        # must therefore be a canonical UUID (it becomes a URL path segment).
+        return ArtifactTarget(artifact_id=validate_resource_id(normalized, kind="artifact"))
     match = _ARTIFACT_URI_RE.match(normalized)
     if not match:
         raise ValueError(
@@ -226,6 +256,16 @@ def descriptor_files(descriptor: Any) -> List[ArtifactFile]:
         url = str(lookup_case_insensitive(raw, "url") or "")
         if not name or not url:
             raise ValueError(f"descriptor file entry missing name or url: {raw!r}")
+        if "\\" in name:
+            # PurePosixPath treats backslashes as ordinary characters, but the
+            # final ``dest_dir / name`` uses HOST semantics — on Windows a
+            # backslash is a separator and ``..\\owned.bin`` escapes dest_dir.
+            raise ValueError(f"unsafe file name in download descriptor: {name!r}")
+        windows_view = PureWindowsPath(name)
+        if windows_view.drive or windows_view.root or ".." in windows_view.parts:
+            # Rejects drive-absolute (C:\\...), drive-relative (C:foo) and
+            # rooted (\\Windows\\...) spellings that are traversal on Windows.
+            raise ValueError(f"unsafe file name in download descriptor: {name!r}")
         pure = PurePosixPath(name)
         if not pure.parts or pure.is_absolute() or ".." in pure.parts:
             raise ValueError(f"unsafe file name in download descriptor: {name!r}")

--- a/weaver/_artifacts.py
+++ b/weaver/_artifacts.py
@@ -47,6 +47,14 @@ DOWNLOAD_MAX_TRANSPORT_RETRIES = 3
 
 # ``weaver://{model_id}/checkpoints/{name}`` optionally followed by
 # ``/artifacts/{kind}`` (the artifact URI shape).
+# Windows device names are reserved in EVERY directory and with any extension
+# ("CON.txt" still names the console device). Checked per path component.
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{i}" for i in range(1, 10)}
+    | {f"LPT{i}" for i in range(1, 10)}
+)
+
 _ARTIFACT_URI_RE = re.compile(
     r"^weaver://(?P<model_id>[^/]+)/checkpoints/(?P<name>[^/]+)"
     r"(?:/artifacts/(?P<kind>[^/]+))?/?$"
@@ -269,6 +277,15 @@ def descriptor_files(descriptor: Any) -> List[ArtifactFile]:
         pure = PurePosixPath(name)
         if not pure.parts or pure.is_absolute() or ".." in pure.parts:
             raise ValueError(f"unsafe file name in download descriptor: {name!r}")
+        for component in pure.parts:
+            stripped = component.rstrip(" .")
+            stem = component.split(".", 1)[0].upper()
+            if (
+                ":" in component  # ADS syntax / drive remnants
+                or stripped != component  # trailing dot/space alias on Windows
+                or stem in _WINDOWS_RESERVED_NAMES  # device names, with or without extension
+            ):
+                raise ValueError(f"unsafe file name in download descriptor: {name!r}")
         if name != str(pure):
             # A name whose literal text differs from its normalized form
             # (``a//b``, ``a/./b``, ``foo/``) can alias another entry's
@@ -344,3 +361,24 @@ def is_file_already_complete(final_path: Path, entry: ArtifactFile, *, verify: b
     if verify and entry.sha256:
         return file_sha256(final_path) == entry.sha256
     return True
+
+
+def ensure_within_directory(dest_dir: Path, candidate_parent: Path) -> None:
+    """Require *candidate_parent* (resolved) to stay under *dest_dir* (resolved).
+
+    Lexical name validation cannot see the filesystem: a pre-existing symlink
+    inside the destination (``dest/link -> /tmp/outside``) turns the validated
+    name ``link/owned.bin`` into a write outside the tree. Resolving both
+    sides closes that hole; combined with O_NOFOLLOW on the final open this
+    leaves only a narrow, accepted check-to-use window.
+
+    Raises:
+        ValueError: When the resolved parent escapes the destination.
+    """
+    resolved_dest = dest_dir.resolve()
+    resolved_parent = candidate_parent.resolve()
+    if not (resolved_parent == resolved_dest or resolved_parent.is_relative_to(resolved_dest)):
+        raise ValueError(
+            f"descriptor file resolves outside the destination directory: "
+            f"{candidate_parent} -> {resolved_parent}"
+        )

--- a/weaver/_artifacts.py
+++ b/weaver/_artifacts.py
@@ -14,20 +14,25 @@
 
 """HF weights export/download helpers shared by the sync and async clients.
 
-Everything in this module is pure (no IO) so both client stacks build
-identical requests and interpret identical responses; see
-``.claude/rules/async-compatibility.md``.
+Request building and response parsing here are pure (no IO) so both client
+stacks build identical requests and interpret identical responses; see
+``.claude/rules/async-compatibility.md``. The download-side helpers at the end
+of the module are the deliberate exception: they touch the local filesystem,
+and both stacks share them verbatim so resume, verification and publish
+semantics cannot drift apart.
 """
 
 from __future__ import annotations
 
 import hashlib
 import re
+import stat
 import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Any, Dict, List, Optional
+from typing import Any, BinaryIO, Dict, List, Optional
 
+from ._safeio import open_for_read, stat_no_follow, unlink_within
 from ._utils import lookup_case_insensitive
 
 # Artifact kinds the server can produce. The server derives the kind
@@ -318,17 +323,36 @@ def descriptor_files(descriptor: Any) -> List[ArtifactFile]:
     return files
 
 
+def hash_stream(fh: BinaryIO) -> str:
+    """Compute the sha256 hex digest of an already-open binary stream.
+
+    Taking a file object rather than a path is what lets the anchored download
+    path hash exactly the bytes it wrote, through the descriptor it wrote them
+    with, instead of re-resolving a name that may since have been replaced.
+    """
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
 def file_sha256(path: Path) -> str:
     """Compute the sha256 hex digest of *path* by streaming it from disk.
 
     Hashing what actually landed on disk (rather than the bytes seen on the
     wire) is deliberate: it also catches short writes and torn resumes.
     """
-    digest = hashlib.sha256()
     with open(path, "rb") as fh:
-        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+        return hash_stream(fh)
+
+
+def sha256_at(parent_fd: int, name: str) -> str:
+    """sha256 of *name* read through *parent_fd*, never through its path."""
+    handle = open_for_read(parent_fd, name)
+    if handle is None:
+        raise FileNotFoundError(name)
+    with handle:
+        return hash_stream(handle)
 
 
 def check_downloaded_file(part_path: Path, entry: ArtifactFile, *, verify: bool) -> None:
@@ -372,14 +396,109 @@ def is_file_already_complete(final_path: Path, entry: ArtifactFile, *, verify: b
     return True
 
 
+# ---------------------------------------------------------------------------
+# Descriptor-anchored twins of the helpers above
+#
+# Same semantics, but every syscall is resolved against a directory descriptor
+# obtained by a no-follow walk (:mod:`weaver._safeio`) instead of against a
+# path that has to be re-traversed — and can therefore be re-pointed — on each
+# call. Both client stacks use these; the path-based versions above survive
+# only for the platform fallback.
+# ---------------------------------------------------------------------------
+
+
+def resume_offset_at(parent_fd: int, part_name: str, entry: ArtifactFile) -> int:
+    """Bytes of *part_name* a Range request may safely resume from.
+
+    The ``.part`` is inspected with ``lstat`` through the anchored descriptor,
+    so a symlink planted at that name is rejected here rather than quietly
+    redirecting the resumed write to its target. A partial longer than the
+    manifest says the whole file is cannot be a prefix of it, so it is
+    discarded and the download restarts.
+
+    Raises:
+        ValueError: The ``.part`` name is held by a symlink or another
+            non-regular file.
+    """
+    info = stat_no_follow(parent_fd, part_name)
+    if info is None:
+        return 0
+    if stat.S_ISLNK(info.st_mode):
+        raise ValueError(f"refusing to write through a symlink: {part_name}")
+    if not stat.S_ISREG(info.st_mode):
+        raise ValueError(f"refusing to write through a non-regular file: {part_name}")
+    if entry.size is not None and info.st_size > entry.size:
+        # Longer than the manifest says it should be: poisoned partial.
+        unlink_within(parent_fd, part_name)
+        return 0
+    return info.st_size
+
+
+def check_downloaded_file_at(
+    parent_fd: int, part_name: str, entry: ArtifactFile, *, verify: bool
+) -> None:
+    """Anchored twin of :func:`check_downloaded_file`.
+
+    Deletes the corrupt file through the same descriptor before raising, so a
+    later retry cannot resume from poisoned bytes.
+
+    Raises:
+        RuntimeError: On a missing file, or a size or sha256 mismatch.
+    """
+    info = stat_no_follow(parent_fd, part_name)
+    if info is None:
+        raise RuntimeError(f"downloaded file disappeared before verification: {entry.name!r}")
+    if entry.size is not None and info.st_size != entry.size:
+        unlink_within(parent_fd, part_name)
+        raise RuntimeError(
+            f"Downloaded size mismatch for {entry.name!r}: "
+            f"expected {entry.size} bytes, got {info.st_size}"
+        )
+    if verify and entry.sha256:
+        actual = sha256_at(parent_fd, part_name)
+        if actual != entry.sha256:
+            unlink_within(parent_fd, part_name)
+            raise RuntimeError(
+                f"sha256 mismatch for {entry.name!r}: " f"expected {entry.sha256}, got {actual}"
+            )
+
+
+def is_file_already_complete_at(
+    parent_fd: int, name: str, entry: ArtifactFile, *, verify: bool
+) -> bool:
+    """Anchored twin of :func:`is_file_already_complete`.
+
+    Only a regular file counts as complete: unlike ``Path.is_file()`` this
+    does not follow a symlink standing at *name*, so a planted link is
+    re-downloaded over (via the ``.part`` and an anchored rename) instead of
+    being trusted as finished work.
+    """
+    if entry.size is None:
+        return False
+    info = stat_no_follow(parent_fd, name)
+    if info is None or not stat.S_ISREG(info.st_mode):
+        return False
+    if info.st_size != entry.size:
+        return False
+    if verify and entry.sha256:
+        return sha256_at(parent_fd, name) == entry.sha256
+    return True
+
+
 def ensure_within_directory(dest_dir: Path, candidate_parent: Path) -> None:
     """Require *candidate_parent* (resolved) to stay under *dest_dir* (resolved).
 
-    Lexical name validation cannot see the filesystem: a pre-existing symlink
-    inside the destination (``dest/link -> /tmp/outside``) turns the validated
-    name ``link/owned.bin`` into a write outside the tree. Resolving both
-    sides closes that hole; combined with O_NOFOLLOW on the final open this
-    leaves only a narrow, accepted check-to-use window.
+    Defense in depth, and no longer the guarantee. This is a cheap early
+    sanity check that rejects an obviously escaping descriptor name — a
+    pre-existing ``dest/link -> /tmp/outside`` turning the validated name
+    ``link/owned.bin`` into a write outside the tree — before anything is
+    created on disk. It cannot be more than that: it reasons about a resolved
+    *name*, and the directory that name points at can be swapped for a symlink
+    immediately afterwards.
+
+    Containment is guaranteed instead by the anchored walk in
+    :mod:`weaver._safeio`, which pins the destination directory by descriptor
+    and issues every write, hash, rename and unlink relative to it.
 
     Raises:
         ValueError: When the resolved parent escapes the destination.

--- a/weaver/_artifacts.py
+++ b/weaver/_artifacts.py
@@ -55,6 +55,10 @@ _WINDOWS_RESERVED_NAMES = frozenset(
     | {f"LPT{i}" for i in range(1, 10)}
 )
 
+# URL path segments derived from URIs must never contain dot-segments or
+# separator characters; server ids are hyphenated-hex UUIDs, well within this.
+_SAFE_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]*")
+
 _ARTIFACT_URI_RE = re.compile(
     r"^weaver://(?P<model_id>[^/]+)/checkpoints/(?P<name>[^/]+)"
     r"(?:/artifacts/(?P<kind>[^/]+))?/?$"
@@ -139,6 +143,11 @@ def parse_download_target(target: str) -> ArtifactTarget:
             f"Unknown artifact kind {kind!r} in {normalized!r}; expected one of {ARTIFACT_KINDS}"
         )
     model_id = match.group("model_id")
+    if not _SAFE_SEGMENT_RE.fullmatch(model_id):
+        # The model id is interpolated into /api/v1/models/{id}/... routes;
+        # '..', encoded dots, '\\' etc. would let a crafted URI reroute the
+        # request. Real model ids are UUIDs, so a conservative charset is safe.
+        raise ValueError(f"unsafe model id in weaver URI: {model_id!r}")
     name = match.group("name")
     return ArtifactTarget(
         model_id=model_id,

--- a/weaver/_artifacts.py
+++ b/weaver/_artifacts.py
@@ -202,8 +202,13 @@ class ArtifactFile:
 def descriptor_files(descriptor: Any) -> List[ArtifactFile]:
     """Validate and normalize ``GET /artifacts/{id}/download`` file entries.
 
-    File names are server-controlled input used to build local paths, so
-    absolute names and ``..`` traversal segments are rejected.
+    File names are server-controlled input used to build local paths, so the
+    validation is strict: absolute names, ``..`` traversal segments, names
+    that normalize to nothing (``.``/``./``, which would alias the destination
+    directory itself), non-canonical spellings (``a//b``, ``a/./b``, trailing
+    slashes — anything whose literal text differs from its normalized form),
+    and duplicate normalized destinations are all rejected before any file is
+    created.
 
     Raises:
         ValueError: On a malformed descriptor or an unsafe file name.
@@ -213,6 +218,7 @@ def descriptor_files(descriptor: Any) -> List[ArtifactFile]:
     if not isinstance(raw_files, list) or not raw_files:
         raise ValueError("artifact download descriptor contains no files")
     files: List[ArtifactFile] = []
+    seen_names: set = set()
     for raw in raw_files:
         if not isinstance(raw, dict):
             raise ValueError(f"malformed descriptor file entry: {raw!r}")
@@ -221,8 +227,16 @@ def descriptor_files(descriptor: Any) -> List[ArtifactFile]:
         if not name or not url:
             raise ValueError(f"descriptor file entry missing name or url: {raw!r}")
         pure = PurePosixPath(name)
-        if pure.is_absolute() or ".." in pure.parts:
+        if not pure.parts or pure.is_absolute() or ".." in pure.parts:
             raise ValueError(f"unsafe file name in download descriptor: {name!r}")
+        if name != str(pure):
+            # A name whose literal text differs from its normalized form
+            # (``a//b``, ``a/./b``, ``foo/``) can alias another entry's
+            # destination or smuggle an empty segment; require canonical form.
+            raise ValueError(f"non-canonical file name in download descriptor: {name!r}")
+        if name in seen_names:
+            raise ValueError(f"duplicate file name in download descriptor: {name!r}")
+        seen_names.add(name)
         size = lookup_case_insensitive(raw, "size")
         sha256 = lookup_case_insensitive(raw, "sha256")
         expires = lookup_case_insensitive(raw, "url_expires_at")

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -55,6 +55,16 @@ from .config import WeaverConfig
 logger = logging.getLogger(__name__)
 
 
+def _no_follow_opener(path: str, flags: int) -> int:
+    """Open refusing to follow a symlink at the final component.
+
+    Descriptor names are untrusted; a symlink pre-planted where the ``.part``
+    lands must fail instead of redirecting the write. O_NOFOLLOW is absent on
+    Windows, where the containment check remains the only guard.
+    """
+    return os.open(path, flags | getattr(os, "O_NOFOLLOW", 0))
+
+
 def build_async_download_client(timeout: httpx.Timeout | float | None = None) -> httpx.AsyncClient:
     """Asyncio twin of :func:`weaver._http.build_download_client`.
 
@@ -114,7 +124,7 @@ async def async_stream_download_to_file(
         partial = response.status_code == httpx.codes.PARTIAL_CONTENT
         mode = "ab" if partial else "wb"
         written = resume_from if partial else 0
-        with open(dest, mode) as fh:
+        with open(dest, mode, opener=_no_follow_opener) as fh:
             async for chunk in response.aiter_bytes(chunk_size):
                 fh.write(chunk)
                 written += len(chunk)

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -124,6 +124,11 @@ async def async_stream_download_to_file(
         partial = response.status_code == httpx.codes.PARTIAL_CONTENT
         mode = "ab" if partial else "wb"
         written = resume_from if partial else 0
+        if dest.is_symlink():
+            # Portable guard: on platforms without O_NOFOLLOW the opener
+            # silently follows links, so a pre-planted .part symlink would
+            # redirect the write outside the destination.
+            raise ValueError(f"refusing to write through a symlink: {dest}")
         with open(dest, mode, opener=_no_follow_opener) as fh:
             async for chunk in response.aiter_bytes(chunk_size):
                 fh.write(chunk)

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -25,8 +25,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from pathlib import Path
-from typing import Any, Mapping, MutableMapping
+from typing import Any, BinaryIO, Mapping, MutableMapping
 
 import httpx
 from opentelemetry import baggage, context, trace
@@ -55,16 +54,6 @@ from .config import WeaverConfig
 logger = logging.getLogger(__name__)
 
 
-def _no_follow_opener(path: str, flags: int) -> int:
-    """Open refusing to follow a symlink at the final component.
-
-    Descriptor names are untrusted; a symlink pre-planted where the ``.part``
-    lands must fail instead of redirecting the write. O_NOFOLLOW is absent on
-    Windows, where the containment check remains the only guard.
-    """
-    return os.open(path, flags | getattr(os, "O_NOFOLLOW", 0))
-
-
 def build_async_download_client(timeout: httpx.Timeout | float | None = None) -> httpx.AsyncClient:
     """Asyncio twin of :func:`weaver._http.build_download_client`.
 
@@ -82,7 +71,7 @@ def build_async_download_client(timeout: httpx.Timeout | float | None = None) ->
 
 async def async_stream_download_to_file(
     url: str,
-    dest: Path,
+    sink: BinaryIO,
     *,
     client: httpx.AsyncClient,
     resume_from: int = 0,
@@ -91,12 +80,15 @@ async def async_stream_download_to_file(
     """Asyncio twin of :func:`weaver._http.stream_download_to_file`.
 
     Network reads are awaited so the event loop stays free; the per-chunk
-    ``fh.write`` is a buffered local-disk write that is fast relative to the
+    ``sink.write`` is a buffered local-disk write that is fast relative to the
     awaited network reads, which keeps the loop responsive without a thread
     hop per chunk.
 
+    The caller owns *sink* — see the sync twin for why opening it here would
+    defeat the descriptor anchoring in :mod:`weaver._safeio`.
+
     Returns:
-        Total bytes now present in *dest*.
+        Total bytes now present in *sink*.
 
     Raises:
         DownloadURLExpiredError: The URL was rejected with 401/403 — refresh
@@ -122,17 +114,18 @@ async def async_stream_download_to_file(
             await response.aread()
             raise_for_response(response)
         partial = response.status_code == httpx.codes.PARTIAL_CONTENT
-        mode = "ab" if partial else "wb"
-        written = resume_from if partial else 0
-        if dest.is_symlink():
-            # Portable guard: on platforms without O_NOFOLLOW the opener
-            # silently follows links, so a pre-planted .part symlink would
-            # redirect the write outside the destination.
-            raise ValueError(f"refusing to write through a symlink: {dest}")
-        with open(dest, mode, opener=_no_follow_opener) as fh:
-            async for chunk in response.aiter_bytes(chunk_size):
-                fh.write(chunk)
-                written += len(chunk)
+        if partial:
+            written = resume_from
+        else:
+            # The server ignored the Range header and is sending the whole
+            # body. The sink may be open for append and already hold a
+            # partial, so drop those bytes rather than doubling the file.
+            sink.seek(0)
+            sink.truncate()
+            written = 0
+        async for chunk in response.aiter_bytes(chunk_size):
+            sink.write(chunk)
+            written += len(chunk)
     return written
 
 

--- a/weaver/_deployments.py
+++ b/weaver/_deployments.py
@@ -1,0 +1,230 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deployment helpers shared by the sync and async clients.
+
+Everything in this module is pure (no IO) so both client stacks build
+identical requests and interpret identical responses; see
+``.claude/rules/async-compatibility.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from ._http import WeaverAPIError
+from ._utils import lookup_case_insensitive
+
+# Request sanity bounds. These mirror the server's own guards so an obvious typo
+# fails locally instead of after a round trip — the server re-validates and
+# remains authoritative.
+MAX_DEPLOYMENT_REPLICAS = 8
+MAX_DEPLOYMENT_GPUS_PER_REPLICA = 16
+
+# A deployment name lives in three name spaces at once — the served model name,
+# a Kubernetes label value, and the gateway's global model name — so it is
+# validated against the strictest of the three. Anything outside this shape
+# would be silently rewritten downstream and published under a name the caller
+# never asked for.
+DEPLOYMENT_NAME_MAX_LEN = 63
+_DEPLOYMENT_NAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+
+def validate_deployment_name(name: str) -> str:
+    """Validate a deployment name and return it stripped.
+
+    Args:
+        name: The user-supplied public model name.
+
+    Returns:
+        The name with surrounding whitespace removed.
+
+    Raises:
+        ValueError: If the name is empty, too long, or contains characters
+            that are not valid in all three downstream name spaces.
+    """
+    normalized = (name or "").strip()
+    if not normalized:
+        raise ValueError("deployment name must not be empty")
+    if len(normalized) > DEPLOYMENT_NAME_MAX_LEN:
+        raise ValueError(
+            f"deployment name must be at most {DEPLOYMENT_NAME_MAX_LEN} characters, "
+            f"got {len(normalized)}"
+        )
+    if not _DEPLOYMENT_NAME_RE.match(normalized):
+        raise ValueError(
+            f"invalid deployment name {normalized!r}: it may contain only letters, "
+            "digits, '.', '-' and '_', and must start and end with a letter or digit"
+        )
+    return normalized
+
+
+def build_create_deployment_body(
+    *,
+    name: str,
+    gpu_type: Optional[str] = None,
+    replicas: int = 1,
+    gpus_per_replica: Optional[int] = None,
+    overwrite: bool = False,
+) -> Dict[str, Any]:
+    """Build the ``POST /checkpoints/{id}/deployments`` request body.
+
+    Unset sizing fields are omitted rather than sent as zero, so the server
+    applies its configured defaults.
+
+    Raises:
+        ValueError: On an invalid name or an out-of-range replica/GPU count.
+    """
+    body: Dict[str, Any] = {
+        "name": validate_deployment_name(name),
+        "overwrite": overwrite,
+    }
+    if replicas is None or replicas < 1 or replicas > MAX_DEPLOYMENT_REPLICAS:
+        raise ValueError(
+            f"replicas must be between 1 and {MAX_DEPLOYMENT_REPLICAS}, got {replicas}"
+        )
+    body["replicas"] = replicas
+    if gpus_per_replica is not None:
+        if gpus_per_replica < 1 or gpus_per_replica > MAX_DEPLOYMENT_GPUS_PER_REPLICA:
+            raise ValueError(
+                f"gpus_per_replica must be between 1 and {MAX_DEPLOYMENT_GPUS_PER_REPLICA}, "
+                f"got {gpus_per_replica}"
+            )
+        body["gpus_per_replica"] = gpus_per_replica
+    if gpu_type is not None:
+        normalized_gpu_type = gpu_type.strip()
+        if not normalized_gpu_type:
+            raise ValueError("gpu_type must not be blank; pass None to use the server default")
+        body["gpu_type"] = normalized_gpu_type
+    return body
+
+
+def deployment_items(payload: Any) -> List[Dict[str, Any]]:
+    """Extract the ``items`` array from a deployment list response."""
+    if not isinstance(payload, dict):
+        return []
+    items = lookup_case_insensitive(payload, "items")
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+# The list endpoint pages at 20 by default and caps a page at 100; both stacks
+# walk every page so a caller with many stopped deployments still sees them all.
+DEPLOYMENT_PAGE_SIZE = 100
+
+
+def next_page_offset(payload: Any, offset: int, page_len: int) -> Optional[int]:
+    """Return the offset of the next page, or ``None`` when the listing is done.
+
+    Stops on an empty page as well as on the reported total, so a server that
+    omits or misreports ``total_count`` cannot spin the caller in a loop.
+    """
+    if page_len == 0:
+        return None
+    advanced = offset + page_len
+    pagination = (
+        lookup_case_insensitive(payload, "pagination") if isinstance(payload, dict) else None
+    )
+    if not isinstance(pagination, dict):
+        return None
+    try:
+        total = int(str(lookup_case_insensitive(pagination, "total_count")))
+    except (TypeError, ValueError):
+        return None
+    return advanced if advanced < total else None
+
+
+# Actionable guidance for the deployment-specific failures. The server's own
+# messages are accurate but terse ("insufficient capability"), and both of the
+# gates below are operator-side configuration the caller cannot discover from
+# the API — so the SDK names what has to change and who can change it.
+_PERMISSION_GUIDANCE = (
+    "Publishing requires the 'deployment.publish' capability, which is granted by "
+    "principal origin rather than by Weaver role: an SSO session always qualifies, "
+    "an API key only when it was minted under an IAM biz_code on the server's "
+    "deployment.allowed_biz_codes allowlist, and a service credential never does. "
+    "Sign in with SSO, or ask a Weaver administrator to add your biz_code to the "
+    "allowlist. Listing, reading and deleting your own deployments do not need it."
+)
+
+_UNAVAILABLE_GUIDANCE = (
+    "Checkpoint deployment is turned off on this server: the 'deployment' feature "
+    "block is disabled or unconfigured. It is deny-by-default and an administrator "
+    "must enable it and supply the gateway credentials and the biz_code allowlist."
+)
+
+_NAME_TAKEN_GUIDANCE = (
+    "Deployment names are unique across every deployment that is not stopped. "
+    "Delete the deployment holding the name (deleting releases it) or choose "
+    "another name. Note that overwrite=True only replaces a registration on the "
+    "gateway — it does not free a name already used inside Weaver."
+)
+
+_QUOTA_GUIDANCE = (
+    "Each live deployment holds GPUs and pins its weights on shared storage, so "
+    "the server caps how many you may run at once. Delete one with "
+    "delete_deployment() before publishing another."
+)
+
+
+def deployment_error_guidance(error: WeaverAPIError) -> Optional[str]:
+    """Return actionable guidance for a deployment API error, if any.
+
+    Args:
+        error: The error raised by the HTTP layer.
+
+    Returns:
+        A sentence explaining what to do about it, or ``None`` when the
+        server's own message already stands on its own.
+    """
+    code = (error.code or "").lower()
+    if error.status_code == 503 and code == "deployment_unavailable":
+        return _UNAVAILABLE_GUIDANCE
+    if error.status_code == 403 and "insufficient capability" in (error.message or "").lower():
+        # Scoped to the capability message on purpose: the same route can answer
+        # 403 "forbidden" for a checkpoint the caller may not write to, which is
+        # a different problem with different advice.
+        return _PERMISSION_GUIDANCE
+    if error.status_code == 409 and code == "name_taken":
+        return _NAME_TAKEN_GUIDANCE
+    if error.status_code == 409 and code == "deployment_limit_reached":
+        return _QUOTA_GUIDANCE
+    return None
+
+
+def translate_deployment_error(error: WeaverAPIError) -> WeaverAPIError:
+    """Re-render a deployment API error with actionable guidance appended.
+
+    The class, status code, error code and every structured field are
+    preserved, so ``except WeaverAPIError`` handlers and code branching on
+    ``error.code`` keep working; only the human-readable message grows.
+    """
+    guidance = deployment_error_guidance(error)
+    if guidance is None:
+        return error
+    return WeaverAPIError(
+        error.status_code,
+        code=error.code,
+        message=f"{error.message}. {guidance}",
+        retryable=error.retryable,
+        request_id=error.request_id,
+        retry_after=error.retry_after,
+        required_nanos=error.required_nanos,
+        available_nanos=error.available_nanos,
+        required_usd=error.required_usd,
+        available_usd=error.available_usd,
+        details=error.details,
+    )

--- a/weaver/_deployments.py
+++ b/weaver/_deployments.py
@@ -91,12 +91,18 @@ def build_create_deployment_body(
         "name": validate_deployment_name(name),
         "overwrite": overwrite,
     }
-    if replicas is None or replicas < 1 or replicas > MAX_DEPLOYMENT_REPLICAS:
+    if type(overwrite) is not bool:  # bool is deliberate: reject "false"/1
+        raise ValueError(f"overwrite must be a bool, got {overwrite!r}")
+    if type(replicas) is not int:  # exact type: bool is an int subclass, floats compare
+        raise ValueError(f"replicas must be an int, got {replicas!r}")
+    if replicas < 1 or replicas > MAX_DEPLOYMENT_REPLICAS:
         raise ValueError(
             f"replicas must be between 1 and {MAX_DEPLOYMENT_REPLICAS}, got {replicas}"
         )
     body["replicas"] = replicas
     if gpus_per_replica is not None:
+        if type(gpus_per_replica) is not int:
+            raise ValueError(f"gpus_per_replica must be an int, got {gpus_per_replica!r}")
         if gpus_per_replica < 1 or gpus_per_replica > MAX_DEPLOYMENT_GPUS_PER_REPLICA:
             raise ValueError(
                 f"gpus_per_replica must be between 1 and {MAX_DEPLOYMENT_GPUS_PER_REPLICA}, "
@@ -112,13 +118,25 @@ def build_create_deployment_body(
 
 
 def deployment_items(payload: Any) -> List[Dict[str, Any]]:
-    """Extract the ``items`` array from a deployment list response."""
+    """Extract the ``items`` array from a deployment list response.
+
+    Malformed entries raise instead of being dropped: pagination advances the
+    offset by the item count, so silently filtering would undercount the
+    records consumed from the page — duplicating rows on the next request or
+    terminating the walk early.
+
+    Raises:
+        ValueError: If an items entry is not an object.
+    """
     if not isinstance(payload, dict):
         return []
     items = lookup_case_insensitive(payload, "items")
     if not isinstance(items, list):
         return []
-    return [item for item in items if isinstance(item, dict)]
+    for item in items:
+        if not isinstance(item, dict):
+            raise ValueError(f"malformed deployment list entry: {item!r}")
+    return list(items)
 
 
 # The list endpoint pages at 20 by default and caps a page at 100; both stacks

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -303,6 +303,11 @@ def stream_download_to_file(
         partial = response.status_code == httpx.codes.PARTIAL_CONTENT
         mode = "ab" if partial else "wb"
         written = resume_from if partial else 0
+        if dest.is_symlink():
+            # Portable guard: on platforms without O_NOFOLLOW the opener
+            # silently follows links, so a pre-planted .part symlink would
+            # redirect the write outside the destination.
+            raise ValueError(f"refusing to write through a symlink: {dest}")
         with open(dest, mode, opener=_no_follow_opener) as fh:
             for chunk in response.iter_bytes(chunk_size):
                 fh.write(chunk)

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -20,8 +20,7 @@ import logging
 import os
 import re
 import time
-from pathlib import Path
-from typing import Any, Mapping, MutableMapping
+from typing import Any, BinaryIO, Mapping, MutableMapping
 
 import httpx
 from opentelemetry import baggage, context, trace
@@ -55,16 +54,6 @@ DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MiB
 DOWNLOAD_TIMEOUT = httpx.Timeout(timeout=60.0, connect=10.0)
 
 logger = logging.getLogger(__name__)
-
-
-def _no_follow_opener(path: str, flags: int) -> int:
-    """Open refusing to follow a symlink at the final component.
-
-    Descriptor names are untrusted; a symlink pre-planted where the ``.part``
-    lands must fail instead of redirecting the write. O_NOFOLLOW is absent on
-    Windows, where the containment check remains the only guard.
-    """
-    return os.open(path, flags | getattr(os, "O_NOFOLLOW", 0))
 
 
 def _is_connection_error(exc: BaseException) -> bool:
@@ -256,26 +245,33 @@ def build_download_client(timeout: httpx.Timeout | float | None = None) -> httpx
 
 def stream_download_to_file(
     url: str,
-    dest: Path,
+    sink: BinaryIO,
     *,
     client: httpx.Client,
     resume_from: int = 0,
     chunk_size: int = DOWNLOAD_CHUNK_SIZE,
 ) -> int:
-    """Stream a plain (non-API) URL to *dest* on disk.
+    """Stream a plain (non-API) URL into the open file *sink*.
+
+    Opening the destination is the caller's job, deliberately: the download
+    path anchors its writes to a directory descriptor (:mod:`weaver._safeio`)
+    so an untrusted descriptor file name cannot be re-pointed at another
+    directory between validation and write. Resolving a path here would put
+    that decision back into this function, where the anchor is not available.
 
     Args:
         url: Presigned download URL. No Weaver auth headers are attached;
             *client* must be a bare client (see :func:`build_download_client`).
-        dest: File to write. Appended to when the server honors the Range
-            request, truncated and rewritten when it does not.
+        sink: Open binary file the body is written into. Must be opened for
+            append when *resume_from* is non-zero, for truncating write
+            otherwise.
         client: Bare ``httpx.Client`` used for the request.
-        resume_from: Byte offset already present in *dest*; sends a ``Range``
+        resume_from: Byte offset already present in *sink*; sends a ``Range``
             header so an interrupted download resumes instead of restarting.
         chunk_size: Streaming chunk size in bytes.
 
     Returns:
-        Total bytes now present in *dest*.
+        Total bytes now present in *sink*.
 
     Raises:
         DownloadURLExpiredError: The URL was rejected with 401/403 — refresh
@@ -301,17 +297,18 @@ def stream_download_to_file(
             response.read()
             raise_for_response(response)
         partial = response.status_code == httpx.codes.PARTIAL_CONTENT
-        mode = "ab" if partial else "wb"
-        written = resume_from if partial else 0
-        if dest.is_symlink():
-            # Portable guard: on platforms without O_NOFOLLOW the opener
-            # silently follows links, so a pre-planted .part symlink would
-            # redirect the write outside the destination.
-            raise ValueError(f"refusing to write through a symlink: {dest}")
-        with open(dest, mode, opener=_no_follow_opener) as fh:
-            for chunk in response.iter_bytes(chunk_size):
-                fh.write(chunk)
-                written += len(chunk)
+        if partial:
+            written = resume_from
+        else:
+            # The server ignored the Range header and is sending the whole
+            # body. The sink may be open for append and already hold a
+            # partial, so drop those bytes rather than doubling the file.
+            sink.seek(0)
+            sink.truncate()
+            written = 0
+        for chunk in response.iter_bytes(chunk_size):
+            sink.write(chunk)
+            written += len(chunk)
     return written
 
 

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -57,6 +57,16 @@ DOWNLOAD_TIMEOUT = httpx.Timeout(timeout=60.0, connect=10.0)
 logger = logging.getLogger(__name__)
 
 
+def _no_follow_opener(path: str, flags: int) -> int:
+    """Open refusing to follow a symlink at the final component.
+
+    Descriptor names are untrusted; a symlink pre-planted where the ``.part``
+    lands must fail instead of redirecting the write. O_NOFOLLOW is absent on
+    Windows, where the containment check remains the only guard.
+    """
+    return os.open(path, flags | getattr(os, "O_NOFOLLOW", 0))
+
+
 def _is_connection_error(exc: BaseException) -> bool:
     """Return True if *exc* represents a transport-level failure.
 
@@ -293,7 +303,7 @@ def stream_download_to_file(
         partial = response.status_code == httpx.codes.PARTIAL_CONTENT
         mode = "ab" if partial else "wb"
         written = resume_from if partial else 0
-        with open(dest, mode) as fh:
+        with open(dest, mode, opener=_no_follow_opener) as fh:
             for chunk in response.iter_bytes(chunk_size):
                 fh.write(chunk)
                 written += len(chunk)

--- a/weaver/_safeio.py
+++ b/weaver/_safeio.py
@@ -156,29 +156,79 @@ def _reject_symlink_leaf(name: str, exc: OSError, *, verb: str) -> None:
         raise ValueError(f"refusing to {verb} through a symlink: {name}") from exc
 
 
+def _reject_hard_link(name: str, fd: int) -> None:
+    """Refuse a descriptor that resolves to a multiply-linked inode.
+
+    ``O_NOFOLLOW`` stops a *symlink* at the final component but says nothing
+    about a *hard* link: a second directory entry pointing at the very same
+    inode, which can sit outside the download tree. A pre-planted
+    ``os.link(outside, dest/x.part)`` would otherwise let a write land on
+    ``outside``.
+
+    The check is on the already-open descriptor, which is what makes it
+    race-safe: ``st_nlink`` is read from the exact inode the write will hit,
+    so a link that existed before the open, or one added between validation
+    and the open, both surface here as ``st_nlink > 1``. A partial we created
+    ourselves has exactly one link; anything else is refused. That is
+    deliberately conservative — an attacker adding a second link to *our* own
+    fresh inode also trips it — but a refused download is always safe.
+    """
+    info = os.fstat(fd)
+    if info.st_nlink != 1:
+        raise ValueError(
+            f"refusing to write through a hard link: {name} has st_nlink="
+            f"{info.st_nlink}; the destination name resolves to an inode with "
+            "another directory entry, which could redirect the write outside "
+            "the download directory"
+        )
+
+
 def open_for_write(parent_fd: int, name: str, *, append: bool) -> BinaryIO:
-    """Open *name* under *parent_fd* for writing, never following a symlink.
+    """Open *name* under *parent_fd* for writing, on a single-linked inode.
+
+    Two escapes are closed at the final component here. ``O_NOFOLLOW`` refuses
+    a symlink; an ``fstat`` on the open descriptor refuses a hard link
+    (:func:`_reject_hard_link`).
+
+    Fresh writes never open an existing name. ``O_CREAT | O_EXCL`` means a
+    truncating open cannot fall on a pre-planted hard link — which matters
+    because ``O_TRUNC`` destroys the target's bytes at *open* time, before any
+    ``fstat`` could reject it. The caller (:func:`resume_offset_at`) guarantees
+    the name is free before a fresh open, so ``O_EXCL`` succeeds in the normal
+    case and ``EEXIST`` means something raced in and is refused.
+
+    Resuming (``append``) opens the existing ``.part`` without ``O_CREAT`` and
+    without ``O_TRUNC``; ``O_APPEND`` adds no bytes until after the hard-link
+    check has run, so a resumed inode is verified before it is touched.
 
     Args:
         parent_fd: Directory descriptor from :func:`open_parent_fd`.
         name: Single path component; never contains a separator.
-        append: Keep the existing bytes and append to them (a resumed
-            download); otherwise truncate what is there.
+        append: Resume into the existing ``.part``; otherwise create it fresh.
 
     Raises:
-        ValueError: *name* is a symlink.
+        ValueError: *name* is a symlink, a hard link, or (fresh open) was
+            occupied by a racing writer.
     """
-    flags = os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW
-    flags |= os.O_APPEND if append else os.O_TRUNC
+    if append:
+        flags = os.O_WRONLY | os.O_APPEND | _O_NOFOLLOW
+    else:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW
     try:
         fd = os.open(name, flags, 0o666, dir_fd=parent_fd)
+    except FileExistsError as exc:
+        # Fresh open only: O_EXCL found the name occupied after
+        # resume_offset_at cleared it. Treat the race as unsafe.
+        raise ValueError(
+            f"refusing to write {name}: a file appeared at the destination "
+            "name between validation and creation"
+        ) from exc
     except OSError as exc:
         _reject_symlink_leaf(name, exc, verb="write")
         raise
     try:
-        if append:
-            return os.fdopen(fd, "ab")
-        return os.fdopen(fd, "wb")
+        _reject_hard_link(name, fd)
+        return os.fdopen(fd, "ab" if append else "wb")
     except BaseException:
         os.close(fd)
         raise

--- a/weaver/_safeio.py
+++ b/weaver/_safeio.py
@@ -1,0 +1,259 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Filesystem access anchored to an open directory descriptor.
+
+Artifact descriptors name their own destination files, so ``download_weights``
+turns untrusted text into local paths. Name validation and a resolved-parent
+containment check both reason about *names*, and a name is only true at the
+instant it is resolved: between the check and the write, anyone able to create
+entries in the destination tree can replace an intermediate directory with a
+symlink and the bytes follow it out of the tree. ``O_NOFOLLOW`` does not close
+that window — it refuses a symlink only at the final component.
+
+This module removes the window rather than narrowing it. The destination is
+walked one component at a time with ``openat`` semantics (``O_NOFOLLOW`` on
+every component below the root), and stat, open, rename and unlink are then
+issued relative to the descriptor that walk returns. A descriptor pins an
+*inode*, not a name: once the walk succeeds, renaming that directory or
+replacing it with a symlink cannot move the write, because nothing afterwards
+re-traverses the name.
+
+Both client stacks share these helpers. They are ordinary blocking ``os``
+calls, which is what the async stack wants: each one is a single metadata
+syscall, no more expensive than the per-chunk ``fh.write`` the async streamer
+already performs inline, while the unbounded work (walking a directory tree,
+hashing a multi-GB shard) is handed to a worker thread by the caller via
+``asyncio.to_thread``. The event loop is never held for an unbounded time.
+
+``dir_fd`` is a POSIX facility; on Windows ``os.supports_dir_fd`` is empty and
+there is no ``O_NOFOLLOW``. Windows is not a supported execution environment
+for this SDK, so :func:`supports_dir_fd` gates the anchored implementation and
+callers take a single documented fallback branch there
+(:func:`legacy_open_for_write`) that keeps the previous path-based behaviour.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO
+
+# Absent on Windows. Falling back to 0 keeps the flag arithmetic total; the
+# anchored code paths that rely on them are gated by supports_dir_fd().
+_O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+# How a refused component surfaces: ELOOP when O_NOFOLLOW meets a symlink,
+# ENOTDIR when the component is (or points at) a non-directory.
+_UNSAFE_COMPONENT_ERRNOS = frozenset({errno.ELOOP, errno.ENOTDIR})
+
+
+def supports_dir_fd() -> bool:
+    """Whether this platform can anchor filesystem calls to a directory fd.
+
+    Evaluated per call rather than cached at import so tests can exercise the
+    fallback branch by emptying ``os.supports_dir_fd``. It is a handful of set
+    lookups against a fixed-size set, once per downloaded file.
+    """
+    return (
+        os.open in os.supports_dir_fd
+        and os.mkdir in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.rename in os.supports_dir_fd
+        and os.unlink in os.supports_dir_fd
+    )
+
+
+def open_parent_fd(root: Path, rel: PurePosixPath, *, create: bool) -> int:
+    """Open the directory that will hold *rel*'s final component.
+
+    *root* is opened by path: it is the caller's own destination, so resolving
+    a symlink there is intended. Every component below it is opened with
+    ``O_NOFOLLOW``, so a symlink standing anywhere along the way fails the walk
+    instead of redirecting it — including one planted between two iterations,
+    since each step is resolved relative to the descriptor of the step above.
+
+    Args:
+        root: Destination directory; must already exist.
+        rel: Validated relative path. Only ``rel.parts[:-1]`` is walked; the
+            final component is the caller's business.
+        create: Create missing intermediate directories while descending.
+
+    Returns:
+        A directory descriptor owned by the caller, who MUST close it.
+
+    Raises:
+        ValueError: A component is a symlink or is not a directory.
+        OSError: The walk failed for an ordinary IO reason (missing component
+            with ``create=False``, permissions, ...).
+    """
+    fd = os.open(os.fspath(root), os.O_RDONLY | _O_DIRECTORY)
+    try:
+        for part in rel.parts[:-1]:
+            child_fd = _open_directory(fd, part, create=create)
+            os.close(fd)
+            fd = child_fd
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _open_directory(parent_fd: int, name: str, *, create: bool) -> int:
+    """Open (optionally creating) the subdirectory *name* under *parent_fd*."""
+    flags = os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW
+    try:
+        return os.open(name, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        if not create:
+            raise
+    except OSError as exc:
+        _reject_unsafe_component(name, exc)
+        raise
+    try:
+        os.mkdir(name, dir_fd=parent_fd)
+    except FileExistsError:
+        # Another writer created it between our open and our mkdir. Re-open
+        # below and let O_NOFOLLOW decide whether what appeared is a directory
+        # or a symlink someone planted in the same window.
+        pass
+    try:
+        return os.open(name, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        _reject_unsafe_component(name, exc)
+        raise
+
+
+def _reject_unsafe_component(name: str, exc: OSError) -> None:
+    """Translate a refused directory component into :class:`ValueError`.
+
+    Returns normally for unrelated ``OSError``s so the caller re-raises them
+    as the IO errors they are.
+    """
+    if exc.errno in _UNSAFE_COMPONENT_ERRNOS:
+        raise ValueError(
+            f"unsafe path component in the download destination: {name!r} "
+            "is a symlink or not a directory"
+        ) from exc
+
+
+def _reject_symlink_leaf(name: str, exc: OSError, *, verb: str) -> None:
+    """Translate ``ELOOP`` on a final component into :class:`ValueError`."""
+    if exc.errno == errno.ELOOP:
+        raise ValueError(f"refusing to {verb} through a symlink: {name}") from exc
+
+
+def open_for_write(parent_fd: int, name: str, *, append: bool) -> BinaryIO:
+    """Open *name* under *parent_fd* for writing, never following a symlink.
+
+    Args:
+        parent_fd: Directory descriptor from :func:`open_parent_fd`.
+        name: Single path component; never contains a separator.
+        append: Keep the existing bytes and append to them (a resumed
+            download); otherwise truncate what is there.
+
+    Raises:
+        ValueError: *name* is a symlink.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | _O_NOFOLLOW
+    flags |= os.O_APPEND if append else os.O_TRUNC
+    try:
+        fd = os.open(name, flags, 0o666, dir_fd=parent_fd)
+    except OSError as exc:
+        _reject_symlink_leaf(name, exc, verb="write")
+        raise
+    try:
+        if append:
+            return os.fdopen(fd, "ab")
+        return os.fdopen(fd, "wb")
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def open_for_read(parent_fd: int, name: str) -> BinaryIO | None:
+    """Open *name* under *parent_fd* for reading, or None when it is missing.
+
+    Raises:
+        ValueError: *name* is a symlink.
+    """
+    try:
+        fd = os.open(name, os.O_RDONLY | _O_NOFOLLOW, dir_fd=parent_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        _reject_symlink_leaf(name, exc, verb="read")
+        raise
+    try:
+        return os.fdopen(fd, "rb")
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def stat_no_follow(parent_fd: int, name: str) -> os.stat_result | None:
+    """``lstat`` *name* under *parent_fd*, or None when it does not exist.
+
+    Not following the link is what lets callers *detect* a planted symlink
+    (and reject it) instead of silently measuring its target.
+    """
+    try:
+        return os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+
+
+def rename_within(parent_fd: int, src_name: str, dst_name: str) -> None:
+    """Rename *src_name* to *dst_name*, both resolved against *parent_fd*.
+
+    ``rename`` never follows a symlink at either end, so publishing a download
+    replaces whatever entry holds the final name rather than writing through
+    it, and the anchor keeps both ends inside the directory the walk verified.
+    """
+    os.rename(src_name, dst_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+
+
+def unlink_within(parent_fd: int, name: str) -> None:
+    """Unlink *name* under *parent_fd*; a name that is already gone is fine."""
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+    except FileNotFoundError:
+        pass
+
+
+def _no_follow_opener(path: str, flags: int) -> int:
+    """Open refusing to follow a symlink at the final component."""
+    return os.open(path, flags | _O_NOFOLLOW)
+
+
+def legacy_open_for_write(path: Path, *, append: bool) -> BinaryIO:
+    """Path-based fallback for platforms without ``dir_fd`` support.
+
+    Only reachable where :func:`supports_dir_fd` is false — Windows, which is
+    not a supported execution environment for this SDK. It preserves the
+    behaviour that predates the anchored walk: refuse a symlink standing at
+    the destination, then open with ``O_NOFOLLOW`` where the platform has it.
+    That leaves the check-to-use window the anchored path removes, which is
+    the accepted cost of the unsupported platform.
+
+    Raises:
+        ValueError: *path* is a symlink.
+    """
+    if path.is_symlink():
+        raise ValueError(f"refusing to write through a symlink: {path}")
+    if append:
+        return open(path, "ab", opener=_no_follow_opener)
+    return open(path, "wb", opener=_no_follow_opener)

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -73,7 +73,8 @@ from __future__ import annotations
 import asyncio
 import atexit
 import logging
-from pathlib import Path
+import os
+from pathlib import Path, PurePosixPath
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -97,11 +98,14 @@ from ._artifacts import (
     DOWNLOAD_MAX_URL_REFRESHES,
     ArtifactFile,
     check_downloaded_file,
+    check_downloaded_file_at,
     descriptor_files,
     ensure_within_directory,
     is_file_already_complete,
+    is_file_already_complete_at,
     parse_download_target,
     resolve_checkpoint_id_from_listing,
+    resume_offset_at,
     select_artifact_payload,
     validate_resource_id,
 )
@@ -117,6 +121,13 @@ from ._deployments import (
     translate_deployment_error,
 )
 from ._http import DownloadURLExpiredError, WeaverAPIError, compute_retry_delay
+from ._safeio import (
+    legacy_open_for_write,
+    open_for_write,
+    open_parent_fd,
+    rename_within,
+    supports_dir_fd,
+)
 from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import AsyncOperationHandle, build_async_operation_handle
@@ -859,7 +870,90 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         current_url: Callable[[str], Awaitable[str]],
         refresh_url: Callable[[str], Awaitable[str]],
     ) -> None:
-        """Download one manifest file with resume, URL refresh, and verification."""
+        """Download one manifest file with resume, URL refresh, and verification.
+
+        See :meth:`weaver.service_client.ServiceClient._download_weights_file`
+        for why the writes are anchored to a directory descriptor rather than
+        composed as ``dest_dir / entry.name``.
+
+        Loop discipline: the directory walk and the hashing are unbounded work
+        (many syscalls, multi-GB reads) and run in worker threads. The
+        remaining calls — one ``lstat``, one ``open``, one ``rename`` per
+        attempt — are single metadata syscalls, kept inline for the same
+        reason the streamer writes chunks inline.
+        """
+        rel = PurePosixPath(entry.name)
+        # Cheap early rejection of an obviously escaping name, before anything
+        # is created on disk. The descriptor chain below is the real guarantee.
+        ensure_within_directory(dest_dir, (dest_dir / rel).parent)
+        if not supports_dir_fd():
+            await self._download_weights_file_unanchored(
+                download_client,
+                entry,
+                dest_dir=dest_dir,
+                verify=verify,
+                current_url=current_url,
+                refresh_url=refresh_url,
+            )
+            return
+        final_name = rel.name
+        part_name = f"{final_name}.part"
+        parent_fd = await asyncio.to_thread(open_parent_fd, dest_dir, rel, create=True)
+        try:
+            # Hashing an existing multi-GB file is blocking CPU+disk work; keep
+            # it off the event loop.
+            if await asyncio.to_thread(
+                is_file_already_complete_at, parent_fd, final_name, entry, verify=verify
+            ):
+                return
+            url = await current_url(entry.name)
+            url_refreshes = 0
+            transport_retries = 0
+            while True:
+                resume_from = resume_offset_at(parent_fd, part_name, entry)
+                try:
+                    with open_for_write(parent_fd, part_name, append=resume_from > 0) as sink:
+                        await async_stream_download_to_file(
+                            url, sink, client=download_client, resume_from=resume_from
+                        )
+                    break
+                except DownloadURLExpiredError:
+                    url_refreshes += 1
+                    if url_refreshes > DOWNLOAD_MAX_URL_REFRESHES:
+                        raise
+                    url = await refresh_url(entry.name)
+                except (httpx.TransportError, OSError):
+                    # GETs are idempotent and the .part keeps its bytes, so retry
+                    # with a Range resume instead of restarting the shard.
+                    transport_retries += 1
+                    if transport_retries > DOWNLOAD_MAX_TRANSPORT_RETRIES:
+                        raise
+                    await asyncio.sleep(compute_retry_delay(transport_retries))
+            # sha256 of a multi-GB shard is blocking work; run it off-loop.
+            await asyncio.to_thread(
+                check_downloaded_file_at, parent_fd, part_name, entry, verify=verify
+            )
+            # Atomic publish through the same descriptor: readers never observe
+            # a half-written file, and the rename cannot be redirected.
+            rename_within(parent_fd, part_name, final_name)
+        finally:
+            os.close(parent_fd)
+
+    async def _download_weights_file_unanchored(
+        self,
+        download_client: httpx.AsyncClient,
+        entry: ArtifactFile,
+        *,
+        dest_dir: Path,
+        verify: bool,
+        current_url: Callable[[str], Awaitable[str]],
+        refresh_url: Callable[[str], Awaitable[str]],
+    ) -> None:
+        """Path-based download for platforms without ``dir_fd`` support.
+
+        Asyncio twin of
+        :meth:`weaver.service_client.ServiceClient._download_weights_file_unanchored`.
+        """
         final_path = dest_dir / entry.name
         final_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_within_directory(dest_dir, final_path.parent)
@@ -878,9 +972,10 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
                 part_path.unlink()
                 resume_from = 0
             try:
-                await async_stream_download_to_file(
-                    url, part_path, client=download_client, resume_from=resume_from
-                )
+                with legacy_open_for_write(part_path, append=resume_from > 0) as sink:
+                    await async_stream_download_to_file(
+                        url, sink, client=download_client, resume_from=resume_from
+                    )
                 break
             except DownloadURLExpiredError:
                 url_refreshes += 1

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -85,6 +85,7 @@ from typing import (
     Optional,
     Sequence,
     Union,
+    overload,
 )
 
 import httpx
@@ -107,14 +108,23 @@ from ._async_http import (
     async_stream_download_to_file,
     build_async_download_client,
 )
-from ._http import DownloadURLExpiredError, compute_retry_delay
+from ._deployments import (
+    DEPLOYMENT_PAGE_SIZE,
+    deployment_items,
+    next_page_offset,
+    translate_deployment_error,
+)
+from ._http import DownloadURLExpiredError, WeaverAPIError, compute_retry_delay
 from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import AsyncOperationHandle, build_async_operation_handle
 from .types import LoraConfig
+from .types.deployment import Deployment
 from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from .async_sampling_client import AsyncSamplingClient
     from .async_training_client import AsyncTrainingClient
 
@@ -885,3 +895,69 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         await asyncio.to_thread(check_downloaded_file, part_path, entry, verify=verify)
         # Atomic publish: readers never observe a half-written file.
         part_path.replace(final_path)
+
+    # ------------------------------------------------------------------
+    # NorthGate deployments
+    # ------------------------------------------------------------------
+
+    async def list_deployments(self) -> List[Deployment]:
+        """List the deployments this principal published.
+
+        See :meth:`weaver.service_client.ServiceClient.list_deployments`.
+        """
+        deployments: List[Deployment] = []
+        offset = 0
+        while True:
+            params = {"limit": DEPLOYMENT_PAGE_SIZE, "offset": offset}
+            try:
+                payload = await self.http.get("/api/v1/deployments", params=params)
+            except WeaverAPIError as exc:
+                raise translate_deployment_error(exc) from exc
+            page = deployment_items(payload)
+            deployments.extend(Deployment.from_payload(item) for item in page)
+            next_offset = next_page_offset(payload, offset, len(page))
+            if next_offset is None:
+                return deployments
+            offset = next_offset
+
+    async def get_deployment(self, deployment_id: str) -> Deployment:
+        """Fetch one deployment by id.
+
+        See :meth:`weaver.service_client.ServiceClient.get_deployment`.
+        """
+        try:
+            payload = await self.http.get(f"/api/v1/deployments/{deployment_id}")
+        except WeaverAPIError as exc:
+            raise translate_deployment_error(exc) from exc
+        return Deployment.from_payload(payload if isinstance(payload, dict) else {})
+
+    @overload
+    async def delete_deployment(
+        self, deployment_id: str, *, wait: "Literal[True]" = True
+    ) -> Deployment: ...
+
+    @overload
+    async def delete_deployment(
+        self, deployment_id: str, *, wait: "Literal[False]"
+    ) -> AsyncOperationHandle: ...
+
+    async def delete_deployment(
+        self, deployment_id: str, *, wait: bool = True
+    ) -> Deployment | AsyncOperationHandle:
+        """Take a deployment down.
+
+        See :meth:`weaver.service_client.ServiceClient.delete_deployment`.
+        Returns the stopped :class:`~weaver.types.Deployment` when *wait* is
+        True, else an ``AsyncOperationHandle``.
+        """
+        try:
+            response = await self.http.delete(f"/api/v1/deployments/{deployment_id}")
+        except WeaverAPIError as exc:
+            raise translate_deployment_error(exc) from exc
+        handle = build_async_operation_handle(
+            self.http, response if isinstance(response, dict) else {}
+        )
+        if not wait:
+            return handle
+        result = await handle.result()
+        return Deployment.from_payload(result if isinstance(result, dict) else {})

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -92,7 +92,6 @@ import httpx
 
 from . import __version__
 from ._artifacts import (
-    validate_resource_id,
     ARTIFACT_KINDS,
     DOWNLOAD_MAX_TRANSPORT_RETRIES,
     DOWNLOAD_MAX_URL_REFRESHES,
@@ -103,6 +102,7 @@ from ._artifacts import (
     parse_download_target,
     resolve_checkpoint_id_from_listing,
     select_artifact_payload,
+    validate_resource_id,
 )
 from ._async_http import (
     AsyncAPIClient,

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -92,6 +92,7 @@ import httpx
 
 from . import __version__
 from ._artifacts import (
+    validate_resource_id,
     ARTIFACT_KINDS,
     DOWNLOAD_MAX_TRANSPORT_RETRIES,
     DOWNLOAD_MAX_URL_REFRESHES,
@@ -827,7 +828,7 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         if isinstance(target, WeightsArtifact):
             if not target.id:
                 raise ValueError("WeightsArtifact has no id")
-            return target.id
+            return validate_resource_id(target.id, kind="artifact")
         parsed = parse_download_target(target)
         if parsed.artifact_id:
             return parsed.artifact_id
@@ -925,6 +926,7 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
 
         See :meth:`weaver.service_client.ServiceClient.get_deployment`.
         """
+        deployment_id = validate_resource_id(deployment_id, kind="deployment")
         try:
             payload = await self.http.get(f"/api/v1/deployments/{deployment_id}")
         except WeaverAPIError as exc:
@@ -950,6 +952,7 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         Returns the stopped :class:`~weaver.types.Deployment` when *wait* is
         True, else an ``AsyncOperationHandle``.
         """
+        deployment_id = validate_resource_id(deployment_id, kind="deployment")
         try:
             response = await self.http.delete(f"/api/v1/deployments/{deployment_id}")
         except WeaverAPIError as exc:

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -98,6 +98,7 @@ from ._artifacts import (
     ArtifactFile,
     check_downloaded_file,
     descriptor_files,
+    ensure_within_directory,
     is_file_already_complete,
     parse_download_target,
     resolve_checkpoint_id_from_listing,
@@ -861,6 +862,7 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
         """Download one manifest file with resume, URL refresh, and verification."""
         final_path = dest_dir / entry.name
         final_path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_within_directory(dest_dir, final_path.parent)
         # Hashing an existing multi-GB file is blocking CPU+disk work; keep it
         # off the event loop.
         if await asyncio.to_thread(is_file_already_complete, final_path, entry, verify=verify):

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -32,6 +32,8 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
 from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload
+from ._deployments import build_create_deployment_body, translate_deployment_error
+from ._http import WeaverAPIError
 from ._payloads import (
     build_request_metadata,
     build_surrogate_data,
@@ -45,6 +47,7 @@ from .async_service_client import AsyncServiceClient
 from .operations import AsyncOperationHandle, build_async_operation_handle
 from .types import AdamParams, Datum
 from .types.checkpoint import Checkpoint
+from .types.deployment import Deployment
 from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
@@ -670,6 +673,77 @@ class AsyncTrainingClient:
             f"{self.model_id}; pass a Checkpoint from save_state() or "
             "list_checkpoints()"
         )
+
+    # ------------------------------------------------------------------
+    # NorthGate deployment
+    # ------------------------------------------------------------------
+
+    @overload
+    async def deploy_checkpoint(
+        self,
+        checkpoint: str | Checkpoint,
+        *,
+        name: str,
+        gpu_type: str | None = None,
+        replicas: int = 1,
+        gpus_per_replica: int | None = None,
+        overwrite: bool = False,
+        wait: "Literal[True]" = True,
+    ) -> Deployment: ...
+
+    @overload
+    async def deploy_checkpoint(
+        self,
+        checkpoint: str | Checkpoint,
+        *,
+        name: str,
+        gpu_type: str | None = None,
+        replicas: int = 1,
+        gpus_per_replica: int | None = None,
+        overwrite: bool = False,
+        wait: "Literal[False]",
+    ) -> AsyncOperationHandle: ...
+
+    async def deploy_checkpoint(  # pylint: disable=too-many-arguments
+        self,
+        checkpoint: str | Checkpoint,
+        *,
+        name: str,
+        gpu_type: str | None = None,
+        replicas: int = 1,
+        gpus_per_replica: int | None = None,
+        overwrite: bool = False,
+        wait: bool = True,
+    ) -> Deployment | AsyncOperationHandle:
+        """Publish a checkpoint as a public, OpenAI-compatible endpoint.
+
+        See :meth:`weaver.training_client.TrainingClient.deploy_checkpoint`.
+        Returns a :class:`~weaver.types.Deployment` when *wait* is True, else
+        an ``AsyncOperationHandle``.
+        """
+        body = build_create_deployment_body(
+            name=name,
+            gpu_type=gpu_type,
+            replicas=replicas,
+            gpus_per_replica=gpus_per_replica,
+            overwrite=overwrite,
+        )
+        checkpoint_id = await self._resolve_checkpoint_id(checkpoint)
+        try:
+            # max_retries=1: creating a deployment is a non-idempotent POST
+            # that launches GPUs and claims a global gateway name.
+            response = await self._service.http.post(
+                f"/api/v1/checkpoints/{checkpoint_id}/deployments", json=body, max_retries=1
+            )
+        except WeaverAPIError as exc:
+            raise translate_deployment_error(exc) from exc
+        handle = build_async_operation_handle(
+            self._service.http, response if isinstance(response, dict) else {}
+        )
+        if not wait:
+            return handle
+        result = await handle.result()
+        return Deployment.from_payload(result if isinstance(result, dict) else {})
 
     async def terminate(self, instance_types: list[str] | None = None) -> Dict[str, Any]:
         """Terminate trainer and/or inference instances for this model."""

--- a/weaver/async_training_client.py
+++ b/weaver/async_training_client.py
@@ -31,7 +31,11 @@ import math
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
-from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload
+from ._artifacts import (
+    DEFAULT_EXPORT_TTL_SECONDS,
+    is_artifact_payload,
+    validate_resource_id,
+)
 from ._deployments import build_create_deployment_body, translate_deployment_error
 from ._http import WeaverAPIError
 from ._payloads import (
@@ -653,12 +657,14 @@ class AsyncTrainingClient:
         if isinstance(checkpoint, Checkpoint):
             if not checkpoint.id:
                 raise ValueError("Checkpoint object has no id")
-            return checkpoint.id
+            return validate_resource_id(checkpoint.id, kind="checkpoint")
         reference = checkpoint.strip()
         if not reference:
             raise ValueError("checkpoint reference must not be empty")
         if not reference.startswith("weaver://"):
-            return reference  # already a checkpoint id
+            # A raw id becomes a URL path segment; require a canonical UUID so
+            # dot-segment tricks cannot reroute the request.
+            return validate_resource_id(reference, kind="checkpoint")
         owner = parse_model_id_from_weaver_path(reference)
         if owner and owner != self.model_id:
             raise ValueError(

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -30,6 +30,7 @@ from ._artifacts import (
     is_artifact_payload,
     parse_download_target,
     resolve_checkpoint_id_from_listing,
+    validate_resource_id,
 )
 from ._deployments import build_create_deployment_body, translate_deployment_error
 from ._http import WeaverAPIError
@@ -728,7 +729,10 @@ def checkpoint_set_ttl_cmd(  # pylint: disable=too-many-positional-arguments
 def _resolve_cli_checkpoint_id(client: ServiceClient, target: str) -> str:
     """Resolve a ``weaver://`` checkpoint URI (or raw id) to a checkpoint id."""
     if not target.startswith("weaver://"):
-        return target
+        # Raw ids are interpolated into API paths by the commands below; the
+        # same UUID guard the client methods apply must hold here, or
+        # `deployment create ../models/<id>` reroutes the request.
+        return validate_resource_id(target, kind="checkpoint")
     parsed = parse_download_target(target)
     listing = client.http.get(f"/api/v1/models/{parsed.model_id}/checkpoints")
     items = (listing or {}).get("items", []) if isinstance(listing, dict) else []

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -16,6 +16,7 @@
 
 import json
 import sys
+from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -30,9 +31,11 @@ from ._artifacts import (
     parse_download_target,
     resolve_checkpoint_id_from_listing,
 )
+from ._deployments import build_create_deployment_body, translate_deployment_error
 from ._http import WeaverAPIError
 from .operations import build_operation_handle
 from .service_client import ServiceClient
+from .types.deployment import Deployment
 
 console = Console()
 
@@ -135,6 +138,31 @@ def create_training_runs_table(items: List[Dict[str, Any]]) -> Table:
             item.get("base_model", ""),
             training_mode,
             format_date(item.get("last_request_at")),
+        )
+
+    return table
+
+
+def create_deployments_table(items: List[Deployment]) -> Table:
+    """Create a rich table for deployments."""
+    table = Table(title="Deployments", box=box.ROUNDED)
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Name", style="green")
+    table.add_column("Status", style="yellow")
+    table.add_column("Endpoint", style="blue")
+    table.add_column("GPU", style="magenta")
+    table.add_column("Replicas", justify="right")
+    table.add_column("Created At", style="magenta")
+
+    for item in items:
+        table.add_row(
+            str(item.id or "")[:8],
+            item.name or "",
+            item.status or "",
+            item.endpoint or "-",
+            item.gpu_type or "default",
+            str(item.replicas if item.replicas is not None else ""),
+            format_date(item.created_at),
         )
 
     return table
@@ -310,6 +338,11 @@ def show():
 @cli.group()
 def checkpoint():
     """Manage checkpoints."""
+
+
+@cli.group()
+def deployment():
+    """Publish checkpoints as public endpoints and manage them."""
 
 
 @cli.group("organizations")
@@ -811,6 +844,151 @@ def checkpoint_download_cmd(  # pylint: disable=too-many-positional-arguments
         client.connect(ensure_session=False)
         dest = client.download_weights(uri, output_dir, kind=kind)
         console.print(f"[green]Downloaded weights to:[/green] {dest}")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+@deployment.command("create")
+@click.argument("checkpoint_uri")
+@click.option("--name", required=True, help="Public model name to publish under")
+@click.option("--gpu-type", default=None, help="GPU type to serve on (default: server's choice)")
+@click.option("--replicas", type=int, default=1, show_default=True, help="Serving replicas (1-8)")
+@click.option(
+    "--gpus-per-replica",
+    type=int,
+    default=None,
+    help="GPUs per replica (1-16, default: sized by the launcher)",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="Replace an existing gateway registration with this name",
+)
+@click.option("--no-wait", is_flag=True, help="Start the deployment and exit without waiting")
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def deployment_create_cmd(  # pylint: disable=too-many-positional-arguments,too-many-arguments
+    checkpoint_uri: str,
+    name: str,
+    gpu_type: Optional[str],
+    replicas: int,
+    gpus_per_replica: Optional[int],
+    overwrite: bool,
+    no_wait: bool,
+    base_url: Optional[str],
+    api_key: Optional[str],
+):
+    """Publish a checkpoint as a public OpenAI-compatible endpoint.
+
+    CHECKPOINT_URI is a checkpoint weaver:// URI or a checkpoint id. The
+    checkpoint is converted to HuggingFace format, launched as a standalone
+    inference workload, and registered on the NorthGate gateway under --name.
+    This takes tens of minutes, mostly conversion.
+
+    Publishing is permission-gated: the server grants it by principal origin
+    (SSO always; an API key only when minted under an allowlisted biz_code).
+    """
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        body = build_create_deployment_body(
+            name=name,
+            gpu_type=gpu_type,
+            replicas=replicas,
+            gpus_per_replica=gpus_per_replica,
+            overwrite=overwrite,
+        )
+        checkpoint_id = _resolve_cli_checkpoint_id(client, checkpoint_uri)
+        try:
+            # max_retries=1: this POST launches GPUs and claims a global name.
+            response = client.http.post(
+                f"/api/v1/checkpoints/{checkpoint_id}/deployments", json=body, max_retries=1
+            )
+        except WeaverAPIError as exc:
+            raise translate_deployment_error(exc) from exc
+        handle = build_operation_handle(client.http, response if isinstance(response, dict) else {})
+        if no_wait:
+            console.print(f"[green]Deployment started.[/green] Operation ID: {handle.operation_id}")
+            return
+        console.print(f"Waiting for deployment operation {handle.operation_id}...")
+        result = handle.result()
+        console.print("[green]Deployment ready:[/green]")
+        format_json_output(result)
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+@deployment.command("list")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def deployment_list_cmd(output_format: str, base_url: Optional[str], api_key: Optional[str]):
+    """List the deployments you published."""
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        deployments = client.list_deployments()
+        if output_format == "json":
+            format_json_output([asdict(item) for item in deployments])
+        else:
+            console.print(create_deployments_table(deployments))
+            console.print(f"\nShowing {len(deployments)} deployment(s)")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+@deployment.command("get")
+@click.argument("deployment_id")
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def deployment_get_cmd(deployment_id: str, base_url: Optional[str], api_key: Optional[str]):
+    """Show one deployment, including its endpoint URL."""
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        format_json_output(asdict(client.get_deployment(deployment_id)))
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
+
+
+@deployment.command("delete")
+@click.argument("deployment_id")
+@click.option("--no-wait", is_flag=True, help="Start the teardown and exit without waiting")
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def deployment_delete_cmd(
+    deployment_id: str,
+    no_wait: bool,
+    base_url: Optional[str],
+    api_key: Optional[str],
+):
+    """Take a deployment down and release its name."""
+    client = ServiceClient(base_url=base_url, api_key=api_key)
+    try:
+        client.connect(ensure_session=False)
+        if no_wait:
+            handle = client.delete_deployment(deployment_id, wait=False)
+            console.print(f"[green]Teardown started.[/green] Operation ID: {handle.operation_id}")
+            return
+        console.print(f"Tearing down deployment {deployment_id}...")
+        stopped = client.delete_deployment(deployment_id)
+        console.print("[green]Deployment stopped:[/green]")
+        format_json_output(asdict(stopped))
     except Exception as e:
         handle_error(e)
     finally:

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -43,6 +43,7 @@ import httpx
 
 from . import __version__
 from ._artifacts import (
+    validate_resource_id,
     ARTIFACT_KINDS,
     DOWNLOAD_MAX_TRANSPORT_RETRIES,
     DOWNLOAD_MAX_URL_REFRESHES,
@@ -881,7 +882,7 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         if isinstance(target, WeightsArtifact):
             if not target.id:
                 raise ValueError("WeightsArtifact has no id")
-            return target.id
+            return validate_resource_id(target.id, kind="artifact")
         parsed = parse_download_target(target)
         if parsed.artifact_id:
             return parsed.artifact_id
@@ -996,6 +997,7 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
                 another principal (404 — a deployment owned by someone else
                 is reported as missing), or deployments are disabled (503).
         """
+        deployment_id = validate_resource_id(deployment_id, kind="deployment")
         try:
             payload = self.http.get(f"/api/v1/deployments/{deployment_id}")
         except WeaverAPIError as exc:
@@ -1038,6 +1040,7 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
                 else (404), is already stopped (409 ``already_stopped``), or
                 deployments are disabled on this server (503).
         """
+        deployment_id = validate_resource_id(deployment_id, kind="deployment")
         try:
             response = self.http.delete(f"/api/v1/deployments/{deployment_id}")
         except WeaverAPIError as exc:

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -14,6 +14,10 @@
 
 """High-level ServiceClient that manages sessions and child clients."""
 
+# The client is the SDK's single entry point, so it aggregates every resource
+# family (sessions, models, checkpoints, artifacts, deployments) by design.
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import atexit
@@ -22,7 +26,18 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+    overload,
+)
 
 import httpx
 
@@ -39,9 +54,16 @@ from ._artifacts import (
     resolve_checkpoint_id_from_listing,
     select_artifact_payload,
 )
+from ._deployments import (
+    DEPLOYMENT_PAGE_SIZE,
+    deployment_items,
+    next_page_offset,
+    translate_deployment_error,
+)
 from ._http import (
     APIClient,
     DownloadURLExpiredError,
+    WeaverAPIError,
     build_download_client,
     compute_retry_delay,
     stream_download_to_file,
@@ -50,9 +72,12 @@ from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
 from .operations import OperationHandle, build_operation_handle
 from .types import LoraConfig
+from .types.deployment import Deployment
 from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from .sampling_client import SamplingClient
     from .training_client import TrainingClient
 
@@ -921,3 +946,104 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         check_downloaded_file(part_path, entry, verify=verify)
         # Atomic publish: readers never observe a half-written file.
         part_path.replace(final_path)
+
+    # ------------------------------------------------------------------
+    # NorthGate deployments
+    # ------------------------------------------------------------------
+
+    def list_deployments(self) -> List[Deployment]:
+        """List the deployments this principal published.
+
+        Deployments are owner-scoped: the listing shows the ones this
+        principal created, not every deployment of the models it can access.
+        Stopped and failed deployments are included, so the history of an
+        endpoint stays visible after it is taken down.
+
+        Returns:
+            Every :class:`~weaver.types.Deployment` the caller owns, newest
+            first.
+
+        Raises:
+            WeaverAPIError: If deployments are disabled on this server (503).
+        """
+        deployments: List[Deployment] = []
+        offset = 0
+        while True:
+            params = {"limit": DEPLOYMENT_PAGE_SIZE, "offset": offset}
+            try:
+                payload = self.http.get("/api/v1/deployments", params=params)
+            except WeaverAPIError as exc:
+                raise translate_deployment_error(exc) from exc
+            page = deployment_items(payload)
+            deployments.extend(Deployment.from_payload(item) for item in page)
+            next_offset = next_page_offset(payload, offset, len(page))
+            if next_offset is None:
+                return deployments
+            offset = next_offset
+
+    def get_deployment(self, deployment_id: str) -> Deployment:
+        """Fetch one deployment by id.
+
+        Args:
+            deployment_id: The deployment's server-generated id.
+
+        Returns:
+            The :class:`~weaver.types.Deployment`, including its endpoint URL
+            once it is running.
+
+        Raises:
+            WeaverAPIError: If the deployment does not exist or belongs to
+                another principal (404 — a deployment owned by someone else
+                is reported as missing), or deployments are disabled (503).
+        """
+        try:
+            payload = self.http.get(f"/api/v1/deployments/{deployment_id}")
+        except WeaverAPIError as exc:
+            raise translate_deployment_error(exc) from exc
+        return Deployment.from_payload(payload if isinstance(payload, dict) else {})
+
+    @overload
+    def delete_deployment(
+        self, deployment_id: str, *, wait: Literal[True] = True
+    ) -> Deployment: ...
+
+    @overload
+    def delete_deployment(self, deployment_id: str, *, wait: Literal[False]) -> OperationHandle: ...
+
+    def delete_deployment(
+        self, deployment_id: str, *, wait: bool = True
+    ) -> Deployment | OperationHandle:
+        """Take a deployment down.
+
+        Offboards the model from the gateway, stops the workload, releases the
+        job name, and frees the materialized weights the deployment was
+        pinning. The name becomes available again once the deployment reaches
+        ``stopped``.
+
+        Deleting deliberately does not need the ``deployment.publish``
+        capability: whoever published an endpoint must always be able to take
+        it down, even if their grant was revoked afterwards.
+
+        Args:
+            deployment_id: The deployment's server-generated id.
+            wait: If True (default), blocks until teardown finishes and
+                returns the stopped :class:`~weaver.types.Deployment`.
+
+        Returns:
+            The stopped :class:`~weaver.types.Deployment` when *wait* is True,
+            else an :class:`OperationHandle` whose result is that deployment.
+
+        Raises:
+            WeaverAPIError: If the deployment is unknown or owned by someone
+                else (404), is already stopped (409 ``already_stopped``), or
+                deployments are disabled on this server (503).
+        """
+        try:
+            response = self.http.delete(f"/api/v1/deployments/{deployment_id}")
+        except WeaverAPIError as exc:
+            raise translate_deployment_error(exc) from exc
+        handle = build_operation_handle(self.http, response if isinstance(response, dict) else {})
+        if not wait:
+            return handle
+        result = handle.result()
+        return Deployment.from_payload(result if isinstance(result, dict) else {})

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -22,10 +22,11 @@ from __future__ import annotations
 
 import atexit
 import logging
+import os
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -48,11 +49,14 @@ from ._artifacts import (
     DOWNLOAD_MAX_URL_REFRESHES,
     ArtifactFile,
     check_downloaded_file,
+    check_downloaded_file_at,
     descriptor_files,
     ensure_within_directory,
     is_file_already_complete,
+    is_file_already_complete_at,
     parse_download_target,
     resolve_checkpoint_id_from_listing,
+    resume_offset_at,
     select_artifact_payload,
     validate_resource_id,
 )
@@ -69,6 +73,13 @@ from ._http import (
     build_download_client,
     compute_retry_delay,
     stream_download_to_file,
+)
+from ._safeio import (
+    legacy_open_for_write,
+    open_for_write,
+    open_parent_fd,
+    rename_within,
+    supports_dir_fd,
 )
 from ._utils import extract_id, lookup_case_insensitive, optional_scope_id
 from .config import WeaverConfig
@@ -913,7 +924,85 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         current_url: Callable[[str], str],
         refresh_url: Callable[[str], str],
     ) -> None:
-        """Download one manifest file with resume, URL refresh, and verification."""
+        """Download one manifest file with resume, URL refresh, and verification.
+
+        Descriptor file names are untrusted, so nothing here is written
+        through the composed path ``dest_dir / entry.name``. The destination
+        directory is walked one component at a time with no-follow ``openat``
+        semantics, and the resume stat, every write, the hash and the final
+        publish are all issued relative to the descriptor that walk returns
+        (:mod:`weaver._safeio`). Replacing a directory with a symlink after
+        the walk is inert: a descriptor names an inode, and no step after the
+        walk resolves the path again.
+        """
+        rel = PurePosixPath(entry.name)
+        # Cheap early rejection of an obviously escaping name, before anything
+        # is created on disk. The descriptor chain below is the real guarantee.
+        ensure_within_directory(dest_dir, (dest_dir / rel).parent)
+        if not supports_dir_fd():
+            self._download_weights_file_unanchored(
+                download_client,
+                entry,
+                dest_dir=dest_dir,
+                verify=verify,
+                current_url=current_url,
+                refresh_url=refresh_url,
+            )
+            return
+        final_name = rel.name
+        part_name = f"{final_name}.part"
+        parent_fd = open_parent_fd(dest_dir, rel, create=True)
+        try:
+            if is_file_already_complete_at(parent_fd, final_name, entry, verify=verify):
+                return
+            url = current_url(entry.name)
+            url_refreshes = 0
+            transport_retries = 0
+            while True:
+                resume_from = resume_offset_at(parent_fd, part_name, entry)
+                try:
+                    with open_for_write(parent_fd, part_name, append=resume_from > 0) as sink:
+                        stream_download_to_file(
+                            url, sink, client=download_client, resume_from=resume_from
+                        )
+                    break
+                except DownloadURLExpiredError:
+                    url_refreshes += 1
+                    if url_refreshes > DOWNLOAD_MAX_URL_REFRESHES:
+                        raise
+                    url = refresh_url(entry.name)
+                except (httpx.TransportError, OSError):
+                    # GETs are idempotent and the .part keeps its bytes, so retry
+                    # with a Range resume instead of restarting the shard.
+                    transport_retries += 1
+                    if transport_retries > DOWNLOAD_MAX_TRANSPORT_RETRIES:
+                        raise
+                    time.sleep(compute_retry_delay(transport_retries))
+            check_downloaded_file_at(parent_fd, part_name, entry, verify=verify)
+            # Atomic publish through the same descriptor: readers never observe
+            # a half-written file, and the rename cannot be redirected.
+            rename_within(parent_fd, part_name, final_name)
+        finally:
+            os.close(parent_fd)
+
+    def _download_weights_file_unanchored(
+        self,
+        download_client: httpx.Client,
+        entry: ArtifactFile,
+        *,
+        dest_dir: Path,
+        verify: bool,
+        current_url: Callable[[str], str],
+        refresh_url: Callable[[str], str],
+    ) -> None:
+        """Path-based download for platforms without ``dir_fd`` support.
+
+        Only Windows reaches this branch, and Windows is not a supported
+        execution environment for this SDK (see :mod:`weaver._safeio`). It
+        keeps the pre-anchoring behaviour — containment check plus a no-follow
+        open of the final component — and with it the check-to-use window the
+        anchored path above removes.
+        """
         final_path = dest_dir / entry.name
         final_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_within_directory(dest_dir, final_path.parent)
@@ -930,9 +1019,10 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
                 part_path.unlink()
                 resume_from = 0
             try:
-                stream_download_to_file(
-                    url, part_path, client=download_client, resume_from=resume_from
-                )
+                with legacy_open_for_write(part_path, append=resume_from > 0) as sink:
+                    stream_download_to_file(
+                        url, sink, client=download_client, resume_from=resume_from
+                    )
                 break
             except DownloadURLExpiredError:
                 url_refreshes += 1

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -49,6 +49,7 @@ from ._artifacts import (
     ArtifactFile,
     check_downloaded_file,
     descriptor_files,
+    ensure_within_directory,
     is_file_already_complete,
     parse_download_target,
     resolve_checkpoint_id_from_listing,
@@ -915,6 +916,7 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
         """Download one manifest file with resume, URL refresh, and verification."""
         final_path = dest_dir / entry.name
         final_path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_within_directory(dest_dir, final_path.parent)
         if is_file_already_complete(final_path, entry, verify=verify):
             return
         part_path = final_path.with_name(final_path.name + ".part")

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -43,7 +43,6 @@ import httpx
 
 from . import __version__
 from ._artifacts import (
-    validate_resource_id,
     ARTIFACT_KINDS,
     DOWNLOAD_MAX_TRANSPORT_RETRIES,
     DOWNLOAD_MAX_URL_REFRESHES,
@@ -54,6 +53,7 @@ from ._artifacts import (
     parse_download_target,
     resolve_checkpoint_id_from_listing,
     select_artifact_payload,
+    validate_resource_id,
 )
 from ._deployments import (
     DEPLOYMENT_PAGE_SIZE,

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -23,6 +23,8 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
 from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload
+from ._deployments import build_create_deployment_body, translate_deployment_error
+from ._http import WeaverAPIError
 from ._payloads import (
     build_request_metadata,
     build_surrogate_data,
@@ -37,6 +39,7 @@ from .operations import OperationHandle, build_operation_handle
 from .service_client import ServiceClient
 from .types import AdamParams, Datum
 from .types.checkpoint import Checkpoint
+from .types.deployment import Deployment
 from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
@@ -812,6 +815,125 @@ class TrainingClient:
             f"{self.model_id}; pass a Checkpoint from save_state() or "
             "list_checkpoints()"
         )
+
+    # ------------------------------------------------------------------
+    # NorthGate deployment
+    # ------------------------------------------------------------------
+
+    @overload
+    def deploy_checkpoint(
+        self,
+        checkpoint: str | Checkpoint,
+        *,
+        name: str,
+        gpu_type: str | None = None,
+        replicas: int = 1,
+        gpus_per_replica: int | None = None,
+        overwrite: bool = False,
+        wait: Literal[True] = True,
+    ) -> Deployment: ...
+
+    @overload
+    def deploy_checkpoint(
+        self,
+        checkpoint: str | Checkpoint,
+        *,
+        name: str,
+        gpu_type: str | None = None,
+        replicas: int = 1,
+        gpus_per_replica: int | None = None,
+        overwrite: bool = False,
+        wait: Literal[False],
+    ) -> OperationHandle: ...
+
+    def deploy_checkpoint(  # pylint: disable=too-many-arguments
+        self,
+        checkpoint: str | Checkpoint,
+        *,
+        name: str,
+        gpu_type: str | None = None,
+        replicas: int = 1,
+        gpus_per_replica: int | None = None,
+        overwrite: bool = False,
+        wait: bool = True,
+    ) -> Deployment | OperationHandle:
+        """Publish a checkpoint as a public, OpenAI-compatible endpoint.
+
+        The server converts the checkpoint to HuggingFace format (reusing an
+        existing export when one is available), launches a standalone
+        inference workload for it, and registers that workload on the
+        NorthGate gateway under *name*. The whole sequence runs as one
+        operation and takes tens of minutes, dominated by the conversion.
+
+        The deployment is independent of this model's training inference
+        instance and of the training session's lifetime: it keeps serving
+        until :meth:`~weaver.service_client.ServiceClient.delete_deployment`
+        stops it, and it pins the source checkpoint and the exported artifact
+        against garbage collection while it lives.
+
+        Publishing is permission-gated. The server grants it by principal
+        origin — SSO sessions always, API keys only when minted under an
+        allowlisted IAM biz_code — and answers 403 otherwise; a server with
+        the feature switched off answers 503. Both are raised as
+        :class:`~weaver.WeaverAPIError` with guidance on what to change.
+
+        Args:
+            checkpoint: The checkpoint to publish. Accepts a
+                :class:`~weaver.types.Checkpoint`, a ``weaver://`` checkpoint
+                path (resolved via :meth:`list_checkpoints`), or a raw
+                checkpoint id.
+            name: Public model name callers will address the endpoint by. It
+                is also the gateway registration name and a Kubernetes label,
+                so it is limited to 63 characters of letters, digits, ``.``,
+                ``-`` and ``_``, starting and ending alphanumerically. Unique
+                across all deployments that are not stopped.
+            gpu_type: GPU type to serve on. ``None`` (default) uses the
+                server's configured default.
+            replicas: Number of serving replicas (1-8).
+            gpus_per_replica: GPUs per replica (1-16). ``None`` (default)
+                lets the launcher size it from the model.
+            overwrite: Replace an existing *gateway* registration of this
+                name. Off by default because the gateway's name space is
+                global and shared with everything else published there. It
+                does not affect Weaver's own name uniqueness.
+            wait: If True (default), blocks until the endpoint is live and
+                returns the :class:`~weaver.types.Deployment`.
+
+        Returns:
+            A :class:`~weaver.types.Deployment` when *wait* is True, else an
+            :class:`OperationHandle` whose result is that deployment.
+
+        Raises:
+            ValueError: On an invalid *name* or sizing argument, or a
+                ``weaver://`` *checkpoint* path that does not resolve to a
+                checkpoint of this model.
+            WeaverAPIError: If the caller may not publish (403), the feature
+                is disabled (503), the name is taken (409), or the per-user
+                deployment cap is reached (409).
+        """
+        body = build_create_deployment_body(
+            name=name,
+            gpu_type=gpu_type,
+            replicas=replicas,
+            gpus_per_replica=gpus_per_replica,
+            overwrite=overwrite,
+        )
+        checkpoint_id = self._resolve_checkpoint_id(checkpoint)
+        try:
+            # max_retries=1: creating a deployment is a non-idempotent POST
+            # that launches GPUs and claims a global gateway name.
+            response = self._service.http.post(
+                f"/api/v1/checkpoints/{checkpoint_id}/deployments", json=body, max_retries=1
+            )
+        except WeaverAPIError as exc:
+            raise translate_deployment_error(exc) from exc
+        handle = build_operation_handle(
+            self._service.http, response if isinstance(response, dict) else {}
+        )
+        if not wait:
+            return handle
+        result = handle.result()
+        return Deployment.from_payload(result if isinstance(result, dict) else {})
 
     def terminate(self, instance_types: list[str] | None = None) -> Dict[str, Any]:
         """Terminate trainer and/or inference instances for this model.

--- a/weaver/training_client.py
+++ b/weaver/training_client.py
@@ -22,7 +22,11 @@ from datetime import datetime, timezone
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Sequence, Tuple, overload
 
-from ._artifacts import DEFAULT_EXPORT_TTL_SECONDS, is_artifact_payload
+from ._artifacts import (
+    DEFAULT_EXPORT_TTL_SECONDS,
+    is_artifact_payload,
+    validate_resource_id,
+)
 from ._deployments import build_create_deployment_body, translate_deployment_error
 from ._http import WeaverAPIError
 from ._payloads import (
@@ -795,12 +799,14 @@ class TrainingClient:
         if isinstance(checkpoint, Checkpoint):
             if not checkpoint.id:
                 raise ValueError("Checkpoint object has no id")
-            return checkpoint.id
+            return validate_resource_id(checkpoint.id, kind="checkpoint")
         reference = checkpoint.strip()
         if not reference:
             raise ValueError("checkpoint reference must not be empty")
         if not reference.startswith("weaver://"):
-            return reference  # already a checkpoint id
+            # A raw id becomes a URL path segment; require a canonical UUID so
+            # dot-segment tricks cannot reroute the request.
+            return validate_resource_id(reference, kind="checkpoint")
         owner = parse_model_id_from_weaver_path(reference)
         if owner and owner != self.model_id:
             raise ValueError(

--- a/weaver/types/__init__.py
+++ b/weaver/types/__init__.py
@@ -16,6 +16,7 @@
 
 from .checkpoint import Checkpoint
 from .datum import Datum
+from .deployment import Deployment
 from .logprobs import LogprobsParams
 from .lora_config import LoraConfig
 from .model_input import ModelInput, ModelInputChunk
@@ -59,6 +60,7 @@ __all__ = [
     "AdamParams",
     "Checkpoint",
     "Datum",
+    "Deployment",
     "LoraConfig",
     "LogprobsParams",
     "ModelInput",

--- a/weaver/types/deployment.py
+++ b/weaver/types/deployment.py
@@ -1,0 +1,120 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deployment type for checkpoints published as NorthGate endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Deployment:
+    """One checkpoint published as a standalone, publicly callable endpoint.
+
+    Created by
+    :meth:`~weaver.training_client.TrainingClient.deploy_checkpoint`, which
+    converts the checkpoint to HuggingFace format, launches a dedicated
+    inference workload for it, and registers that workload on the NorthGate
+    gateway as an OpenAI-compatible model.
+
+    A deployment is independent of the training inference instance and of
+    every other deployment of the same model: it owns its own GPUs, and it
+    keeps its weights alive (neither the source checkpoint nor the exported
+    artifact can be garbage-collected while the deployment is live).
+
+    Attributes:
+        id: Unique deployment identifier (UUID, server-generated).
+        checkpoint_id: Identifier of the published checkpoint.
+        artifact_id: Identifier of the HuggingFace artifact the workload
+            serves from, or ``None`` until the conversion has produced one.
+        model_id: Identifier of the model the checkpoint belongs to.
+        name: Public model name. It is simultaneously the served model name,
+            the gateway's ``model_name``, and a Kubernetes label value, so it
+            is limited to 63 characters of letters, digits, ``.``, ``-`` and
+            ``_``, starting and ending alphanumerically.
+        status: Lifecycle status — ``"pending"``, ``"converting"``,
+            ``"provisioning"``, ``"onboarding"``, ``"running"``, ``"failed"``,
+            or ``"stopped"``. Only ``running`` serves traffic; ``failed`` and
+            ``stopped`` are terminal.
+        endpoint: OpenAI-compatible URL the gateway serves this model on, or
+            ``None`` before onboarding completes.
+        northgate_model_id: The gateway's own id for the onboarded model, or
+            ``None`` before onboarding completes.
+        gpu_type: GPU type the workload runs on, or ``None`` when the server
+            chose its configured default.
+        replicas: Number of serving replicas.
+        gpus_per_replica: GPUs per replica (``0`` when the launcher's default
+            applies).
+        error: Stable failure code when ``status == "failed"`` — one of
+            ``"conversion_failed"``, ``"provisioning_failed"``,
+            ``"onboarding_failed"``, ``"teardown_failed"``,
+            ``"deleted_during_deploy"``, or ``"gateway_name_taken"``.
+            Detailed diagnostics stay in the operation and the server logs.
+        created_at: ISO 8601 creation timestamp (server-generated).
+        updated_at: ISO 8601 last-update timestamp (server-generated).
+    """
+
+    id: str
+    checkpoint_id: str | None = None
+    artifact_id: str | None = None
+    model_id: str | None = None
+    name: str | None = None
+    status: str | None = None
+    endpoint: str | None = None
+    northgate_model_id: str | None = None
+    gpu_type: str | None = None
+    replicas: int | None = None
+    gpus_per_replica: int | None = None
+    error: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> Deployment:
+        """Create a Deployment from a server response dict.
+
+        Args:
+            payload: Raw JSON dict from the Weaver API.
+
+        Returns:
+            A ``Deployment`` instance.
+        """
+        from .._utils import lookup_case_insensitive
+
+        return cls(
+            id=str(lookup_case_insensitive(payload, "id") or ""),
+            checkpoint_id=_str_or_none(lookup_case_insensitive(payload, "checkpoint_id")),
+            artifact_id=_str_or_none(lookup_case_insensitive(payload, "artifact_id")),
+            model_id=_str_or_none(lookup_case_insensitive(payload, "model_id")),
+            name=_str_or_none(lookup_case_insensitive(payload, "name")),
+            status=_str_or_none(lookup_case_insensitive(payload, "status")),
+            endpoint=_str_or_none(lookup_case_insensitive(payload, "endpoint")),
+            northgate_model_id=_str_or_none(lookup_case_insensitive(payload, "northgate_model_id")),
+            gpu_type=_str_or_none(lookup_case_insensitive(payload, "gpu_type")),
+            replicas=_int_or_none(lookup_case_insensitive(payload, "replicas")),
+            gpus_per_replica=_int_or_none(lookup_case_insensitive(payload, "gpus_per_replica")),
+            error=_str_or_none(lookup_case_insensitive(payload, "error")),
+            created_at=_str_or_none(lookup_case_insensitive(payload, "created_at")),
+            updated_at=_str_or_none(lookup_case_insensitive(payload, "updated_at")),
+        )
+
+
+def _str_or_none(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _int_or_none(value: Any) -> int | None:
+    return int(value) if value is not None else None


### PR DESCRIPTION
## Stacked on #106

This branch is cut from `feat/hf-export-download` (#106), not from `main`. **#106's commit
(`f5ad9d1`) shows up in this diff** and will disappear once #106 merges and this branch is
rebased. Review only `377623c`. Merging this before #106 would drag the export work in with it.

The dependency is real, not just a convenience: a deployment serves from the materialized
HuggingFace copy the export pipeline produces, and `deploy_checkpoint()` reuses the
`_resolve_checkpoint_id` helper #106 added.

## What this adds

The server side is already merged (weaver-server #612, tag v1.9.6.4) — three routes, a
`deployments` table, the orchestration, and two gates. Nothing in the SDK could reach them.

| Surface | |
|---|---|
| `TrainingClient.deploy_checkpoint(checkpoint, *, name, gpu_type, replicas, gpus_per_replica, overwrite, wait)` | `POST /api/v1/checkpoints/{id}/deployments` |
| `ServiceClient.list_deployments()` | `GET /api/v1/deployments` |
| `ServiceClient.get_deployment(id)` | `GET /api/v1/deployments/{id}` |
| `ServiceClient.delete_deployment(id, *, wait)` | `DELETE /api/v1/deployments/{id}` |
| `weaver deployment create/list/get/delete` | CLI |

Plus the `Deployment` frozen dataclass (exported from `weaver` and `weaver.types`) and async
twins for all four methods.

## Mirrored from the server, not from a design doc

Every field name, route, status and error code below was read out of `origin/main` in
weaver-server rather than taken from the design note:

- **Routes + middleware chain** — `internal/http/handlers/api.go:316-328`. Create sits behind
  `requireDeploymentsEnabled` → `auditControl` → `RequireDeploymentPublish` →
  `requireCheckpointAccess(write)`. Read and delete are owner-scoped only.
- **Request body** — `createDeploymentRequest`, `internal/http/handlers/deployments.go:26-37`:
  `name` (required), `gpu_type`, `replicas`, `gpus_per_replica`, `overwrite`.
- **Response shape** — `DeploymentService.PublicView`, `internal/services/deployments.go:339-372`.
  A closed allowlist of 14 keys; `Deployment` mirrors it exactly, including the fields the
  server nulls until they exist (`artifact_id`, `endpoint`, `northgate_model_id`, `gpu_type`).
  Note it deliberately omits `stopped_at` and all provisioner metadata, so the SDK type does too.
- **Both operations return that same view as their result** (`deployment_orchestration.go:123`
  for deploy, `:530` for teardown), which is why `wait=True` can return a `Deployment` on both
  create and delete.
- **Op types** `deploy_checkpoint` / `undeploy_checkpoint` — `internal/services/deployments.go:30-33`.
- **Bounds** — replicas 1-8, gpus_per_replica 1-16 (`deployments.go:21-24`); name ≤63 chars
  matching `^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$` (`services/deployments.go:73-97`).
- **Errors** — 403 `forbidden`/"insufficient capability" (`middleware/auth.go:299-307`), 503
  `deployment_unavailable` (`handlers/deployments.go:42-49`), 409 `name_taken` /
  `deployment_limit_reached` / `already_stopped`.

## Error UX

The two gates are operator-side config a caller cannot discover from the API, so the raw
answers name a problem the reader cannot act on. Both are re-rendered with what has to change:

- **403** → which principal origins carry `deployment.publish` (SSO always; an API key only
  under an allowlisted IAM `biz_code`; a service credential never), and that read/delete need
  no capability.
- **503** → the `deployment` feature block is deny-by-default and needs an administrator.
- **409 name_taken** → deleting releases a name, and `overwrite` only touches the *gateway*
  registration — a distinction the server's message does not make.

The 403 mapping keys on the capability *message*, not the code, because the same route also
answers 403 `forbidden` for a checkpoint the caller may not write to. Class, status code, error
code and every structured field survive the rewrite; only the message grows.

## Notes for review

- Per `.claude/rules/async-compatibility.md`, all pure logic (name validation, body building,
  listing extraction, page advancement, error mapping) is in `weaver/_deployments.py`, so both
  stacks send identical bytes and produce identical messages.
- `list_deployments()` walks every page instead of returning the server's default first 20 —
  the listing includes stopped and failed rows, which accumulate.
- Create POSTs with `max_retries=1`, matching `export_weights()`: it launches GPUs and claims a
  globally unique gateway name. DELETE needs no override — `_request` never retries
  non-idempotent methods on an API error.
- `service_client.py` crossed pylint's 1000-line module limit, so it carries an explicit
  `disable=too-many-lines` with a reason rather than leaving a new warning in `make lint`.

## Testing

`tests/test_deployments.py`, 80 tests mirroring `test_hf_export.py`: the type, every pure
helper, both client stacks at parity, and all four CLI commands including both permission
failures.

- `make test` → **409 passed**
- `make lint` → black/isort clean, mypy clean (33 files), pylint 9.99/10 with only the two
  warnings that predate this branch (`_telemetry.py`, `_sampling_utils.py`)

Not exercised against a live server: the feature is off in every environment today (it needs
`deployment.enabled`, the biz_code allowlist, and `NORTHGATE_API_KEY`), so this is unit-level
only.