### PR TITLE
Expose LoRA alpha and safe unembedding default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.14.0"
+version = "1.15.0"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -137,6 +137,9 @@ def test_datum_from_raw():
 def test_lora_config_serializes_explicit_alpha_only_when_set():
     default_payload = LoraConfig(rank=32).to_payload()
     assert "lora_alpha" not in default_payload
+    assert default_payload["train_unembed"] is False
+    assert default_payload["train_mlp"] is True
+    assert default_payload["train_attn"] is True
 
     configured_payload = LoraConfig(rank=32, lora_alpha=64).to_payload()
     assert configured_payload["lora_alpha"] == 64

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,6 +17,7 @@
 import torch
 
 from weaver.types.datum import Datum
+from weaver.types.lora_config import LoraConfig
 from weaver.types.model_input import ModelInput
 from weaver.types.tensor import TensorData, tensor_payload
 
@@ -131,3 +132,22 @@ def test_datum_from_raw():
     datum = Datum.from_raw(model_input=model_input, loss_fn_inputs={"labels": labels})
     assert isinstance(datum, Datum)
     assert "labels" in datum.loss_fn_inputs
+
+
+def test_lora_config_serializes_explicit_alpha_only_when_set():
+    default_payload = LoraConfig(rank=32).to_payload()
+    assert "lora_alpha" not in default_payload
+
+    configured_payload = LoraConfig(rank=32, lora_alpha=64).to_payload()
+    assert configured_payload["lora_alpha"] == 64
+    assert configured_payload["rank"] == 32
+
+
+def test_lora_config_positional_arguments_remain_backward_compatible():
+    config = LoraConfig(16, 42, False, True, False)
+    assert config.rank == 16
+    assert config.seed == 42
+    assert config.train_unembed is False
+    assert config.train_mlp is True
+    assert config.train_attn is False
+    assert config.lora_alpha is None

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -354,7 +354,7 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
             client.create_model(
                 base_model="Qwen/Qwen3-8B",
                 training_mode="lora",
-                lora_config=LoraConfig(rank=16, seed=42)
+                lora_config=LoraConfig(rank=32, lora_alpha=64, seed=42)
             )
 
             # Long-context (256k) variant, full fine-tuning, fast throughput tier

--- a/weaver/types/lora_config.py
+++ b/weaver/types/lora_config.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(slots=True)
@@ -30,22 +29,33 @@ class LoraConfig:
     rank: int
     """LoRA rank (dimension of low-rank matrices)"""
 
-    seed: Optional[int] = None
+    seed: int | None = None
     """Seed used for initialization of LoRA weights.
 
     Useful if you need deterministic or reproducible initialization of weights.
     """
 
-    train_unembed: bool = True
-    """Whether to add LoRA to the unembedding layer"""
+    train_unembed: bool = False
+    """Whether to add LoRA to the unembedding layer.
+
+    This is disabled by default because unembedding-layer adapters are not
+    supported by every trainer/export/serving stack. Set it explicitly only
+    when the selected supported model advertises end-to-end support.
+    """
 
     train_mlp: bool = True
-    """Whether to add LoRAs to the MLP layers (including MoE layers)"""
+    """Whether to add LoRAs to the MLP layers (including MoE layers).
+
+    Backend support for excluding this target group is model dependent.
+    """
 
     train_attn: bool = True
-    """Whether to add LoRAs to the attention layers"""
+    """Whether to add LoRAs to the attention layers.
 
-    lora_alpha: Optional[int] = None
+    Backend support for excluding this target group is model dependent.
+    """
+
+    lora_alpha: int | None = None
     """Optional LoRA scaling numerator.
 
     The effective LoRA scale is ``lora_alpha / rank``. When omitted, the

--- a/weaver/types/lora_config.py
+++ b/weaver/types/lora_config.py
@@ -45,6 +45,15 @@ class LoraConfig:
     train_attn: bool = True
     """Whether to add LoRAs to the attention layers"""
 
+    lora_alpha: Optional[int] = None
+    """Optional LoRA scaling numerator.
+
+    The effective LoRA scale is ``lora_alpha / rank``. When omitted, the
+    platform keeps its backwards-compatible default (currently 32). Alpha does
+    not change adapter tensor shapes, so models sharing a trainer may choose
+    different values.
+    """
+
     def to_payload(self) -> dict[str, object]:
         """Convert to API payload format."""
         payload: dict[str, object] = {
@@ -53,6 +62,8 @@ class LoraConfig:
             "train_mlp": self.train_mlp,
             "train_attn": self.train_attn,
         }
+        if self.lora_alpha is not None:
+            payload["lora_alpha"] = self.lora_alpha
         if self.seed is not None:
             payload["seed"] = self.seed
         return payload


### PR DESCRIPTION
## What changed

- add optional `lora_alpha` to `LoraConfig`
- serialize alpha only when explicitly set, preserving the existing server default when omitted
- default `train_unembed` to `False` because it is not yet supported end to end by every trainer/export/serving stack
- document that target-group exclusion support is backend/model dependent
- retain positional compatibility for every pre-existing `LoraConfig` field

## Why

The SDK exposed rank and target-layer flags but had no way to request a LoRA scaling numerator. Users therefore could not run `rank=32, alpha=64` experiments even though the control plane stores LoRA config per model.

The previous `train_unembed=True` default also promised behavior that the production Megatron Bridge trainer did not perform. Keeping it enabled by default caused checkpoint metadata to overstate what was trained and could yield adapters that downstream engines could not load. This PR makes the conservative behavior explicit while the full target-module support matrix is being completed.

This PR remains draft until the paired server validation and shared-trainer per-adapter alpha changes are released and end-to-end validated.

## Impact

Existing alpha behavior is byte-for-byte compatible because `lora_alpha` is omitted by default. New clients may opt in with `LoraConfig(rank=32, lora_alpha=64)` after the matching trainer/server versions are available. The unembedding target now requires explicit opt-in.

## Validation

- `pytest -q tests/test_types.py` (15 passed)
- repository pre-commit hooks passed during commit, including black, isort, license header, pylint, and mypy
