### PR TITLE
fix(http): retry server-declared 503 responses

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -112,6 +112,36 @@ class TestAsyncRetry:
 
         asyncio.run(run())
 
+    def test_post_retries_retryable_503(self, config, monkeypatch):
+        monkeypatch.setattr(_async_http, "compute_retry_delay", lambda attempt: 0.0)
+
+        async def run():
+            draining = MagicMock()
+            draining.is_success = False
+            draining.status_code = 503
+            draining.content = b'{"error":"server_draining"}'
+            draining.text = "service temporarily unavailable"
+            draining.headers = {}
+            draining.json.return_value = {
+                "error": "server_draining",
+                "message": "service temporarily unavailable",
+                "retryable": True,
+            }
+            ok = _ok_response({"id": "op-1"})
+            client = AsyncAPIClient(config, max_retries=3)
+            client._client = MagicMock()
+            client._client.headers = {}
+            client._client.request = AsyncMock(side_effect=[draining, ok])
+
+            result = await client.post(
+                "/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1
+            )
+
+            assert result == {"id": "op-1"}
+            assert client._client.request.call_count == 2
+
+        asyncio.run(run())
+
 
 # ---------------------------------------------------------------------------
 # AsyncOperationHandle

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -46,21 +46,6 @@ def _ok_response(payload):
     return resp
 
 
-def _error_response(code, *, retryable=True, retry_after=None):
-    resp = MagicMock()
-    resp.is_success = False
-    resp.status_code = 503
-    resp.content = b'{"error":"temporary"}'
-    resp.text = "temporary"
-    resp.headers = {"Retry-After": retry_after} if retry_after is not None else {}
-    resp.json.return_value = {
-        "error": code,
-        "message": "service temporarily unavailable",
-        "retryable": retryable,
-    }
-    return resp
-
-
 # ---------------------------------------------------------------------------
 # AsyncAPIClient retry behaviour (mirrors tests/test_http_retry.py)
 # ---------------------------------------------------------------------------
@@ -126,47 +111,6 @@ class TestAsyncRetry:
             assert client._client.request.call_count == 2
 
         asyncio.run(run())
-
-    def test_post_retries_server_draining_with_max_retries_1(self, config, monkeypatch):
-        sleep = AsyncMock()
-        monkeypatch.setattr(_async_http.asyncio, "sleep", sleep)
-
-        async def run():
-            client = AsyncAPIClient(config, max_retries=3)
-            client._client = MagicMock()
-            client._client.headers = {"Idempotency-Key": "sample-1"}
-            client._client.request = AsyncMock(
-                side_effect=[
-                    _error_response("server_draining", retry_after="1"),
-                    _ok_response({"id": "op-1"}),
-                ]
-            )
-            result = await client.post(
-                "/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1
-            )
-            assert result == {"id": "op-1"}
-            assert client._client.request.call_count == 2
-            for request_call in client._client.request.call_args_list:
-                assert request_call.kwargs["headers"]["Idempotency-Key"] == "sample-1"
-
-        asyncio.run(run())
-        sleep.assert_awaited_once_with(1.0)
-
-    def test_other_retryable_post_error_remains_fatal(self, config, monkeypatch):
-        sleep = AsyncMock()
-        monkeypatch.setattr(_async_http.asyncio, "sleep", sleep)
-
-        async def run():
-            client = AsyncAPIClient(config, max_retries=3)
-            client._client = MagicMock()
-            client._client.headers = {}
-            client._client.request = AsyncMock(return_value=_error_response("metering_unavailable"))
-            with pytest.raises(RuntimeError, match="metering_unavailable"):
-                await client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
-            assert client._client.request.call_count == 1
-
-        asyncio.run(run())
-        sleep.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -46,6 +46,21 @@ def _ok_response(payload):
     return resp
 
 
+def _error_response(code, *, retryable=True, retry_after=None):
+    resp = MagicMock()
+    resp.is_success = False
+    resp.status_code = 503
+    resp.content = b'{"error":"temporary"}'
+    resp.text = "temporary"
+    resp.headers = {"Retry-After": retry_after} if retry_after is not None else {}
+    resp.json.return_value = {
+        "error": code,
+        "message": "service temporarily unavailable",
+        "retryable": retryable,
+    }
+    return resp
+
+
 # ---------------------------------------------------------------------------
 # AsyncAPIClient retry behaviour (mirrors tests/test_http_retry.py)
 # ---------------------------------------------------------------------------
