### PR TITLE
feat: expose LoRA and Full-FT supported-model pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ the same settings as command-line options:
 
 ```bash
 python examples/pig_latin.py \
+  --base-model Qwen/Qwen3.5-0.8B:262144 \
+  --lora-rank 16 \
   --tensor-transport http-binary \
   --tensor-compression zstd
 ```
@@ -111,6 +113,32 @@ weaver scope resolve --organization research --project alignment
 
 Organization slugs are globally unique. Project slugs and names are unique inside
 their organization; an ambiguous display name is rejected instead of guessed.
+
+### Supported models and training modes
+
+The backwards-compatible call still returns model names. Request details when choosing
+between the independently priced LoRA and Full-FT modes:
+
+```python
+models = client.list_supported_models(detailed=True)
+for model in models:
+    for mode in model.training_modes:
+        print(model.name, mode.display_name, mode.prices)
+```
+
+`training_modes` contains only modes that the model explicitly supports and
+that have all four effective prices. A missing Full-FT quote means Full-FT is
+not supported; the SDK never fabricates a 10× display price.
+
+The CLI uses one compact row per mode with `Train`, `Input`, `Cached input`, and
+`Output` columns. Filter to one mode, emit names only, or request stable JSON when needed:
+
+```bash
+weaver list supported-models
+weaver list supported-models --mode full-ft
+weaver list supported-models --format names
+weaver list supported-models --format json
+```
 
 ## Usage
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -90,6 +90,29 @@ weaver scope resolve --organization research --project alignment
 
 组织 slug 全局唯一；项目 slug 和名称在组织内唯一。展示名称存在歧义时会明确报错，不会猜测选择。
 
+### 支持的模型与训练模式
+
+为保持兼容，原调用仍返回模型名称；选择 LoRA 或 Full-FT 时可以请求包含两种独立价格的详情：
+
+```python
+models = client.list_supported_models(detailed=True)
+for model in models:
+    for mode in model.training_modes:
+        print(model.name, mode.display_name, mode.prices)
+```
+
+`training_modes` 只包含模型明确支持且四项有效价格齐全的模式。缺少 Full-FT
+报价就表示不支持 Full-FT；SDK 不会自行展示 10× 的估算价格。
+
+CLI 默认让每种模式占一行，并紧凑展示训练、输入、缓存输入、输出四列价格；也可以只看一种模式、只输出名称，或输出稳定 JSON：
+
+```bash
+weaver list supported-models
+weaver list supported-models --mode full-ft
+weaver list supported-models --format names
+weaver list supported-models --format json
+```
+
 ## 使用方法
 
 参见 [`examples/weaver_walkthrough.ipynb`](examples/weaver_walkthrough.ipynb)，通过 Pig Latin 翻译任务交互式演示完整的 SDK 工作流——涵盖数据准备、LoRA / 全量微调、采样推理和 checkpoint 管理。

--- a/examples/connect.py
+++ b/examples/connect.py
@@ -23,8 +23,15 @@ def main():
     with ServiceClient(
         api_key=os.getenv("WEAVER_API_KEY"),
     ) as client:
-        models = client.list_supported_models()
-        print(models)
+        models = client.list_supported_models(detailed=True)
+        for model in models:
+            prices = {
+                mode.display_name: {
+                    kind: str(price.unit_price_usd) for kind, price in mode.prices.items()
+                }
+                for mode in model.training_modes
+            }
+            print(model.name, prices)
 
 
 if __name__ == "__main__":

