### PR TITLE
Bump version from 1.12.0 to 1.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.12.0"
+version = "1.13.0"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Release 1.13.0: HF weights export/download (#106) + checkpoint→NorthGate deploy SDK surface with path-security hardening (#107).