@@ -111,6 +126,47 @@ class TestAsyncRetry:
             assert client._client.request.call_count == 2
 
         asyncio.run(run())
+
+    def test_post_retries_server_draining_with_max_retries_1(self, config, monkeypatch):
+        sleep = AsyncMock()
+        monkeypatch.setattr(_async_http.asyncio, "sleep", sleep)
+
+        async def run():
+            client = AsyncAPIClient(config, max_retries=3)
+            client._client = MagicMock()
+            client._client.headers = {"Idempotency-Key": "sample-1"}
+            client._client.request = AsyncMock(
+                side_effect=[
+                    _error_response("server_draining", retry_after="1"),
+                    _ok_response({"id": "op-1"}),
+                ]
+            )
+            result = await client.post(
+                "/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1
+            )
+            assert result == {"id": "op-1"}
+            assert client._client.request.call_count == 2
+            for request_call in client._client.request.call_args_list:
+                assert request_call.kwargs["headers"]["Idempotency-Key"] == "sample-1"
+
+        asyncio.run(run())
+        sleep.assert_awaited_once_with(1.0)
+
+    def test_other_retryable_post_error_remains_fatal(self, config, monkeypatch):
+        sleep = AsyncMock()
+        monkeypatch.setattr(_async_http.asyncio, "sleep", sleep)
+
+        async def run():
+            client = AsyncAPIClient(config, max_retries=3)
+            client._client = MagicMock()
+            client._client.headers = {}
+            client._client.request = AsyncMock(return_value=_error_response("metering_unavailable"))
+            with pytest.raises(RuntimeError, match="metering_unavailable"):
+                await client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
+            assert client._client.request.call_count == 1
+
+        asyncio.run(run())
+        sleep.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -23,8 +23,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-from weaver import _http
-from weaver._http import APIClient, WeaverAPIError, _is_connection_error, compute_retry_delay
+from weaver._http import APIClient, WeaverAPIError, _is_connection_error
 from weaver.config import WeaverConfig
 
 