--- a/examples/pig_latin.py
+++ b/examples/pig_latin.py
@@ -85,6 +85,17 @@ def parse_args() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(description="Run the Pig Latin fine-tuning example.")
     parser.add_argument(
+        "--base-model",
+        default=os.getenv("WEAVER_BASE_MODEL", "Qwen/Qwen3-8B"),
+        help="supported base model; defaults to WEAVER_BASE_MODEL or Qwen/Qwen3-8B",
+    )
+    parser.add_argument(
+        "--lora-rank",
+        type=int,
+        default=int(os.getenv("WEAVER_LORA_RANK", "16")),
+        help="LoRA rank; defaults to WEAVER_LORA_RANK or 16",
+    )
+    parser.add_argument(
         "--tensor-transport",
         choices=("default", "http-binary"),
         default=None,
@@ -101,13 +112,16 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    base_model = "Qwen/Qwen3-8B"
+    base_model = args.base_model
     with ServiceClient(
         api_key=os.getenv("WEAVER_API_KEY"),
         tensor_transport=args.tensor_transport,
         tensor_compression=args.tensor_compression,
     ) as service_client:
-        training_client = service_client.create_model(base_model=base_model)
+        training_client = service_client.create_model(
+            base_model=base_model,
+            lora_config=types.LoraConfig(rank=args.lora_rank),
+        )
         print(f"Model ID: {training_client.model_id}")
         tokenizer = training_client.get_tokenizer()
 

--- a/examples/pig_latin_fullft.py
+++ b/examples/pig_latin_fullft.py
@@ -85,6 +85,11 @@ def parse_args() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(description="Run the Pig Latin full-FT example.")
     parser.add_argument(
+        "--base-model",
+        default=os.getenv("WEAVER_BASE_MODEL", "Qwen/Qwen3-8B"),
+        help="supported base model; defaults to WEAVER_BASE_MODEL or Qwen/Qwen3-8B",
+    )
+    parser.add_argument(
         "--tensor-transport",
         choices=("default", "http-binary"),
         default=None,
@@ -101,7 +106,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    base_model = "Qwen/Qwen3-8B"
+    base_model = args.base_model
     with ServiceClient(
         api_key=os.getenv("WEAVER_API_KEY"),
         tensor_transport=args.tensor_transport,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nex-weaver"
-version = "1.14.0"
+version = "1.15.0"
 description = "Python SDK for the Weaver platform"
 readme = "README.md"
 authors = [

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-from weaver._http import APIClient, _is_connection_error
+from weaver._http import APIClient, WeaverAPIError, _is_connection_error
 from weaver.config import WeaverConfig
 
 
@@ -173,9 +173,11 @@ class TestConnectionErrorRetry:
         client._client.headers = {}
         client._client.request.side_effect = OSError(9, "Bad file descriptor")
 
-        with pytest.raises(OSError, match="Bad file descriptor"):
+        with pytest.raises(WeaverAPIError, match="transport_unavailable") as exc_info:
             client.post("/api/v1/models/m1/operations", json={}, max_retries=1)
 
+        assert exc_info.value.retryable is True
+        assert isinstance(exc_info.value.__cause__, OSError)
         assert client._client.request.call_count == DEFAULT_CONNECTION_RETRIES
 
     def test_non_connection_error_not_retried_with_max_retries_1(self, client):

--- a/tests/test_supported_models.py
+++ b/tests/test_supported_models.py
@@ -1,0 +1,248 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import json
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from click.testing import CliRunner
+
+from weaver.async_service_client import AsyncServiceClient
+from weaver.cli import cli
+from weaver.service_client import ServiceClient
+from weaver.types import SupportedModel
+
+
+def catalog_model(name: str = "Qwen/Qwen3.5-0.8B:262144") -> dict:
+    return {
+        "id": "model-1",
+        "name": name,
+        "status": "available",
+        "visibility": "public",
+        "training_modes": ["lora", "full_ft"],
+        "metadata": {"context_length": 262144},
+        "prices": {
+            "training_tokens:lora": {
+                "unit": "million_tokens",
+                "unit_price_micros": 335_000,
+                "version": "north-ledger-sku-2867",
+            },
+            "training_tokens:full_ft": {
+                "unit": "million_tokens",
+                "unit_price_micros": 3_350_000,
+                "version": "north-ledger-sku-2868",
+            },
+            "sampling_prefill_tokens:lora": {
+                "unit": "million_tokens",
+                "unit_price_micros": 110_000,
+                "version": "lora-prefill",
+            },
+            "sampling_cached_prefill_tokens:lora": {
+                "unit": "million_tokens",
+                "unit_price_micros": 22_000,
+                "version": "lora-cached",
+            },
+            "sampling_output_tokens:lora": {
+                "unit": "million_tokens",
+                "unit_price_micros": 440_000,
+                "version": "lora-output",
+            },
+            "sampling_prefill_tokens:full_ft": {
+                "unit": "million_tokens",
+                "unit_price_micros": 1_100_000,
+                "version": "full-prefill",
+            },
+            "sampling_cached_prefill_tokens:full_ft": {
+                "unit": "million_tokens",
+                "unit_price_micros": 220_000,
+                "version": "full-cached",
+            },
+            "sampling_output_tokens:full_ft": {
+                "unit": "million_tokens",
+                "unit_price_micros": 4_400_000,
+                "version": "full-output",
+            },
+        },
+    }
+
+
+def test_detailed_supported_models_have_two_independent_prices() -> None:
+    client = ServiceClient(organization_id="org-1")
+    client._http = MagicMock()
+    client._http.get.return_value = {
+        "items": [catalog_model()],
+        "pagination": {"total_count": 1},
+    }
+
+    models = client.list_supported_models(detailed=True)
+
+    assert len(models) == 1
+    assert isinstance(models[0], SupportedModel)
+    assert models[0].training_mode("lora").price.unit_price_usd == Decimal("0.335")
+    assert models[0].training_mode("full-ft").price.unit_price_usd == Decimal("3.35")
+    assert models[0].training_mode("lora").price_for(
+        "sampling_cached_prefill_tokens"
+    ).unit_price_usd == Decimal("0.022")
+    assert models[0].training_mode("full-ft").price_for(
+        "sampling_output_tokens"
+    ).unit_price_usd == Decimal("4.4")
+    client._http.get.assert_called_once_with(
+        "/api/v1/model-catalog",
+        params={"limit": 100, "offset": 0, "organization_id": "org-1"},
+    )
+
+
+def test_legacy_sampling_fills_only_the_explicitly_quoted_training_mode() -> None:
+    payload = catalog_model()
+    payload["prices"] = {
+        "training_tokens:lora": {
+            "unit": "million_tokens",
+            "unit_price_micros": 200_000,
+            "version": "legacy",
+        },
+        "sampling_prefill_tokens": {
+            "unit": "million_tokens",
+            "unit_price_micros": 90_000,
+            "version": "legacy-prefill",
+        },
+        "sampling_cached_prefill_tokens": {
+            "unit": "million_tokens",
+            "unit_price_micros": 18_000,
+            "version": "legacy-cached",
+        },
+        "sampling_output_tokens": {
+            "unit": "million_tokens",
+            "unit_price_micros": 300_000,
+            "version": "legacy-output",
+        },
+    }
+
+    payload["training_modes"] = ["lora"]
+    model = SupportedModel.from_payload(payload)
+    assert [mode.mode for mode in model.training_modes] == ["lora"]
+    assert model.training_mode("lora").price.unit_price_micros == 200_000
+    assert (
+        model.training_mode("lora").price_for("sampling_prefill_tokens").unit_price_micros == 90_000
+    )
+    assert model.training_mode("full_ft") is None
+
+
+def test_missing_full_ft_quote_means_full_ft_is_not_supported() -> None:
+    payload = catalog_model()
+    payload["training_modes"] = ["lora", "full_ft"]
+    del payload["prices"]["training_tokens:full_ft"]
+
+    model = SupportedModel.from_payload(payload)
+
+    assert [mode.mode for mode in model.training_modes] == ["lora"]
+    assert model.training_mode("full_ft") is None
+
+
+def test_async_detailed_supported_models_match_sync_shape() -> None:
+    async def run() -> None:
+        client = AsyncServiceClient(organization_id="org-async")
+        client._http = MagicMock()
+        client._http.get = AsyncMock(
+            return_value={"items": [catalog_model()], "pagination": {"total_count": 1}}
+        )
+
+        models = await client.list_supported_models(detailed=True)
+
+        assert models[0].training_mode("lora").display_name == "LoRA"
+        assert client._http.get.await_args_list == [
+            call(
+                "/api/v1/model-catalog",
+                params={"limit": 100, "offset": 0, "organization_id": "org-async"},
+            )
+        ]
+
+    asyncio.run(run())
+
+
+def test_cli_renders_one_complete_price_row_per_mode(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_supported_model_details.return_value = [
+        SupportedModel.from_payload(catalog_model())
+    ]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(cli, ["list", "supported-models"])
+
+    assert result.exit_code == 0
+    assert result.output.count("Qwen/Qwen3.5-0.8B:262144") == 1
+    assert "LoRA" in result.output
+    assert "Full-FT" in result.output
+    for price in ("$0.335", "$0.11", "$0.022", "$0.44", "$3.35", "$1.1", "$0.22", "$4.4"):
+        assert price in result.output
+    assert "Cached input" in result.output
+    client.connect.assert_called_once_with(ensure_session=False)
+    client.close.assert_called_once_with()
+
+
+def test_cli_json_can_select_one_training_mode(monkeypatch) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_supported_model_details.return_value = [
+        SupportedModel.from_payload(catalog_model())
+    ]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(
+            cli,
+            ["list", "supported-models", "--mode", "full-ft", "--format", "json"],
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert [item["mode"] for item in payload[0]["training_modes"]] == ["full_ft"]
+    prices = payload[0]["training_modes"][0]["prices"]
+    assert prices["training_tokens"]["unit_price_micros"] == 3_350_000
+    assert prices["sampling_output_tokens"]["unit_price_micros"] == 4_400_000
+
+
+@pytest.mark.parametrize("output_format", ["table", "json", "names"])
+def test_cli_mode_filter_hides_models_that_do_not_support_the_mode(
+    monkeypatch, output_format: str
+) -> None:
+    monkeypatch.delenv("WEAVER_BASE_URL", raising=False)
+    monkeypatch.delenv("WEAVER_API_KEY", raising=False)
+    payload = catalog_model("Qwen/LoRAOnly")
+    payload["training_modes"] = ["lora"]
+    client = MagicMock()
+    client.list_supported_model_details.return_value = [SupportedModel.from_payload(payload)]
+    with patch("weaver.cli.ServiceClient", return_value=client):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "list",
+                "supported-models",
+                "--mode",
+                "full-ft",
+                "--format",
+                output_format,
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "Qwen/LoRAOnly" not in result.output
+    assert "Not supported" not in result.output
+    if output_format == "json":
+        assert json.loads(result.output) == []
+    elif output_format == "table":
+        assert "0 supported models" in result.output

--- a/weaver/__init__.py
+++ b/weaver/__init__.py
@@ -31,6 +31,11 @@ from .async_training_client import AsyncTrainingClient  # noqa: F401
 from .operations import AsyncOperationHandle, OperationHandle  # noqa: F401
 from .service_client import ServiceClient  # noqa: F401
 from .types.deployment import Deployment  # noqa: F401
+from .types.supported_model import (  # noqa: F401
+    SupportedModel,
+    SupportedModelPrice,
+    SupportedTrainingMode,
+)
 from .types.weights_artifact import WeightsArtifact  # noqa: F401
 
 __all__ = [
@@ -43,6 +48,9 @@ __all__ = [
     "WeaverAPIError",
     "WeightsArtifact",
     "Deployment",
+    "SupportedModel",
+    "SupportedModelPrice",
+    "SupportedTrainingMode",
     "types",
     "__version__",
 ]

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -760,7 +760,13 @@ class APIClient:
                             path,
                             str(e),
                         )
-                        raise
+                        transport_error = WeaverAPIError(
+                            503,
+                            "transport_unavailable",
+                            f"{method} {path} failed after {connection_error_count} connection attempts",
+                            True,
+                        )
+                        raise transport_error from e
 
                     delay = min(
                         INITIAL_RETRY_DELAY * (2 ** (connection_error_count - 1)),

--- a/weaver/async_service_client.py
+++ b/weaver/async_service_client.py
@@ -134,6 +134,7 @@ from .operations import AsyncOperationHandle, build_async_operation_handle
 from .tensor_transport import TensorPack
 from .types import LoraConfig
 from .types.deployment import Deployment
+from .types.supported_model import SupportedModel
 from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
@@ -717,8 +718,64 @@ class AsyncServiceClient:  # pylint: disable=too-many-public-methods
                 return item
         return None
 
-    async def list_supported_models(self) -> List[str]:
-        """Return usable model names exposed to the authenticated role."""
+    async def _list_model_catalog_records(self) -> List[Dict[str, Any]]:
+        """Traverse the user-facing, organization-priced model catalog."""
+
+        records: List[Dict[str, Any]] = []
+        limit = 100
+        offset = 0
+        scope = await self._supported_model_scope_params()
+        while True:
+            params: Dict[str, Any] = {"limit": limit, "offset": offset, **scope}
+            payload = await self.http.get("/api/v1/model-catalog", params=params)
+            if not isinstance(payload, dict):
+                break
+            items = payload.get("items")
+            if not isinstance(items, list):
+                break
+            records.extend(item for item in items if isinstance(item, dict))
+            pagination = payload.get("pagination")
+            if not isinstance(pagination, dict):
+                break
+            try:
+                total_count = int(str(pagination.get("total_count")))
+            except (TypeError, ValueError):
+                break
+            offset += len(items)
+            if not items or offset >= total_count:
+                break
+        return records
+
+    async def list_supported_model_details(self) -> List[SupportedModel]:
+        """Return usable models with four explicit prices per LoRA/Full-FT mode."""
+
+        models = [
+            SupportedModel.from_payload(item) for item in await self._list_model_catalog_records()
+        ]
+        return [
+            model
+            for model in models
+            if model.name and model.status.lower() in {"healthy", "available"}
+        ]
+
+    @overload
+    async def list_supported_models(self, *, detailed: Literal[False] = False) -> List[str]: ...
+
+    @overload
+    async def list_supported_models(self, *, detailed: Literal[True]) -> List[SupportedModel]: ...
+
+    async def list_supported_models(
+        self, *, detailed: bool = False
+    ) -> List[str] | List[SupportedModel]:
+        """Return usable supported models.
+
+        The default remains a list of names for backwards compatibility. Pass
+        ``detailed=True`` to receive typed catalog records where LoRA and
+        Full-FT are separate modes with independent train/input/cache/output prices.
+        """
+
+        if detailed:
+            return await self.list_supported_model_details()
 
         names: List[str] = []
         for item in await self._list_supported_model_records():

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -37,6 +37,7 @@ from ._http import WeaverAPIError
 from .operations import build_operation_handle
 from .service_client import ServiceClient
 from .types.deployment import Deployment
+from .types.supported_model import SupportedModel, SupportedModelPrice
 
 console = Console()
 
@@ -194,6 +195,48 @@ def create_models_table(items: List[Dict[str, Any]]) -> Table:
             format_date(item.get("created_at")),
         )
 
+    return table
+
+
+def format_supported_model_price(price: SupportedModelPrice | None) -> str:
+    """Format an exact catalog price for narrow terminal output."""
+
+    if price is None:
+        return "[dim]Not priced[/dim]"
+    if price.unit == "million_tokens":
+        return f"${price.unit_price_usd}"
+    return f"${price.unit_price_usd} / {price.unit}"
+
+
+def create_supported_models_table(items: List[SupportedModel], mode: str = "all") -> Table:
+    """Render one compact row for each explicitly supported model mode."""
+
+    normalized_mode = mode.replace("-", "_")
+    table = Table(title="Supported Models · USD per 1M tokens", box=box.ROUNDED)
+    table.add_column("Model", style="green")
+    table.add_column("Mode", style="cyan", no_wrap=True)
+    table.add_column("Train", justify="right", no_wrap=True)
+    table.add_column("Input", justify="right", no_wrap=True)
+    table.add_column("Cached input", justify="right", no_wrap=True)
+    table.add_column("Output", justify="right", no_wrap=True)
+    for model in items:
+        modes = [
+            item
+            for item in model.training_modes
+            if normalized_mode == "all" or item.mode == normalized_mode
+        ]
+        for index, training_mode in enumerate(modes):
+            table.add_row(
+                model.name if index == 0 else "",
+                training_mode.display_name,
+                format_supported_model_price(training_mode.price_for("training_tokens")),
+                format_supported_model_price(training_mode.price_for("sampling_prefill_tokens")),
+                format_supported_model_price(
+                    training_mode.price_for("sampling_cached_prefill_tokens")
+                ),
+                format_supported_model_price(training_mode.price_for("sampling_output_tokens")),
+                end_section=index == len(modes) - 1,
+            )
     return table
 
 
@@ -532,6 +575,71 @@ def projects_list_cmd(
     """List projects in an organization."""
 
     _run_list_projects(org_id, org_reference, output_format, base_url, api_key)
+
+
+@list.command("supported-models")
+@click.option(
+    "--mode",
+    type=click.Choice(["all", "lora", "full-ft"]),
+    default="all",
+    show_default=True,
+    help="Show both training modes or only one mode",
+)
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json", "names"]),
+    default="table",
+    show_default=True,
+    help="Table for humans, JSON for scripts, or one model name per line",
+)
+@click.option(
+    "--organization-id",
+    "--org-id",
+    envvar="WEAVER_ORGANIZATION_ID",
+    help="Organization whose effective catalog prices should be shown",
+)
+@click.option("--base-url", envvar="WEAVER_BASE_URL", help="Weaver server base URL")
+@click.option("--api-key", envvar="WEAVER_API_KEY", help="Weaver API key")
+def list_supported_models_cmd(
+    mode: str,
+    output_format: str,
+    organization_id: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> None:
+    """List usable models with separate LoRA and Full-FT choices."""
+
+    client = ServiceClient(
+        base_url=base_url,
+        api_key=api_key,
+        organization_id=organization_id,
+    )
+    try:
+        client.connect(ensure_session=False)
+        models = client.list_supported_model_details()
+        normalized_mode = mode.replace("-", "_")
+        selected_models = (
+            models
+            if normalized_mode == "all"
+            else [model for model in models if model.training_mode(normalized_mode) is not None]
+        )
+        if output_format == "names":
+            for model in selected_models:
+                click.echo(model.name)
+        elif output_format == "json":
+            selected_mode = None if mode == "all" else mode
+            format_json_output(
+                [model.to_dict(mode=selected_mode) for model in selected_models]
+            )
+        else:
+            console.print(create_supported_models_table(selected_models, mode))
+            console.print(f"\n{len(selected_models)} supported models")
+    except Exception as e:
+        handle_error(e)
+    finally:
+        client.close()
 
 
 @scope_group.command("resolve")

--- a/weaver/cli.py
+++ b/weaver/cli.py
@@ -630,9 +630,7 @@ def list_supported_models_cmd(
                 click.echo(model.name)
         elif output_format == "json":
             selected_mode = None if mode == "all" else mode
-            format_json_output(
-                [model.to_dict(mode=selected_mode) for model in selected_models]
-            )
+            format_json_output([model.to_dict(mode=selected_mode) for model in selected_models])
         else:
             console.print(create_supported_models_table(selected_models, mode))
             console.print(f"\n{len(selected_models)} supported models")

--- a/weaver/service_client.py
+++ b/weaver/service_client.py
@@ -87,6 +87,7 @@ from .operations import OperationHandle, build_operation_handle
 from .tensor_transport import TensorPack
 from .types import LoraConfig
 from .types.deployment import Deployment
+from .types.supported_model import SupportedModel
 from .types.weights_artifact import WeightsArtifact
 
 if TYPE_CHECKING:
@@ -661,8 +662,60 @@ class ServiceClient:  # pylint: disable=too-many-public-methods
                 break
         return records
 
-    def list_supported_models(self) -> List[str]:
-        """Return usable model names exposed to the authenticated role."""
+    def _list_model_catalog_records(self) -> List[Dict[str, Any]]:
+        """Traverse the user-facing, organization-priced model catalog."""
+
+        records: List[Dict[str, Any]] = []
+        limit = 100
+        offset = 0
+        scope = self._supported_model_scope_params()
+        while True:
+            params: Dict[str, Any] = {"limit": limit, "offset": offset, **scope}
+            payload = self.http.get("/api/v1/model-catalog", params=params)
+            if not isinstance(payload, dict):
+                break
+            items = payload.get("items")
+            if not isinstance(items, list):
+                break
+            records.extend(item for item in items if isinstance(item, dict))
+            pagination = payload.get("pagination")
+            if not isinstance(pagination, dict):
+                break
+            try:
+                total_count = int(str(pagination.get("total_count")))
+            except (TypeError, ValueError):
+                break
+            offset += len(items)
+            if not items or offset >= total_count:
+                break
+        return records
+
+    def list_supported_model_details(self) -> List[SupportedModel]:
+        """Return usable models with four explicit prices per LoRA/Full-FT mode."""
+
+        models = [SupportedModel.from_payload(item) for item in self._list_model_catalog_records()]
+        return [
+            model
+            for model in models
+            if model.name and model.status.lower() in {"healthy", "available"}
+        ]
+
+    @overload
+    def list_supported_models(self, *, detailed: Literal[False] = False) -> List[str]: ...
+
+    @overload
+    def list_supported_models(self, *, detailed: Literal[True]) -> List[SupportedModel]: ...
+
+    def list_supported_models(self, *, detailed: bool = False) -> List[str] | List[SupportedModel]:
+        """Return usable supported models.
+
+        The default remains a list of names for backwards compatibility. Pass
+        ``detailed=True`` to receive typed catalog records where LoRA and
+        Full-FT are separate modes with independent train/input/cache/output prices.
+        """
+
+        if detailed:
+            return self.list_supported_model_details()
 
         names: List[str] = []
         for item in self._list_supported_model_records():

--- a/weaver/types/__init__.py
+++ b/weaver/types/__init__.py
@@ -50,6 +50,7 @@ from .router_replay import (
 )
 from .sampling import SamplingParams
 from .sampling_control import PauseMode, coerce_pause_mode
+from .supported_model import SupportedModel, SupportedModelPrice, SupportedTrainingMode
 from .tensor import TensorData
 from .weights_artifact import WeightsArtifact
 
@@ -67,6 +68,9 @@ __all__ = [
     "ModelInputChunk",
     "PauseMode",
     "SamplingParams",
+    "SupportedModel",
+    "SupportedModelPrice",
+    "SupportedTrainingMode",
     "TensorData",
     "WeightsArtifact",
     "coerce_pause_mode",

--- a/weaver/types/supported_model.py
+++ b/weaver/types/supported_model.py
@@ -1,0 +1,188 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""User-facing supported-model catalog types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+MODE_PRICE_KINDS = (
+    "training_tokens",
+    "sampling_prefill_tokens",
+    "sampling_cached_prefill_tokens",
+    "sampling_output_tokens",
+)
+
+
+@dataclass(frozen=True)
+class SupportedModelPrice:
+    """One effective catalog price, represented without floating-point loss."""
+
+    unit: str
+    unit_price_micros: int
+    version: str | None = None
+
+    @property
+    def unit_price_usd(self) -> Decimal:
+        """Return the USD price for one catalog unit."""
+
+        return Decimal(self.unit_price_micros) / Decimal(1_000_000)
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> SupportedModelPrice | None:
+        if not isinstance(payload, dict):
+            return None
+        try:
+            unit_price_micros = int(payload["unit_price_micros"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        return cls(
+            unit=str(payload.get("unit") or ""),
+            unit_price_micros=unit_price_micros,
+            version=str(payload["version"]) if payload.get("version") is not None else None,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "unit": self.unit,
+            "unit_price_micros": self.unit_price_micros,
+            "unit_price_usd": str(self.unit_price_usd),
+            "version": self.version,
+        }
+
+
+@dataclass(frozen=True)
+class SupportedTrainingMode:
+    """A model mode and its four independently configurable effective prices."""
+
+    mode: str
+    display_name: str
+    prices: dict[str, SupportedModelPrice]
+
+    @property
+    def price(self) -> SupportedModelPrice | None:
+        """Compatibility alias for the training-token price."""
+
+        return self.prices.get("training_tokens")
+
+    def price_for(self, usage_kind: str) -> SupportedModelPrice | None:
+        """Return this mode's price for one catalog usage kind."""
+
+        return self.prices.get(usage_kind)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "display_name": self.display_name,
+            "prices": {key: price.to_dict() for key, price in self.prices.items()},
+        }
+
+
+@dataclass(frozen=True)
+class SupportedModel:
+    """A usable model with only its explicitly supported, fully priced modes."""
+
+    id: str
+    name: str
+    status: str
+    visibility: str | None
+    training_modes: tuple[SupportedTrainingMode, ...]
+    metadata: dict[str, Any]
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> SupportedModel:
+        prices = payload.get("prices")
+        prices = prices if isinstance(prices, dict) else {}
+
+        def prices_for_mode(mode: str) -> dict[str, SupportedModelPrice]:
+            result: dict[str, SupportedModelPrice] = {}
+            for kind in MODE_PRICE_KINDS:
+                price = SupportedModelPrice.from_payload(
+                    prices.get(f"{kind}:{mode}")
+                    or (prices.get(kind) if kind != "training_tokens" else None)
+                )
+                if price is not None:
+                    result[kind] = price
+            return result
+
+        raw_modes = payload.get("training_modes")
+        if isinstance(raw_modes, list):
+            declared_modes = {str(mode).strip().lower().replace("-", "_") for mode in raw_modes}
+        else:
+            # Compatibility with servers that predate the capability field:
+            # infer only from an exact mode-qualified training quote.
+            declared_modes = {
+                mode for mode in ("lora", "full_ft") if f"training_tokens:{mode}" in prices
+            }
+        training_modes_list: list[SupportedTrainingMode] = []
+        for mode, display_name in (("lora", "LoRA"), ("full_ft", "Full-FT")):
+            mode_prices = prices_for_mode(mode)
+            if mode in declared_modes and len(mode_prices) == len(MODE_PRICE_KINDS):
+                training_modes_list.append(
+                    SupportedTrainingMode(
+                        mode=mode,
+                        display_name=display_name,
+                        prices=mode_prices,
+                    )
+                )
+        training_modes = tuple(training_modes_list)
+        metadata = payload.get("metadata")
+        return cls(
+            id=str(payload.get("id") or ""),
+            name=str(payload.get("name") or ""),
+            status=str(payload.get("status") or "available"),
+            visibility=(
+                str(payload["visibility"]) if payload.get("visibility") is not None else None
+            ),
+            training_modes=training_modes,
+            metadata=dict(metadata) if isinstance(metadata, dict) else {},
+        )
+
+    @property
+    def sampling_prices(self) -> dict[str, SupportedModelPrice]:
+        """Compatibility view of LoRA sampling prices.
+
+        New code should use ``training_mode(...).prices`` so Full-FT sampling
+        is never mistaken for LoRA pricing.
+        """
+
+        lora = self.training_mode("lora")
+        if lora is None:
+            return {}
+        return {key: price for key, price in lora.prices.items() if key != "training_tokens"}
+
+    def training_mode(self, mode: str) -> SupportedTrainingMode | None:
+        """Return one normalized training-mode entry."""
+
+        normalized = mode.strip().lower().replace("-", "_")
+        return next((item for item in self.training_modes if item.mode == normalized), None)
+
+    def to_dict(self, *, mode: str | None = None) -> dict[str, Any]:
+        normalized = mode.strip().lower().replace("-", "_") if mode else None
+        training_modes = [
+            item.to_dict()
+            for item in self.training_modes
+            if normalized is None or item.mode == normalized
+        ]
+        return {
+            "id": self.id,
+            "name": self.name,
+            "status": self.status,
+            "visibility": self.visibility,
+            "training_modes": training_modes,
+            "metadata": self.metadata,
+        }


### PR DESCRIPTION
## Summary
- preserve the existing name-only supported-model API while adding typed detailed catalog records
- expose independent train, input, cached-input, and output prices for LoRA and Full-FT
- add a compact CLI table plus table, JSON, and names mode filtering
- omit models that do not support the selected mode
- make the Pig Latin examples accept the requested base model
- wrap exhausted transport failures as retryable 503 errors so long-running operation polling can recover

## Validation
- 38 targeted supported-model and HTTP retry tests pass
- full suite: 565 passed; four timeout-sensitive concurrency tests only timed out under concurrent local load and each passed when rerun sequentially

Related: china-qijizhifeng/weaver-server#784
Related: china-qijizhifeng/weaver-server#768