### PR TITLE
fix: clean up failed sampling sync sessions

### DIFF
--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from weaver.operations import OperationHandle
 from weaver.service_client import ServiceClient
 
 
@@ -148,6 +149,29 @@ def test_create_model_passes_debug_info():
     assert training.debug_info == debug_info
     assert training.debug_info["kubectl_exec"].startswith("kubectl exec")
     assert training.model_id == "abc-123"
+
+
+def test_create_sampling_client_deletes_session_when_sync_wait_fails(monkeypatch):
+    client = ServiceClient(api_key="sk-test-key")
+    client._session_id = "session-1"
+    client._http = MagicMock()
+    client._http.post.return_value = {
+        "sampling_session": {"id": "sampling-1"},
+        "sync_operation": {"id": "operation-1", "status": "pending"},
+    }
+    monkeypatch.setattr(
+        OperationHandle,
+        "wait",
+        MagicMock(side_effect=KeyboardInterrupt),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        client.create_sampling_client(
+            base_model="Qwen/Qwen3.5-9B-Base:262144",
+            model_path="weaver://model/checkpoints/step-1",
+        )
+
+    client._http.delete.assert_called_once_with("/api/v1/sampling-sessions/sampling-1")
 
 
 def _build_atexit_script(marker_path: str, exit_code: str = "") -> str:

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -489,13 +489,29 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             )
             if sync_op_payload and isinstance(sync_op_payload, dict):
                 session = lookup_case_insensitive(resp, "sampling_session") or {}
+                created_sampling_session_id = extract_id(session)
                 # Wait for the background sync_weights to finish
                 sync_handle = OperationHandle.from_payload(self.http, sync_op_payload)
                 logger.info(
                     "Waiting for background weights sync (operation %s)...",
                     sync_handle.operation_id,
                 )
-                sync_handle.wait()
+                try:
+                    sync_handle.wait()
+                except BaseException:
+                    # Creating a sampling client is transactional from the SDK's
+                    # point of view. If waiting is interrupted or the sync
+                    # fails, delete the remote sampling session so its pending
+                    # sync cannot be redispatched into a later cold-start pool.
+                    try:
+                        self.http.delete(f"/api/v1/sampling-sessions/{created_sampling_session_id}")
+                    except Exception as cleanup_exc:  # pragma: no cover - best effort
+                        logger.warning(
+                            "Failed to clean up sampling session %s after weights sync failure: %s",
+                            created_sampling_session_id,
+                            cleanup_exc,
+                        )
+                    raise
                 logger.info("Weights sync completed.")
             else:
                 # Standard 201 response: body is the SamplingSession directly


### PR DESCRIPTION
## Summary
- delete a newly-created sampling session when its blocking weight sync fails or is interrupted
- prevent orphaned sync operations from polluting a later shared LoRA cold start
- cover `KeyboardInterrupt`, which is intentionally outside `Exception`

## Verification
- `pytest -q tests/test_service_client.py -k create_sampling_client_deletes_session_when_sync_wait_fails`