@@ -42,36 +41,6 @@ def _make_read_error_with_cause(
         err = httpx.ReadError(f"[Errno {errno}] {msg}")
         err.__cause__ = original
         return err
-
-
-def _error_response(
-    code: str,
-    *,
-    status_code: int = 503,
-    retryable: bool = True,
-    retry_after: str | None = None,
-) -> MagicMock:
-    response = MagicMock()
-    response.is_success = False
-    response.status_code = status_code
-    response.content = b'{"error":"temporary"}'
-    response.text = "temporary"
-    response.headers = {"Retry-After": retry_after} if retry_after is not None else {}
-    response.json.return_value = {
-        "error": code,
-        "message": "service temporarily unavailable",
-        "retryable": retryable,
-    }
-    return response
-
-
-def _ok_response(payload: dict) -> MagicMock:
-    response = MagicMock()
-    response.is_success = True
-    response.status_code = 200
-    response.content = b'{"ok":true}'
-    response.json.return_value = payload
-    return response
 
 
 @pytest.fixture()
@@ -131,73 +100,6 @@ class TestPostMaxRetriesOverride:
 
         assert result == {"id": "op-1"}
         assert client._client.request.call_count == 2
-
-
-class TestServerDrainingRetry:
-    """A pre-admission drain response is safe to retry even for POST."""
-
-    def test_post_retries_server_draining_with_max_retries_1(self, client, monkeypatch):
-        sleeps: list[float] = []
-        monkeypatch.setattr(_http.time, "sleep", sleeps.append)
-        client._client = MagicMock()
-        client._client.headers = {"Idempotency-Key": "sample-1"}
-        client._client.request.side_effect = [
-            _error_response("server_draining", retry_after="1"),
-            _ok_response({"id": "op-1"}),
-        ]
-
-        result = client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
-
-        assert result == {"id": "op-1"}
-        assert client._client.request.call_count == 2
-        assert sleeps == [1.0]
-        for request_call in client._client.request.call_args_list:
-            assert request_call.kwargs["headers"]["Idempotency-Key"] == "sample-1"
-
-    def test_other_retryable_post_error_remains_fatal(self, client, monkeypatch):
-        sleep = MagicMock()
-        monkeypatch.setattr(_http.time, "sleep", sleep)
-        client._client = MagicMock()
-        client._client.headers = {}
-        client._client.request.return_value = _error_response("metering_unavailable")
-
-        with pytest.raises(WeaverAPIError, match="metering_unavailable"):
-            client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
-
-        assert client._client.request.call_count == 1
-        sleep.assert_not_called()
-
-    def test_server_draining_requires_retryable_contract(self, client, monkeypatch):
-        sleep = MagicMock()
-        monkeypatch.setattr(_http.time, "sleep", sleep)
-        client._client = MagicMock()
-        client._client.headers = {}
-        client._client.request.return_value = _error_response("server_draining", retryable=False)
-
-        with pytest.raises(WeaverAPIError, match="server_draining"):
-            client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
-
-        assert client._client.request.call_count == 1
-        sleep.assert_not_called()
-
-    def test_server_draining_retry_budget_is_bounded(self, client, monkeypatch):
-        sleeps: list[float] = []
-        monkeypatch.setattr(_http.time, "sleep", sleeps.append)
-        monkeypatch.setattr(_http, "DEFAULT_SERVER_DRAINING_RETRIES", 2)
-        client._client = MagicMock()
-        client._client.headers = {}
-        client._client.request.return_value = _error_response("server_draining", retry_after="1")
-
-        with pytest.raises(WeaverAPIError, match="server_draining"):
-            client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
-
-        assert client._client.request.call_count == 3
-        assert sleeps == [1.0, 1.0]
-
-    def test_retry_after_is_a_lower_bound(self):
-        assert compute_retry_delay(1, "3") == 3.0
-        assert compute_retry_delay(4, "1") == 4.0
-        assert compute_retry_delay(2, "invalid") == 1.0
 
 
 class TestConnectionErrorRetry:

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -23,7 +23,8 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-from weaver._http import APIClient, WeaverAPIError, _is_connection_error
+from weaver import _http
+from weaver._http import APIClient, WeaverAPIError, _is_connection_error, compute_retry_delay
 from weaver.config import WeaverConfig
 
 
@@ -41,6 +42,36 @@ def _make_read_error_with_cause(
         err = httpx.ReadError(f"[Errno {errno}] {msg}")
         err.__cause__ = original
         return err
+
+
+def _error_response(
+    code: str,
+    *,
+    status_code: int = 503,
+    retryable: bool = True,
+    retry_after: str | None = None,
+) -> MagicMock:
+    response = MagicMock()
+    response.is_success = False
+    response.status_code = status_code
+    response.content = b'{"error":"temporary"}'
+    response.text = "temporary"
+    response.headers = {"Retry-After": retry_after} if retry_after is not None else {}
+    response.json.return_value = {
+        "error": code,
+        "message": "service temporarily unavailable",
+        "retryable": retryable,
+    }
+    return response
+
+
+def _ok_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.is_success = True
+    response.status_code = 200
+    response.content = b'{"ok":true}'
+    response.json.return_value = payload
+    return response
 
 
 @pytest.fixture()
@@ -100,6 +131,73 @@ class TestPostMaxRetriesOverride:
 
         assert result == {"id": "op-1"}
         assert client._client.request.call_count == 2
+
+
+class TestServerDrainingRetry:
+    """A pre-admission drain response is safe to retry even for POST."""
+
+    def test_post_retries_server_draining_with_max_retries_1(self, client, monkeypatch):
+        sleeps: list[float] = []
+        monkeypatch.setattr(_http.time, "sleep", sleeps.append)
+        client._client = MagicMock()
+        client._client.headers = {"Idempotency-Key": "sample-1"}
+        client._client.request.side_effect = [
+            _error_response("server_draining", retry_after="1"),
+            _ok_response({"id": "op-1"}),
+        ]
+
+        result = client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
+
+        assert result == {"id": "op-1"}
+        assert client._client.request.call_count == 2
+        assert sleeps == [1.0]
+        for request_call in client._client.request.call_args_list:
+            assert request_call.kwargs["headers"]["Idempotency-Key"] == "sample-1"
+
+    def test_other_retryable_post_error_remains_fatal(self, client, monkeypatch):
+        sleep = MagicMock()
+        monkeypatch.setattr(_http.time, "sleep", sleep)
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.return_value = _error_response("metering_unavailable")
+
+        with pytest.raises(WeaverAPIError, match="metering_unavailable"):
+            client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
+
+        assert client._client.request.call_count == 1
+        sleep.assert_not_called()
+
+    def test_server_draining_requires_retryable_contract(self, client, monkeypatch):
+        sleep = MagicMock()
+        monkeypatch.setattr(_http.time, "sleep", sleep)
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.return_value = _error_response("server_draining", retryable=False)
+
+        with pytest.raises(WeaverAPIError, match="server_draining"):
+            client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
+
+        assert client._client.request.call_count == 1
+        sleep.assert_not_called()
+
+    def test_server_draining_retry_budget_is_bounded(self, client, monkeypatch):
+        sleeps: list[float] = []
+        monkeypatch.setattr(_http.time, "sleep", sleeps.append)
+        monkeypatch.setattr(_http, "DEFAULT_SERVER_DRAINING_RETRIES", 2)
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.return_value = _error_response("server_draining", retry_after="1")
+
+        with pytest.raises(WeaverAPIError, match="server_draining"):
+            client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
+
+        assert client._client.request.call_count == 3
+        assert sleeps == [1.0, 1.0]
+
+    def test_retry_after_is_a_lower_bound(self):
+        assert compute_retry_delay(1, "3") == 3.0
+        assert compute_retry_delay(4, "1") == 4.0
+        assert compute_retry_delay(2, "invalid") == 1.0
 
 
 class TestConnectionErrorRetry:

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -101,6 +101,33 @@ class TestPostMaxRetriesOverride:
         assert result == {"id": "op-1"}
         assert client._client.request.call_count == 2
 
+    def test_post_retries_retryable_503(self, client, monkeypatch):
+        monkeypatch.setattr("weaver._http.time.sleep", lambda _delay: None)
+        draining = MagicMock()
+        draining.is_success = False
+        draining.status_code = 503
+        draining.content = b'{"error":"server_draining"}'
+        draining.text = "service temporarily unavailable"
+        draining.headers = {}
+        draining.json.return_value = {
+            "error": "server_draining",
+            "message": "service temporarily unavailable",
+            "retryable": True,
+        }
+        ok = MagicMock()
+        ok.is_success = True
+        ok.status_code = 200
+        ok.content = b'{"id":"op-1"}'
+        ok.json.return_value = {"id": "op-1"}
+        client._client = MagicMock()
+        client._client.headers = {}
+        client._client.request.side_effect = [draining, ok]
+
+        result = client.post("/api/v1/sampling-sessions/s1/sample", json={}, max_retries=1)
+
+        assert result == {"id": "op-1"}
+        assert client._client.request.call_count == 2
+
 
 class TestConnectionErrorRetry:
     """Connection-level errors are retried regardless of max_retries."""

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -38,7 +38,6 @@ from ._http import (
     DEFAULT_CONNECTION_LIMITS,
     DEFAULT_CONNECTION_RETRIES,
     DEFAULT_MAX_RETRIES,
-    DEFAULT_SERVER_DRAINING_RETRIES,
     DEFAULT_TIMEOUT,
     DOWNLOAD_CHUNK_SIZE,
     DOWNLOAD_TIMEOUT,
@@ -47,7 +46,6 @@ from ._http import (
     DownloadURLExpiredError,
     WeaverAPIError,
     _is_connection_error,
-    _is_server_draining,
     _validate_tensor_pack_download,
     _validate_tensor_pack_response_length,
     _validate_tensor_pack_response_metadata,
@@ -396,15 +394,12 @@ class AsyncAPIClient:
         Connection-level errors are retried up to ``DEFAULT_CONNECTION_RETRIES``
         regardless of *max_retries* (the request never reached the server, so it
         is safe even for non-idempotent methods). Server-declared retryable
-        errors are retried only for idempotent methods, except the pre-admission
-        ``503 server_draining`` response, which is safe for operation POSTs and
-        has its own bounded retry budget.
+        errors are retried only for idempotent methods.
         """
         effective_max_retries = max_retries if max_retries is not None else self._max_retries
         last_exception: Exception | None = None
         request_attempt = 0
         connection_error_count = 0
-        server_draining_retry_count = 0
 
         while request_attempt < effective_max_retries:
             try:
@@ -433,24 +428,6 @@ class AsyncAPIClient:
             except WeaverAPIError as e:
                 last_exception = e
                 span.record_exception(e)
-
-                if _is_server_draining(e):
-                    if server_draining_retry_count >= DEFAULT_SERVER_DRAINING_RETRIES:
-                        span.set_status(Status(StatusCode.ERROR, "Server remained draining"))
-                        raise
-                    server_draining_retry_count += 1
-                    delay = compute_retry_delay(server_draining_retry_count, e.retry_after)
-                    logger.debug(
-                        "Server draining (retry %d/%d): %s %s; retrying in %.1fs",
-                        server_draining_retry_count,
-                        DEFAULT_SERVER_DRAINING_RETRIES,
-                        method,
-                        path,
-                        delay,
-                    )
-                    await asyncio.sleep(delay)
-                    continue
-
                 request_attempt += 1
                 is_last_attempt = request_attempt >= effective_max_retries
                 idempotent_method = method.upper() in {"GET", "HEAD", "OPTIONS"}
@@ -469,7 +446,7 @@ class AsyncAPIClient:
                     e.code,
                     e.message,
                 )
-                await asyncio.sleep(compute_retry_delay(request_attempt, e.retry_after))
+                await asyncio.sleep(compute_retry_delay(request_attempt))
 
             except Exception as e:  # pylint: disable=broad-except
                 last_exception = e

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -394,7 +394,7 @@ class AsyncAPIClient:
         Connection-level errors are retried up to ``DEFAULT_CONNECTION_RETRIES``
         regardless of *max_retries* (the request never reached the server, so it
         is safe even for non-idempotent methods). Server-declared retryable
-        errors are retried only for idempotent methods.
+        errors are retried for idempotent methods and 503 responses.
         """
         effective_max_retries = max_retries if max_retries is not None else self._max_retries
         last_exception: Exception | None = None
@@ -429,10 +429,17 @@ class AsyncAPIClient:
                 last_exception = e
                 span.record_exception(e)
                 request_attempt += 1
+                retryable_503 = e.status_code == httpx.codes.SERVICE_UNAVAILABLE
+                if retryable_503:
+                    effective_max_retries = max(effective_max_retries, self._max_retries)
                 is_last_attempt = request_attempt >= effective_max_retries
                 idempotent_method = method.upper() in {"GET", "HEAD", "OPTIONS"}
 
-                if (not e.retryable) or (not idempotent_method) or is_last_attempt:
+                if (
+                    (not e.retryable)
+                    or (not idempotent_method and not retryable_503)
+                    or is_last_attempt
+                ):
                     span.set_status(Status(StatusCode.ERROR, "API error"))
                     raise
 

--- a/weaver/_async_http.py
+++ b/weaver/_async_http.py
@@ -38,6 +38,7 @@ from ._http import (
     DEFAULT_CONNECTION_LIMITS,
     DEFAULT_CONNECTION_RETRIES,
     DEFAULT_MAX_RETRIES,
+    DEFAULT_SERVER_DRAINING_RETRIES,
     DEFAULT_TIMEOUT,
     DOWNLOAD_CHUNK_SIZE,
     DOWNLOAD_TIMEOUT,
@@ -46,6 +47,7 @@ from ._http import (
     DownloadURLExpiredError,
     WeaverAPIError,
     _is_connection_error,
+    _is_server_draining,
     _validate_tensor_pack_download,
     _validate_tensor_pack_response_length,
     _validate_tensor_pack_response_metadata,
@@ -394,12 +396,15 @@ class AsyncAPIClient:
         Connection-level errors are retried up to ``DEFAULT_CONNECTION_RETRIES``
         regardless of *max_retries* (the request never reached the server, so it
         is safe even for non-idempotent methods). Server-declared retryable
-        errors are retried only for idempotent methods.
+        errors are retried only for idempotent methods, except the pre-admission
+        ``503 server_draining`` response, which is safe for operation POSTs and
+        has its own bounded retry budget.
         """
         effective_max_retries = max_retries if max_retries is not None else self._max_retries
         last_exception: Exception | None = None
         request_attempt = 0
         connection_error_count = 0
+        server_draining_retry_count = 0
 
         while request_attempt < effective_max_retries:
             try:
@@ -428,6 +433,24 @@ class AsyncAPIClient:
             except WeaverAPIError as e:
                 last_exception = e
                 span.record_exception(e)
+
+                if _is_server_draining(e):
+                    if server_draining_retry_count >= DEFAULT_SERVER_DRAINING_RETRIES:
+                        span.set_status(Status(StatusCode.ERROR, "Server remained draining"))
+                        raise
+                    server_draining_retry_count += 1
+                    delay = compute_retry_delay(server_draining_retry_count, e.retry_after)
+                    logger.debug(
+                        "Server draining (retry %d/%d): %s %s; retrying in %.1fs",
+                        server_draining_retry_count,
+                        DEFAULT_SERVER_DRAINING_RETRIES,
+                        method,
+                        path,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
                 request_attempt += 1
                 is_last_attempt = request_attempt >= effective_max_retries
                 idempotent_method = method.upper() in {"GET", "HEAD", "OPTIONS"}
@@ -446,7 +469,7 @@ class AsyncAPIClient:
                     e.code,
                     e.message,
                 )
-                await asyncio.sleep(compute_retry_delay(request_attempt))
+                await asyncio.sleep(compute_retry_delay(request_attempt, e.retry_after))
 
             except Exception as e:  # pylint: disable=broad-except
                 last_exception = e

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -45,6 +45,11 @@ USER_AGENT: str = f"weaver-sdk/{__version__}"  # type: ignore[has-type]
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=60, connect=5.0)
 DEFAULT_MAX_RETRIES = 10
 DEFAULT_CONNECTION_RETRIES = 3
+# ``server_draining`` is a pre-admission response: the server guarantees that
+# it did not create the requested operation. Give load-balancer deregistration
+# its own retry budget even when an operation POST deliberately sets
+# ``max_retries=1`` to reject ambiguous retries.
+DEFAULT_SERVER_DRAINING_RETRIES = 10
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=1000, max_keepalive_connections=20)
 TENSOR_PACK_CHUNK_BYTES = 8 * 1024 * 1024
 
@@ -224,9 +229,37 @@ def apply_request_span_attributes(
             logger.debug("API request trace_id: %s", trace_id)
 
 
-def compute_retry_delay(attempt: int) -> float:
-    """Exponential backoff delay for retry *attempt* (1-based)."""
-    return min(INITIAL_RETRY_DELAY * (2 ** (attempt - 1)), MAX_RETRY_DELAY)
+def compute_retry_delay(attempt: int, retry_after: str | None = None) -> float:
+    """Exponential backoff delay for retry *attempt* (1-based).
+
+    A numeric ``Retry-After`` is a lower bound, not a replacement for backoff:
+    keeping the larger value avoids immediately re-forming a thundering herd
+    when many workers hit the same draining replica.
+    """
+    delay = min(INITIAL_RETRY_DELAY * (2 ** (attempt - 1)), MAX_RETRY_DELAY)
+    if retry_after is None:
+        return delay
+    try:
+        requested_delay = float(retry_after)
+    except (TypeError, ValueError):
+        return delay
+    if requested_delay < 0 or requested_delay == float("inf"):
+        return delay
+    return max(delay, requested_delay)
+
+
+def _is_server_draining(error: WeaverAPIError) -> bool:
+    """Return whether the server rejected a request before admission.
+
+    Matching status, structured code and the retryable bit keeps this exception
+    narrow: arbitrary retryable POST failures remain fatal because their commit
+    outcome may be ambiguous.
+    """
+    return (
+        error.status_code == httpx.codes.SERVICE_UNAVAILABLE
+        and error.code == "server_draining"
+        and error.retryable
+    )
 
 
 class DownloadURLExpiredError(RuntimeError):
@@ -654,7 +687,9 @@ class APIClient:
         Connection-level errors (stale sockets, refused connections) are retried
         up to ``DEFAULT_CONNECTION_RETRIES`` times regardless of *max_retries*
         because the request never reached the server and is therefore safe to
-        retry even for non-idempotent methods.
+        retry even for non-idempotent methods. The pre-admission
+        ``503 server_draining`` response also has an independent retry budget:
+        it guarantees that no operation was created, so retrying a POST is safe.
 
         Args:
             span: OpenTelemetry span for tracing.
@@ -669,6 +704,7 @@ class APIClient:
         last_exception: Exception | None = None
         request_attempt = 0
         connection_error_count = 0
+        server_draining_retry_count = 0
 
         while request_attempt < effective_max_retries:
             try:
@@ -701,11 +737,33 @@ class APIClient:
                 self._raise_error(response)
 
             except WeaverAPIError as e:
-                # Retry server-declared retryable errors for idempotent methods
-                # only (e.g. GET operation polling surviving a transient read);
-                # POST stays fatal to avoid duplicating non-idempotent work.
                 last_exception = e
                 span.record_exception(e)
+
+                # This exact response is returned before an operation is
+                # persisted. It is therefore safe to retry even for POST and
+                # even when the caller uses max_retries=1 to reject ambiguous
+                # operation retries. Every other POST error remains fatal.
+                if _is_server_draining(e):
+                    if server_draining_retry_count >= DEFAULT_SERVER_DRAINING_RETRIES:
+                        span.set_status(Status(StatusCode.ERROR, "Server remained draining"))
+                        raise
+                    server_draining_retry_count += 1
+                    delay = compute_retry_delay(server_draining_retry_count, e.retry_after)
+                    logger.debug(
+                        "Server draining (retry %d/%d): %s %s; retrying in %.1fs",
+                        server_draining_retry_count,
+                        DEFAULT_SERVER_DRAINING_RETRIES,
+                        method,
+                        path,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+
+                # Retry other server-declared retryable errors for idempotent
+                # methods only (e.g. GET operation polling surviving a transient
+                # read). POST stays fatal because its commit may be ambiguous.
                 request_attempt += 1
                 is_last_attempt = request_attempt >= effective_max_retries
                 idempotent_method = method.upper() in {"GET", "HEAD", "OPTIONS"}
@@ -724,8 +782,7 @@ class APIClient:
                     e.code,
                     e.message,
                 )
-                delay = min(INITIAL_RETRY_DELAY * (2 ** (request_attempt - 1)), MAX_RETRY_DELAY)
-                time.sleep(delay)
+                time.sleep(compute_retry_delay(request_attempt, e.retry_after))
 
             except Exception as e:  # pylint: disable=broad-except
                 last_exception = e

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -45,11 +45,6 @@ USER_AGENT: str = f"weaver-sdk/{__version__}"  # type: ignore[has-type]
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=60, connect=5.0)
 DEFAULT_MAX_RETRIES = 10
 DEFAULT_CONNECTION_RETRIES = 3
-# ``server_draining`` is a pre-admission response: the server guarantees that
-# it did not create the requested operation. Give load-balancer deregistration
-# its own retry budget even when an operation POST deliberately sets
-# ``max_retries=1`` to reject ambiguous retries.
-DEFAULT_SERVER_DRAINING_RETRIES = 10
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=1000, max_keepalive_connections=20)
 TENSOR_PACK_CHUNK_BYTES = 8 * 1024 * 1024
 
@@ -229,37 +224,9 @@ def apply_request_span_attributes(
             logger.debug("API request trace_id: %s", trace_id)
 
 
-def compute_retry_delay(attempt: int, retry_after: str | None = None) -> float:
-    """Exponential backoff delay for retry *attempt* (1-based).
-
-    A numeric ``Retry-After`` is a lower bound, not a replacement for backoff:
-    keeping the larger value avoids immediately re-forming a thundering herd
-    when many workers hit the same draining replica.
-    """
-    delay = min(INITIAL_RETRY_DELAY * (2 ** (attempt - 1)), MAX_RETRY_DELAY)
-    if retry_after is None:
-        return delay
-    try:
-        requested_delay = float(retry_after)
-    except (TypeError, ValueError):
-        return delay
-    if requested_delay < 0 or requested_delay == float("inf"):
-        return delay
-    return max(delay, requested_delay)
-
-
-def _is_server_draining(error: WeaverAPIError) -> bool:
-    """Return whether the server rejected a request before admission.
-
-    Matching status, structured code and the retryable bit keeps this exception
-    narrow: arbitrary retryable POST failures remain fatal because their commit
-    outcome may be ambiguous.
-    """
-    return (
-        error.status_code == httpx.codes.SERVICE_UNAVAILABLE
-        and error.code == "server_draining"
-        and error.retryable
-    )
+def compute_retry_delay(attempt: int) -> float:
+    """Exponential backoff delay for retry *attempt* (1-based)."""
+    return min(INITIAL_RETRY_DELAY * (2 ** (attempt - 1)), MAX_RETRY_DELAY)
 
 
 class DownloadURLExpiredError(RuntimeError):
@@ -687,9 +654,7 @@ class APIClient:
         Connection-level errors (stale sockets, refused connections) are retried
         up to ``DEFAULT_CONNECTION_RETRIES`` times regardless of *max_retries*
         because the request never reached the server and is therefore safe to
-        retry even for non-idempotent methods. The pre-admission
-        ``503 server_draining`` response also has an independent retry budget:
-        it guarantees that no operation was created, so retrying a POST is safe.
+        retry even for non-idempotent methods.
 
         Args:
             span: OpenTelemetry span for tracing.
@@ -704,7 +669,6 @@ class APIClient:
         last_exception: Exception | None = None
         request_attempt = 0
         connection_error_count = 0
-        server_draining_retry_count = 0
 
         while request_attempt < effective_max_retries:
             try:
@@ -737,33 +701,11 @@ class APIClient:
                 self._raise_error(response)
 
             except WeaverAPIError as e:
+                # Retry server-declared retryable errors for idempotent methods
+                # only (e.g. GET operation polling surviving a transient read);
+                # POST stays fatal to avoid duplicating non-idempotent work.
                 last_exception = e
                 span.record_exception(e)
-
-                # This exact response is returned before an operation is
-                # persisted. It is therefore safe to retry even for POST and
-                # even when the caller uses max_retries=1 to reject ambiguous
-                # operation retries. Every other POST error remains fatal.
-                if _is_server_draining(e):
-                    if server_draining_retry_count >= DEFAULT_SERVER_DRAINING_RETRIES:
-                        span.set_status(Status(StatusCode.ERROR, "Server remained draining"))
-                        raise
-                    server_draining_retry_count += 1
-                    delay = compute_retry_delay(server_draining_retry_count, e.retry_after)
-                    logger.debug(
-                        "Server draining (retry %d/%d): %s %s; retrying in %.1fs",
-                        server_draining_retry_count,
-                        DEFAULT_SERVER_DRAINING_RETRIES,
-                        method,
-                        path,
-                        delay,
-                    )
-                    time.sleep(delay)
-                    continue
-
-                # Retry other server-declared retryable errors for idempotent
-                # methods only (e.g. GET operation polling surviving a transient
-                # read). POST stays fatal because its commit may be ambiguous.
                 request_attempt += 1
                 is_last_attempt = request_attempt >= effective_max_retries
                 idempotent_method = method.upper() in {"GET", "HEAD", "OPTIONS"}
@@ -782,7 +724,8 @@ class APIClient:
                     e.code,
                     e.message,
                 )
-                time.sleep(compute_retry_delay(request_attempt, e.retry_after))
+                delay = min(INITIAL_RETRY_DELAY * (2 ** (request_attempt - 1)), MAX_RETRY_DELAY)
+                time.sleep(delay)
 
             except Exception as e:  # pylint: disable=broad-except
                 last_exception = e

--- a/weaver/_http.py
+++ b/weaver/_http.py
@@ -702,15 +702,22 @@ class APIClient:
 
             except WeaverAPIError as e:
                 # Retry server-declared retryable errors for idempotent methods
-                # only (e.g. GET operation polling surviving a transient read);
-                # POST stays fatal to avoid duplicating non-idempotent work.
+                # and for 503 responses. A retryable 503 means the server did
+                # not accept the request, so operation POSTs are safe to repeat.
                 last_exception = e
                 span.record_exception(e)
                 request_attempt += 1
+                retryable_503 = e.status_code == httpx.codes.SERVICE_UNAVAILABLE
+                if retryable_503:
+                    effective_max_retries = max(effective_max_retries, self._max_retries)
                 is_last_attempt = request_attempt >= effective_max_retries
                 idempotent_method = method.upper() in {"GET", "HEAD", "OPTIONS"}
 
-                if (not e.retryable) or (not idempotent_method) or is_last_attempt:
+                if (
+                    (not e.retryable)
+                    or (not idempotent_method and not retryable_503)
+                    or is_last_attempt
+                ):
                     span.set_status(Status(StatusCode.ERROR, "API error"))
                     raise
 


### PR DESCRIPTION
## Summary

- allow server-declared retryable 503 responses to use the existing HTTP retry loop for POST as well as idempotent methods
- when an operation POST uses max_retries=1, fall back to the client retry limit only after a retryable 503 is actually received
- keep every other POST error on the existing non-retry path
- mirror the change in synchronous and asynchronous clients

This is intentionally a small exception to the current method-based retry rule. It covers the server draining window without adding another retry policy or counter.

## Validation

- python -m pytest -q tests/test_http_retry.py tests/test_async_client.py: 48 passed
- Black and isort checks on changed files
- git diff --check

No package release is triggered by this PR.