### PR TITLE
docs: explain binary tensor transport configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ python examples/pig_latin.py
 | `http-binary` | `zstd` | Zstandard-compressed binary tensor packs |
 
 `tensor_compression` (or `WEAVER_TENSOR_COMPRESSION`) only takes effect with
-`http-binary`. The SDK packs uploads and materializes result tensors back into the
-legacy public response shape automatically, so `Datum` construction, training calls,
-and result handling do not need to change. Keep the `default` transport when connecting
+`http-binary`. For `cross_entropy` requests, the SDK moves eligible dense input tensors
+into the binary pack; control metadata and other values remain JSON. When an operation
+returns output tensors, the SDK downloads and materializes them back into the legacy
+public response shape automatically. `Datum` construction, training calls, and result
+handling therefore do not need to change. Keep the `default` transport when connecting
 to an older Weaver server/trainer deployment that does not support binary tensor packs.
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -28,9 +28,39 @@ the server keeps its stable personal-organization/default-project fallback.
 
 ### Training tensor transport
 
-`WEAVER_TENSOR_TRANSPORT` accepts `default` (inline JSON) or `http-binary`.
-HTTP packs use Zstandard compression by default; set
-`WEAVER_TENSOR_COMPRESSION=raw` to disable compression.
+Training tensors use inline JSON by default, preserving the behavior of existing
+clients. To opt into compressed binary transport, configure the service client:
+
+```python
+from weaver import ServiceClient
+
+with ServiceClient(
+    tensor_transport="http-binary",
+    tensor_compression="zstd",  # Optional: Zstandard is the binary-pack default.
+) as client:
+    ...
+```
+
+`AsyncServiceClient` accepts the same options. You can also configure an existing
+script, such as the Pig Latin example, without changing its source:
+
+```bash
+WEAVER_TENSOR_TRANSPORT=http-binary \
+WEAVER_TENSOR_COMPRESSION=zstd \
+python examples/pig_latin.py
+```
+
+| Transport | Compression | Behavior |
+| --- | --- | --- |
+| `default` | Ignored | Legacy inline JSON (the default) |
+| `http-binary` | `raw` | Binary tensor packs without compression |
+| `http-binary` | `zstd` | Zstandard-compressed binary tensor packs |
+
+`tensor_compression` (or `WEAVER_TENSOR_COMPRESSION`) only takes effect with
+`http-binary`. The SDK packs uploads and materializes result tensors back into the
+legacy public response shape automatically, so `Datum` construction, training calls,
+and result handling do not need to change. Keep the `default` transport when connecting
+to an older Weaver server/trainer deployment that does not support binary tensor packs.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,17 @@ with ServiceClient(
     ...
 ```
 
-`AsyncServiceClient` accepts the same options. You can also configure an existing
-script, such as the Pig Latin example, without changing its source:
+`AsyncServiceClient` accepts the same options. The runnable Pig Latin examples expose
+the same settings as command-line options:
+
+```bash
+python examples/pig_latin.py \
+  --tensor-transport http-binary \
+  --tensor-compression zstd
+```
+
+All clients also honor environment variables, so the same example can be configured
+without command-line options:
 
 ```bash
 WEAVER_TENSOR_TRANSPORT=http-binary \

--- a/README_zh.md
+++ b/README_zh.md
@@ -59,7 +59,7 @@ python examples/pig_latin.py
 | `http-binary` | `raw` | 不压缩的二进制 tensor pack |
 | `http-binary` | `zstd` | 使用 Zstandard 压缩的二进制 tensor pack |
 
-`tensor_compression`（或 `WEAVER_TENSOR_COMPRESSION`）仅在 transport 为 `http-binary` 时生效。SDK 会自动打包上传张量，并将结果张量还原成原有的公开返回结构，因此无需修改 `Datum` 构造、训练调用或结果处理代码。连接到不支持二进制 tensor pack 的旧版 Weaver server/trainer 部署时，请继续使用 `default` transport。
+`tensor_compression`（或 `WEAVER_TENSOR_COMPRESSION`）仅在 transport 为 `http-binary` 时生效。对于 `cross_entropy` 请求，SDK 只会将符合条件的稠密输入张量移入二进制 tensor pack；控制元数据和其他值仍使用 JSON。操作返回输出张量时，SDK 会自动下载并将其还原成原有的公开返回结构。因此无需修改 `Datum` 构造、训练调用或结果处理代码。连接到不支持二进制 tensor pack 的旧版 Weaver server/trainer 部署时，请继续使用 `default` transport。
 
 ## 快速开始
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -37,7 +37,15 @@ with ServiceClient(
     ...
 ```
 
-`AsyncServiceClient` 支持相同的参数。也可以通过环境变量配置已有脚本，例如无需修改 Pig Latin 示例源码即可运行：
+`AsyncServiceClient` 支持相同的参数。可运行的 Pig Latin 示例也提供了对应的命令行参数：
+
+```bash
+python examples/pig_latin.py \
+  --tensor-transport http-binary \
+  --tensor-compression zstd
+```
+
+所有 client 同样支持环境变量，因此也可以不传命令行参数来配置同一个示例：
 
 ```bash
 WEAVER_TENSOR_TRANSPORT=http-binary \

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,6 +23,36 @@ pip install nex-weaver
 
 规范 UUID 的优先级更高。组织和项目均为空时，服务端继续使用稳定的个人组织和默认项目回退逻辑。
 
+### 训练张量传输
+
+训练张量默认使用 inline JSON，以保持现有客户端的行为不变。要启用压缩的二进制传输，配置 service client：
+
+```python
+from weaver import ServiceClient
+
+with ServiceClient(
+    tensor_transport="http-binary",
+    tensor_compression="zstd",  # 可省略：二进制 tensor pack 默认使用 Zstandard。
+) as client:
+    ...
+```
+
+`AsyncServiceClient` 支持相同的参数。也可以通过环境变量配置已有脚本，例如无需修改 Pig Latin 示例源码即可运行：
+
+```bash
+WEAVER_TENSOR_TRANSPORT=http-binary \
+WEAVER_TENSOR_COMPRESSION=zstd \
+python examples/pig_latin.py
+```
+
+| Transport | Compression | 行为 |
+| --- | --- | --- |
+| `default` | 忽略 | 兼容旧行为的 inline JSON（默认值） |
+| `http-binary` | `raw` | 不压缩的二进制 tensor pack |
+| `http-binary` | `zstd` | 使用 Zstandard 压缩的二进制 tensor pack |
+
+`tensor_compression`（或 `WEAVER_TENSOR_COMPRESSION`）仅在 transport 为 `http-binary` 时生效。SDK 会自动打包上传张量，并将结果张量还原成原有的公开返回结构，因此无需修改 `Datum` 构造、训练调用或结果处理代码。连接到不支持二进制 tensor pack 的旧版 Weaver server/trainer 部署时，请继续使用 `default` transport。
+
 ## 快速开始
 
 ```python

--- a/examples/pig_latin.py
+++ b/examples/pig_latin.py
@@ -11,10 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Pig Latin fine-tuning walkthrough using the Weaver SDK."""
+"""Pig Latin fine-tuning walkthrough using the Weaver SDK.
+
+Run with ``--tensor-transport http-binary`` to use binary tensor packs. Zstandard
+compression is enabled by default for binary packs; select ``--tensor-compression raw``
+to disable it.
+"""
 
 from __future__ import annotations
 
+import argparse
 import os
 from typing import Any, Dict, List
 
@@ -74,10 +80,32 @@ def _extract_logprobs(output: Dict[str, Any]) -> torch.Tensor:
     return torch.as_tensor(value, dtype=torch.float32)
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command-line tensor transport options."""
+
+    parser = argparse.ArgumentParser(description="Run the Pig Latin fine-tuning example.")
+    parser.add_argument(
+        "--tensor-transport",
+        choices=("default", "http-binary"),
+        default=None,
+        help="defaults to WEAVER_TENSOR_TRANSPORT or default",
+    )
+    parser.add_argument(
+        "--tensor-compression",
+        choices=("raw", "zstd"),
+        default=None,
+        help="compression for http-binary; defaults to WEAVER_TENSOR_COMPRESSION or zstd",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
+    args = parse_args()
     base_model = "Qwen/Qwen3-8B"
     with ServiceClient(
         api_key=os.getenv("WEAVER_API_KEY"),
+        tensor_transport=args.tensor_transport,
+        tensor_compression=args.tensor_compression,
     ) as service_client:
         training_client = service_client.create_model(base_model=base_model)
         print(f"Model ID: {training_client.model_id}")

--- a/examples/pig_latin_async.py
+++ b/examples/pig_latin_async.py
@@ -34,10 +34,13 @@ calling ``asyncio.run``. See the "Event loop model" section in
 ``AsyncServiceClient`` for the full integration contract.
 
 Run with:  ``python examples/pig_latin_async.py``  (needs ``WEAVER_API_KEY``).
+Add ``--tensor-transport http-binary`` to use binary tensor packs; Zstandard
+compression is the default and ``--tensor-compression raw`` disables it.
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import os
 from typing import Any, Dict, List
@@ -103,9 +106,33 @@ def _loss_per_token(fwdbwd_result: Dict[str, Any], examples: List[types.Datum]) 
     return float(-torch.dot(logprobs, weights) / weights.sum())
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command-line tensor transport options."""
+
+    parser = argparse.ArgumentParser(description="Run the async Pig Latin example.")
+    parser.add_argument(
+        "--tensor-transport",
+        choices=("default", "http-binary"),
+        default=None,
+        help="defaults to WEAVER_TENSOR_TRANSPORT or default",
+    )
+    parser.add_argument(
+        "--tensor-compression",
+        choices=("raw", "zstd"),
+        default=None,
+        help="compression for http-binary; defaults to WEAVER_TENSOR_COMPRESSION or zstd",
+    )
+    return parser.parse_args()
+
+
 async def main() -> None:
+    args = parse_args()
     base_model = os.getenv("WEAVER_BASE_MODEL", "Qwen/Qwen3-8B")
-    async with AsyncServiceClient(api_key=os.getenv("WEAVER_API_KEY")) as service_client:
+    async with AsyncServiceClient(
+        api_key=os.getenv("WEAVER_API_KEY"),
+        tensor_transport=args.tensor_transport,
+        tensor_compression=args.tensor_compression,
+    ) as service_client:
         training_client = await service_client.create_model(base_model=base_model)
         print(f"Model ID: {training_client.model_id}")
         tokenizer = training_client.get_tokenizer()

--- a/examples/pig_latin_fullft.py
+++ b/examples/pig_latin_fullft.py
@@ -11,10 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Pig Latin fine-tuning walkthrough using the Weaver SDK."""
+"""Pig Latin full fine-tuning walkthrough using the Weaver SDK.
+
+Run with ``--tensor-transport http-binary`` to use binary tensor packs. Zstandard
+compression is enabled by default for binary packs; select ``--tensor-compression raw``
+to disable it.
+"""
 
 from __future__ import annotations
 
+import argparse
 import os
 from typing import Any, Dict, List
 
@@ -74,10 +80,32 @@ def _extract_logprobs(output: Dict[str, Any]) -> torch.Tensor:
     return torch.as_tensor(value, dtype=torch.float32)
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command-line tensor transport options."""
+
+    parser = argparse.ArgumentParser(description="Run the Pig Latin full-FT example.")
+    parser.add_argument(
+        "--tensor-transport",
+        choices=("default", "http-binary"),
+        default=None,
+        help="defaults to WEAVER_TENSOR_TRANSPORT or default",
+    )
+    parser.add_argument(
+        "--tensor-compression",
+        choices=("raw", "zstd"),
+        default=None,
+        help="compression for http-binary; defaults to WEAVER_TENSOR_COMPRESSION or zstd",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
+    args = parse_args()
     base_model = "Qwen/Qwen3-8B"
     with ServiceClient(
         api_key=os.getenv("WEAVER_API_KEY"),
+        tensor_transport=args.tensor_transport,
+        tensor_compression=args.tensor_compression,
     ) as service_client:
         training_client = service_client.create_model(
             base_model=base_model,


### PR DESCRIPTION
## Summary

- show how to enable compressed binary tensor transport through `ServiceClient`, CLI options, or environment variables
- expose `--tensor-transport` and `--tensor-compression` in the sync, async, and full-FT Pig Latin examples
- clarify the behavior of `default`, `http-binary/raw`, and `http-binary/zstd`
- document transparent result materialization and compatibility with older deployments
- mirror the guidance in the Chinese README

Follow-up documentation for #93 and the README review discussion.

## Validation

- `pre-commit run --files README.md README_zh.md examples/pig_latin.py examples/pig_latin_async.py examples/pig_latin_fullft.py`
- CLI parsing smoke check for defaults and `http-binary/raw`
- `python -m pytest -q tests/test_config.py tests/test_tensor_transport.py` (59 passed)
- `git diff --check`