### PR TITLE
chore: remove transformers version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "socksio>=1.0.0",
   "pydantic>=2.6,<3",
   "torch>=2.3,<3",
-  "transformers>=4.40,<5",
+  "transformers",
   "typing-extensions>=4.8,<5",
   "click>=8.1,<9",
   "rich>=13.0",


### PR DESCRIPTION
## Summary

- change the Weaver SDK dependency from `transformers>=4.40,<5` to `transformers`
- allow environments using Transformers 5.x or other compatible releases to install the SDK without resolver conflicts

## Why

The SDK currently declares an upper bound below Transformers 5 even though the package dependency does not need to enforce that version restriction.

## Impact

Package installers will continue to install Transformers when needed, but Weaver will no longer constrain the selected Transformers version.

## Validation

- `python -m pytest -q` — 509 passed
- parsed `pyproject.toml` and verified the declared dependency is exactly `transformers`
- `git diff --check`
